### PR TITLE
Add statistics page

### DIFF
--- a/src/app/Router.js
+++ b/src/app/Router.js
@@ -11,6 +11,7 @@ import DashboardPage   from '@/pages/DashboardPage/DashboardPage';
 import TicketsPage     from '@/pages/TicketsPage/TicketsPage';
 import TicketFormPage  from '@/pages/TicketsPage/TicketFormPage';
 import LitigationsPage from '@/pages/LitigationsPage/LitigationsPage';
+import StatsPage       from '@/pages/StatsPage/StatsPage';
 
 import LoginPage    from '@/pages/UnitsPage/LoginPage';     // ← CHANGE
 import RegisterPage from '@/pages/UnitsPage/RegisterPage';  // ← CHANGE
@@ -94,6 +95,14 @@ export default function AppRouter() {
                 element={(
                     <RequireAuth>
                         <LitigationsPage />
+                    </RequireAuth>
+                )}
+            />
+            <Route
+                path="/stats"
+                element={(
+                    <RequireAuth>
+                        <StatsPage />
                     </RequireAuth>
                 )}
             />

--- a/src/entities/ticket.js
+++ b/src/entities/ticket.js
@@ -321,3 +321,20 @@ export function useDeleteTicket() {
         onError: (e) => notify.error(`Ошибка удаления замечания: ${e.message}`),
     });
 }
+
+// -----------------------------------------------------------------------------
+// Получить все замечания без фильтрации по проекту (для статистики)
+// -----------------------------------------------------------------------------
+export function useAllTicketsSimple() {
+    return useQuery({
+        queryKey: ['tickets-all'],
+        queryFn : async () => {
+            const { data, error } = await supabase
+                .from('tickets')
+                .select('id, status_id');
+            if (error) throw error;
+            return data ?? [];
+        },
+        staleTime: 5 * 60_000,
+    });
+}

--- a/src/pages/StatsPage/StatsPage.js
+++ b/src/pages/StatsPage/StatsPage.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Paper, Typography, CircularProgress, Box } from '@mui/material';
+import { useProjects } from '@/entities/project';
+import { useAllTicketsSimple } from '@/entities/ticket';
+import { useTicketStatuses } from '@/entities/ticketStatus';
+
+export default function StatsPage() {
+    const { data: projects = [], isPending: loadingProjects } = useProjects();
+    const { data: tickets = [], isPending: loadingTickets, error } = useAllTicketsSimple();
+    const { data: statuses = [] } = useTicketStatuses();
+
+    const totalTickets = tickets.length;
+    const byStatus = React.useMemo(() => {
+        const m = {};
+        tickets.forEach((t) => {
+            m[t.status_id] = (m[t.status_id] || 0) + 1;
+        });
+        return m;
+    }, [tickets]);
+
+    if (loadingProjects || loadingTickets) {
+        return <CircularProgress />;
+    }
+
+    return (
+        <Paper sx={{ p: 3 }}>
+            <Typography variant="h4" gutterBottom>Статистика</Typography>
+            <Typography>Количество проектов: {projects.length}</Typography>
+            <Typography sx={{ mt: 1 }}>Всего замечаний: {totalTickets}</Typography>
+            <Box sx={{ mt: 2 }}>
+                {statuses.map((st) => (
+                    <Typography key={st.id}>{st.name}: {byStatus[st.id] ?? 0}</Typography>
+                ))}
+            </Box>
+            {error && (
+                <Typography color="error" sx={{ mt: 2 }}>{error.message}</Typography>
+            )}
+        </Paper>
+    );
+}

--- a/src/widgets/NavBar.js
+++ b/src/widgets/NavBar.js
@@ -41,7 +41,7 @@ const NavBar = () => {
                 <Button color="inherit" component={RouterLink} to="/structure">
                     Структура&nbsp;проекта
                 </Button>
-                <Button color="inherit" component={RouterLink} to="/stats-go">
+                <Button color="inherit" component={RouterLink} to="/stats">
                     Статистика
                 </Button>
                 <Button color="inherit" component={RouterLink} to="/tickets/new">


### PR DESCRIPTION
## Summary
- create statistics page
- fetch global ticket data
- show project and ticket counts
- link stats page in the navbar
- register stats route

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm test` *(fails: craco not found)*