### PR TITLE
Fix units person_id on creation

### DIFF
--- a/src/features/addBuildingOrSection/AddBuildingOrSectionDialog.js
+++ b/src/features/addBuildingOrSection/AddBuildingOrSectionDialog.js
@@ -1,19 +1,31 @@
 import React, { useState } from 'react';
 import { Dialog, DialogTitle, DialogContent, DialogActions, TextField, Button } from '@mui/material';
 import { supabase } from '@/shared/api/supabaseClient';
+import { useAuthStore } from '@/shared/store/authStore';
 
 export default function AddBuildingOrSectionDialog({ open, type, onClose, projectId, building, afterAdd }) {
     const [value, setValue] = useState('');
     const handleConfirm = async () => {
         if (!value.trim()) return;
+        const userId = useAuthStore.getState().profile?.id ?? null;
         if (type === 'building') {
             await supabase.from('units').insert([{
-                project_id: projectId, building: value.trim(), section: null, floor: 1, name: '1'
+                project_id: projectId,
+                building: value.trim(),
+                section: null,
+                floor: 1,
+                name: '1',
+                person_id: userId,
             }]);
         }
         if (type === 'section') {
             await supabase.from('units').insert([{
-                project_id: projectId, building, section: value.trim(), floor: 1, name: '1'
+                project_id: projectId,
+                building,
+                section: value.trim(),
+                floor: 1,
+                name: '1',
+                person_id: userId,
             }]);
         }
         onClose();

--- a/src/features/project-structure/StructureGrid.js
+++ b/src/features/project-structure/StructureGrid.js
@@ -4,6 +4,7 @@ import FloorCell from '@/entities/floor/FloorCell';
 import UnitCell from '@/entities/unit/UnitCell';
 import AddIcon from '@mui/icons-material/Add';
 import { supabase } from '@/shared/api/supabaseClient';
+import { useAuthStore } from '@/shared/store/authStore';
 
 const CELL_SIZE = 56;
 
@@ -15,6 +16,7 @@ export default function StructureGrid({
 
     // --- Добавить квартиру по правилам ниже лежащего этажа
     const handleAddUnit = async (floor) => {
+        const userId = useAuthStore.getState().profile?.id ?? null;
         let idx = floors.indexOf(floor);
         let belowFloor = idx < floors.length - 1 ? floors[idx + 1] : null;
         let maxName = 0;
@@ -24,7 +26,12 @@ export default function StructureGrid({
         }
         const newName = String(maxName + 1);
         const payload = {
-            project_id: projectId, building, section: section || null, floor, name: newName
+            project_id: projectId,
+            building,
+            section: section || null,
+            floor,
+            name: newName,
+            person_id: userId,
         };
         const { data, error } = await supabase.from('units').insert([payload]).select('*');
         if (!error) setUnits((prev) => [...prev, data[0]]);

--- a/src/shared/hooks/useUnitsMatrix.js
+++ b/src/shared/hooks/useUnitsMatrix.js
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback } from 'react';
 import { supabase } from '@/shared/api/supabaseClient';
+import { useAuthStore } from '@/shared/store/authStore';
 
 // Универсальный хук для матрицы квартир
 export default function useUnitsMatrix(projectId, building, section) {
@@ -89,6 +90,7 @@ export default function useUnitsMatrix(projectId, building, section) {
 
     // Добавить квартиру (только в выбранный корпус/секцию)
     const handleAddUnit = async (floor) => {
+        const userId = useAuthStore.getState().profile?.id ?? null;
         let maxNum = 0;
         if (unitsByFloor[floor] && unitsByFloor[floor].length > 0) {
             const nums = unitsByFloor[floor]
@@ -112,6 +114,7 @@ export default function useUnitsMatrix(projectId, building, section) {
             section: section || null,
             floor,
             name: newName,
+            person_id: userId,
         };
         const { error } = await supabase.from('units').insert([payload]);
         if (!error) {


### PR DESCRIPTION
## Summary
- include user id when creating units
- ensure new buildings and sections store creator uuid
- pass creator uuid in units matrix operations

## Testing
- `npm test` *(fails: craco not found)*
- `npm run lint` *(fails: ESLint config missing)*