### PR TITLE
Implement basic court case management

### DIFF
--- a/src/app/Router.js
+++ b/src/app/Router.js
@@ -11,6 +11,7 @@ import DashboardPage   from '@/pages/DashboardPage/DashboardPage';
 import TicketsPage     from '@/pages/TicketsPage/TicketsPage';
 import TicketFormPage  from '@/pages/TicketsPage/TicketFormPage';
 import StatsPage       from '@/pages/StatsPage/StatsPage';
+import CourtCasesPage  from '@/pages/CourtCasesPage/CourtCasesPage';
 
 import LoginPage    from '@/pages/UnitsPage/LoginPage';     // ← CHANGE
 import RegisterPage from '@/pages/UnitsPage/RegisterPage';  // ← CHANGE
@@ -62,6 +63,14 @@ export default function AppRouter() {
                 element={(
                     <RequireAuth>
                         <TicketsPage />
+                    </RequireAuth>
+                )}
+            />
+            <Route
+                path="/court-cases"
+                element={(
+                    <RequireAuth>
+                        <CourtCasesPage />
                     </RequireAuth>
                 )}
             />

--- a/src/entities/courtCase.js
+++ b/src/entities/courtCase.js
@@ -1,0 +1,93 @@
+import { supabase } from '@/shared/api/supabaseClient';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import { useProjectId } from '@/shared/hooks/useProjectId';
+
+const FIELDS = `
+  id, internal_no, project_id, unit_id, stage_id, status,
+  responsible_lawyer_id, fix_start_date, fix_end_date, comments,
+  created_at, updated_at,
+  projects(id,name),
+  units(id,name),
+  litigation_stages(id,name),
+  profiles(id,name)
+`;
+
+const serialize = (data) => ({
+    internal_no: data.internal_no.trim(),
+    project_id: data.project_id,
+    unit_id: data.unit_id ?? null,
+    stage_id: data.stage_id ?? null,
+    status: data.status,
+    responsible_lawyer_id: data.responsible_lawyer_id ?? null,
+    fix_start_date: data.fix_start_date ? dayjs(data.fix_start_date).format('YYYY-MM-DD') : null,
+    fix_end_date: data.fix_end_date ? dayjs(data.fix_end_date).format('YYYY-MM-DD') : null,
+    comments: data.comments?.trim() || null,
+});
+
+export const useCourtCases = () => {
+    const projectId = useProjectId();
+    return useQuery({
+        queryKey: ['court_cases', projectId],
+        enabled: !!projectId,
+        queryFn: async () => {
+            const { data, error } = await supabase
+                .from('court_cases')
+                .select(FIELDS)
+                .eq('project_id', projectId)
+                .order('id');
+            if (error) throw error;
+            return data ?? [];
+        },
+        staleTime: 5 * 60_000,
+    });
+};
+
+const invalidate = (qc, projectId) => qc.invalidateQueries({ queryKey: ['court_cases', projectId] });
+
+export const useAddCourtCase = () => {
+    const projectId = useProjectId();
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async (values) => {
+            const { data, error } = await supabase
+                .from('court_cases')
+                .insert(serialize({ ...values, project_id: projectId }))
+                .select('id')
+                .single();
+            if (error) throw error;
+            return data;
+        },
+        onSuccess: () => invalidate(qc, projectId),
+    });
+};
+
+export const useUpdateCourtCase = () => {
+    const projectId = useProjectId();
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async ({ id, updates }) => {
+            const { data, error } = await supabase
+                .from('court_cases')
+                .update(serialize({ ...updates, project_id: projectId }))
+                .eq('id', id)
+                .select('id')
+                .single();
+            if (error) throw error;
+            return data;
+        },
+        onSuccess: () => invalidate(qc, projectId),
+    });
+};
+
+export const useDeleteCourtCase = () => {
+    const projectId = useProjectId();
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async (id) => {
+            const { error } = await supabase.from('court_cases').delete().eq('id', id);
+            if (error) throw error;
+        },
+        onSuccess: () => invalidate(qc, projectId),
+    });
+};

--- a/src/entities/courtCaseStatus.js
+++ b/src/entities/courtCaseStatus.js
@@ -1,0 +1,65 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/shared/api/supabaseClient';
+
+const TABLE = 'court_case_statuses';
+const KEY = [TABLE];
+
+export const useCourtCaseStatuses = () =>
+    useQuery({
+        queryKey: KEY,
+        queryFn : async () => {
+            const { data, error } = await supabase
+                .from(TABLE)
+                .select('id, name')
+                .order('id');
+            if (error) throw error;
+            return data ?? [];
+        },
+        staleTime: 5 * 60_000,
+    });
+
+const invalidate = (qc) => qc.invalidateQueries({ queryKey: KEY });
+
+export const useAddCourtCaseStatus = () => {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async (name) => {
+            const { data, error } = await supabase
+                .from(TABLE)
+                .insert({ name })
+                .select('id, name')
+                .single();
+            if (error) throw error;
+            return data;
+        },
+        onSuccess: () => invalidate(qc),
+    });
+};
+
+export const useUpdateCourtCaseStatus = () => {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async ({ id, name }) => {
+            const { data, error } = await supabase
+                .from(TABLE)
+                .update({ name })
+                .eq('id', id)
+                .select('id, name')
+                .single();
+            if (error) throw error;
+            return data;
+        },
+        onSuccess: () => invalidate(qc),
+    });
+};
+
+export const useDeleteCourtCaseStatus = () => {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async (id) => {
+            const { error } = await supabase.from(TABLE).delete().eq('id', id);
+            if (error) throw error;
+        },
+        onSuccess: () => invalidate(qc),
+    });
+};

--- a/src/entities/letter.js
+++ b/src/entities/letter.js
@@ -1,0 +1,94 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import { supabase } from '@/shared/api/supabaseClient';
+import { useProjectId } from '@/shared/hooks/useProjectId';
+
+const SELECT = 'id, case_id, number, letter_type, letter_date, subject, sender, receiver';
+
+export const useCaseLetters = (caseId) => {
+    const projectId = useProjectId();
+    return useQuery({
+        queryKey: ['letters', projectId, caseId],
+        enabled: !!projectId && !!caseId,
+        queryFn: async () => {
+            const { data, error } = await supabase
+                .from('letters')
+                .select(SELECT)
+                .eq('project_id', projectId)
+                .eq('case_id', caseId)
+                .order('letter_date');
+            if (error) throw error;
+            return data ?? [];
+        },
+        staleTime: 5 * 60_000,
+    });
+};
+
+const invalidate = (qc, projectId, caseId) => {
+    qc.invalidateQueries({ queryKey: ['letters', projectId, caseId] });
+};
+
+export const useAddLetter = () => {
+    const projectId = useProjectId();
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async (values) => {
+            const { data, error } = await supabase
+                .from('letters')
+                .insert({
+                    ...values,
+                    project_id: projectId,
+                    letter_date: values.letter_date
+                        ? dayjs(values.letter_date).format('YYYY-MM-DD')
+                        : null,
+                })
+                .select('id')
+                .single();
+            if (error) throw error;
+            return data;
+        },
+        onSuccess: (_, vars) => invalidate(qc, projectId, vars.case_id),
+    });
+};
+
+export const useUpdateLetter = () => {
+    const projectId = useProjectId();
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async ({ id, case_id, updates }) => {
+            const { data, error } = await supabase
+                .from('letters')
+                .update({
+                    ...updates,
+                    project_id: projectId,
+                    letter_date: updates.letter_date
+                        ? dayjs(updates.letter_date).format('YYYY-MM-DD')
+                        : null,
+                })
+                .eq('id', id)
+                .eq('case_id', case_id)
+                .select('id')
+                .single();
+            if (error) throw error;
+            return data;
+        },
+        onSuccess: (_, vars) => invalidate(qc, projectId, vars.case_id),
+    });
+};
+
+export const useDeleteLetter = () => {
+    const projectId = useProjectId();
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async ({ id, case_id }) => {
+            const { error } = await supabase
+                .from('letters')
+                .delete()
+                .eq('id', id)
+                .eq('case_id', case_id)
+                .eq('project_id', projectId);
+            if (error) throw error;
+        },
+        onSuccess: (_, vars) => invalidate(qc, projectId, vars.case_id),
+    });
+};

--- a/src/entities/letterType.js
+++ b/src/entities/letterType.js
@@ -1,0 +1,65 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/shared/api/supabaseClient';
+
+const TABLE = 'letter_types';
+const KEY = [TABLE];
+
+export const useLetterTypes = () =>
+    useQuery({
+        queryKey: KEY,
+        queryFn : async () => {
+            const { data, error } = await supabase
+                .from(TABLE)
+                .select('id, name')
+                .order('id');
+            if (error) throw error;
+            return data ?? [];
+        },
+        staleTime: 5 * 60_000,
+    });
+
+const invalidate = (qc) => qc.invalidateQueries({ queryKey: KEY });
+
+export const useAddLetterType = () => {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async (name) => {
+            const { data, error } = await supabase
+                .from(TABLE)
+                .insert({ name })
+                .select('id, name')
+                .single();
+            if (error) throw error;
+            return data;
+        },
+        onSuccess: () => invalidate(qc),
+    });
+};
+
+export const useUpdateLetterType = () => {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async ({ id, name }) => {
+            const { data, error } = await supabase
+                .from(TABLE)
+                .update({ name })
+                .eq('id', id)
+                .select('id, name')
+                .single();
+            if (error) throw error;
+            return data;
+        },
+        onSuccess: () => invalidate(qc),
+    });
+};
+
+export const useDeleteLetterType = () => {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async (id) => {
+            const { error } = await supabase.from(TABLE).delete().eq('id', id);
+            if (error) throw error;
+        },
+        onSuccess: () => invalidate(qc),
+    });
+};

--- a/src/entities/partyType.js
+++ b/src/entities/partyType.js
@@ -1,0 +1,65 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/shared/api/supabaseClient';
+
+const TABLE = 'party_types';
+const KEY = [TABLE];
+
+export const usePartyTypes = () =>
+    useQuery({
+        queryKey: KEY,
+        queryFn : async () => {
+            const { data, error } = await supabase
+                .from(TABLE)
+                .select('id, name')
+                .order('id');
+            if (error) throw error;
+            return data ?? [];
+        },
+        staleTime: 5 * 60_000,
+    });
+
+const invalidate = (qc) => qc.invalidateQueries({ queryKey: KEY });
+
+export const useAddPartyType = () => {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async (name) => {
+            const { data, error } = await supabase
+                .from(TABLE)
+                .insert({ name })
+                .select('id, name')
+                .single();
+            if (error) throw error;
+            return data;
+        },
+        onSuccess: () => invalidate(qc),
+    });
+};
+
+export const useUpdatePartyType = () => {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async ({ id, name }) => {
+            const { data, error } = await supabase
+                .from(TABLE)
+                .update({ name })
+                .eq('id', id)
+                .select('id, name')
+                .single();
+            if (error) throw error;
+            return data;
+        },
+        onSuccess: () => invalidate(qc),
+    });
+};
+
+export const useDeletePartyType = () => {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async (id) => {
+            const { error } = await supabase.from(TABLE).delete().eq('id', id);
+            if (error) throw error;
+        },
+        onSuccess: () => invalidate(qc),
+    });
+};

--- a/src/features/courtCase/CourtCaseForm.js
+++ b/src/features/courtCase/CourtCaseForm.js
@@ -1,0 +1,211 @@
+import React, { useEffect, useState } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { Stack, TextField, Button, Dialog, DialogTitle, DialogContent, DialogActions, Autocomplete } from '@mui/material';
+import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import dayjs from 'dayjs';
+import { useUnitsByProject } from '@/entities/unit';
+import { useLitigationStages } from '@/entities/litigationStage';
+import { useCourtCaseStatuses } from '@/entities/courtCaseStatus';
+import { useUsers } from '@/entities/user';
+import { useProjectId } from '@/shared/hooks/useProjectId';
+import {
+    useCaseLetters,
+    useAddLetter,
+    useUpdateLetter,
+} from '@/entities/letter';
+import LetterForm from '@/features/letter/LetterForm';
+import LettersTable from '@/widgets/LettersTable';
+
+export default function CourtCaseForm({ initialData, onSubmit, onCancel }) {
+    const projectId = useProjectId();
+    const { data: stages = [] } = useLitigationStages();
+    const { data: statuses = [] } = useCourtCaseStatuses();
+    const { data: users = [] } = useUsers();
+    const { data: units = [] } = useUnitsByProject(projectId);
+
+    const { data: letters = [] } = useCaseLetters(initialData?.id);
+    const addLetter = useAddLetter();
+    const updateLetter = useUpdateLetter();
+    const [letterModal, setLetterModal] = useState(null); // {mode, data}
+
+    const { control, handleSubmit, reset, setValue } = useForm({
+        defaultValues: {
+            internal_no: '',
+            project_id: projectId,
+            unit_id: null,
+            stage_id: null,
+            status: 'NEW',
+            responsible_lawyer_id: null,
+            fix_start_date: null,
+            fix_end_date: null,
+            comments: '',
+        },
+    });
+
+    useEffect(() => {
+        if (initialData) {
+            reset({
+                internal_no: initialData.internal_no,
+                project_id: initialData.project_id,
+                unit_id: initialData.unit_id,
+                stage_id: initialData.stage_id,
+                status: initialData.status,
+                responsible_lawyer_id: initialData.responsible_lawyer_id,
+                fix_start_date: initialData.fix_start_date ? dayjs(initialData.fix_start_date) : null,
+                fix_end_date: initialData.fix_end_date ? dayjs(initialData.fix_end_date) : null,
+                comments: initialData.comments ?? '',
+            });
+        } else {
+            setValue('internal_no', `CC-${Date.now()}`);
+        }
+    }, [initialData, reset, setValue]);
+
+    useEffect(() => {
+        setValue('project_id', projectId);
+    }, [projectId, setValue]);
+
+    return (
+        <Dialog open onClose={onCancel} fullWidth maxWidth="sm">
+            <DialogTitle>{initialData ? 'Редактировать дело' : 'Новое дело'}</DialogTitle>
+            <DialogContent dividers>
+                <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="ru">
+                    <Stack spacing={2} sx={{ mt: 1 }}>
+                        <Controller
+                            name="internal_no"
+                            control={control}
+                            rules={{ required: 'Номер обязателен' }}
+                            render={({ field, fieldState }) => (
+                                <TextField
+                                    {...field}
+                                    label="Внутренний номер"
+                                    required
+                                    fullWidth
+                                    error={!!fieldState.error}
+                                    helperText={fieldState.error?.message}
+                                />
+                            )}
+                        />
+                        <Controller
+                            name="unit_id"
+                            control={control}
+                            render={({ field }) => (
+                                <Autocomplete
+                                    {...field}
+                                    onChange={(_, v) => field.onChange(v?.id ?? null)}
+                                    options={units}
+                                    getOptionLabel={(o) => o.name || ''}
+                                    isOptionEqualToValue={(o, v) => o.id === v.id}
+                                    renderInput={(params) => <TextField {...params} label="Объект" />}
+                                />
+                            )}
+                        />
+                        <Controller
+                            name="stage_id"
+                            control={control}
+                            render={({ field }) => (
+                                <Autocomplete
+                                    {...field}
+                                    onChange={(_, v) => field.onChange(v?.id ?? null)}
+                                    options={stages}
+                                    getOptionLabel={(o) => o.name || ''}
+                                    isOptionEqualToValue={(o, v) => o.id === v.id}
+                                    renderInput={(params) => <TextField {...params} label="Стадия" />}
+                                />
+                            )}
+                        />
+                        <Controller
+                            name="status"
+                            control={control}
+                            render={({ field }) => (
+                                <Autocomplete
+                                    {...field}
+                                    onChange={(_, v) => field.onChange(v?.name ?? '')}
+                                    options={statuses}
+                                    getOptionLabel={(o) => o.name || ''}
+                                    isOptionEqualToValue={(o, v) => o.name === v.name}
+                                    renderInput={(params) => <TextField {...params} label="Статус" />}
+                                />
+                            )}
+                        />
+                        <Controller
+                            name="responsible_lawyer_id"
+                            control={control}
+                            render={({ field }) => (
+                                <Autocomplete
+                                    {...field}
+                                    onChange={(_, v) => field.onChange(v?.id ?? null)}
+                                    options={users}
+                                    getOptionLabel={(o) => o.name || o.email || ''}
+                                    isOptionEqualToValue={(o, v) => o.id === v.id}
+                                    renderInput={(params) => <TextField {...params} label="Ответственный юрист" />}
+                                />
+                            )}
+                        />
+                        <Controller
+                            name="fix_start_date"
+                            control={control}
+                            render={({ field }) => (
+                                <DatePicker
+                                    {...field}
+                                    label="Дата начала устранения"
+                                    format="DD.MM.YYYY"
+                                    onChange={(v) => field.onChange(v)}
+                                />
+                            )}
+                        />
+                        <Controller
+                            name="fix_end_date"
+                            control={control}
+                            render={({ field }) => (
+                                <DatePicker
+                                    {...field}
+                                    label="Дата завершения устранения"
+                                    format="DD.MM.YYYY"
+                                    onChange={(v) => field.onChange(v)}
+                                />
+                            )}
+                        />
+                        <Controller
+                            name="comments"
+                            control={control}
+                            render={({ field }) => (
+                                <TextField {...field} label="Заметки" multiline rows={3} fullWidth />
+                            )}
+                        />
+                    </Stack>
+                </LocalizationProvider>
+                {initialData && (
+                    <Stack spacing={2} sx={{ mt: 3 }}>
+                        <Button variant="outlined" onClick={() => setLetterModal({ mode: 'add', data: null })}>
+                            Добавить письмо
+                        </Button>
+                        <LettersTable
+                            rows={letters}
+                            onEdit={(row) => setLetterModal({ mode: 'edit', data: row })}
+                        />
+                    </Stack>
+                )}
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onCancel}>Отмена</Button>
+                <Button variant="contained" onClick={handleSubmit(onSubmit)}>Сохранить</Button>
+            </DialogActions>
+            {letterModal && initialData && (
+                <LetterForm
+                    open
+                    initialData={letterModal.data}
+                    onCancel={() => setLetterModal(null)}
+                    onSubmit={async (vals) => {
+                        if (letterModal.mode === 'add') {
+                            await addLetter.mutateAsync({ ...vals, case_id: initialData.id });
+                        } else if (letterModal.mode === 'edit' && letterModal.data) {
+                            await updateLetter.mutateAsync({ id: letterModal.data.id, case_id: initialData.id, updates: vals });
+                        }
+                        setLetterModal(null);
+                    }}
+                />
+            )}
+        </Dialog>
+    );
+}

--- a/src/features/courtCaseStatus/CourtCaseStatusForm.js
+++ b/src/features/courtCaseStatus/CourtCaseStatusForm.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { Stack, TextField, DialogActions, Button, CircularProgress } from '@mui/material';
+
+export default function CourtCaseStatusForm({ initialData, onSubmit, onCancel }) {
+    const { control, handleSubmit, formState: { isSubmitting } } = useForm({
+        defaultValues: {
+            name: initialData?.name ?? '',
+        },
+    });
+
+    return (
+        <form onSubmit={handleSubmit(onSubmit)} noValidate>
+            <Stack spacing={2} sx={{ minWidth: 320 }}>
+                <Controller
+                    name="name"
+                    control={control}
+                    rules={{ required: 'Название обязательно' }}
+                    render={({ field, fieldState }) => (
+                        <TextField
+                            {...field}
+                            label="Название статуса"
+                            fullWidth
+                            required
+                            error={!!fieldState.error}
+                            helperText={fieldState.error?.message}
+                            autoFocus
+                        />
+                    )}
+                />
+                <DialogActions sx={{ px: 0 }}>
+                    <Button onClick={onCancel}>Отмена</Button>
+                    <Button
+                        type="submit"
+                        variant="contained"
+                        disabled={isSubmitting}
+                        startIcon={isSubmitting && <CircularProgress size={18} color="inherit" />}
+                    >
+                        Сохранить
+                    </Button>
+                </DialogActions>
+            </Stack>
+        </form>
+    );
+}

--- a/src/features/letter/LetterForm.js
+++ b/src/features/letter/LetterForm.js
@@ -1,0 +1,123 @@
+import React, { useEffect } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Stack, TextField, Autocomplete } from '@mui/material';
+import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import dayjs from 'dayjs';
+import { useLetterTypes } from '@/entities/letterType';
+
+export default function LetterForm({ open, initialData, onSubmit, onCancel }) {
+    const { data: types = [] } = useLetterTypes();
+    const { control, handleSubmit, reset } = useForm({
+        defaultValues: {
+            number: '',
+            letter_type: '',
+            letter_date: null,
+            subject: '',
+            sender: '',
+            receiver: '',
+        },
+    });
+
+    useEffect(() => {
+        if (initialData) {
+            reset({
+                number: initialData.number ?? '',
+                letter_type: initialData.letter_type ?? '',
+                letter_date: initialData.letter_date ? dayjs(initialData.letter_date) : null,
+                subject: initialData.subject ?? '',
+                sender: initialData.sender ?? '',
+                receiver: initialData.receiver ?? '',
+            });
+        } else {
+            reset({
+                number: '',
+                letter_type: '',
+                letter_date: null,
+                subject: '',
+                sender: '',
+                receiver: '',
+            });
+        }
+    }, [initialData, reset]);
+
+    return (
+        <Dialog open={open} onClose={onCancel} fullWidth maxWidth="sm">
+            <form onSubmit={handleSubmit(onSubmit)} noValidate>
+                <DialogTitle>{initialData ? 'Редактировать письмо' : 'Новое письмо'}</DialogTitle>
+                <DialogContent dividers>
+                    <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="ru">
+                        <Stack spacing={2} sx={{ mt: 1 }}>
+                            <Controller
+                                name="number"
+                                control={control}
+                                rules={{ required: 'Номер обязателен' }}
+                                render={({ field, fieldState }) => (
+                                    <TextField
+                                        {...field}
+                                        label="Номер"
+                                        required
+                                        fullWidth
+                                        error={!!fieldState.error}
+                                        helperText={fieldState.error?.message}
+                                    />
+                                )}
+                            />
+                            <Controller
+                                name="letter_type"
+                                control={control}
+                                render={({ field }) => (
+                                    <Autocomplete
+                                        {...field}
+                                        onChange={(_, v) => field.onChange(v?.name ?? '')}
+                                        options={types}
+                                        getOptionLabel={(o) => o.name || ''}
+                                        isOptionEqualToValue={(o, v) => o.name === v.name}
+                                        renderInput={(params) => <TextField {...params} label="Тип" />}
+                                    />
+                                )}
+                            />
+                            <Controller
+                                name="letter_date"
+                                control={control}
+                                render={({ field }) => (
+                                    <DatePicker
+                                        {...field}
+                                        label="Дата"
+                                        format="DD.MM.YYYY"
+                                        onChange={(v) => field.onChange(v)}
+                                    />
+                                )}
+                            />
+                            <Controller
+                                name="subject"
+                                control={control}
+                                render={({ field }) => (
+                                    <TextField {...field} label="Тема" fullWidth />
+                                )}
+                            />
+                            <Controller
+                                name="sender"
+                                control={control}
+                                render={({ field }) => (
+                                    <TextField {...field} label="От кого" fullWidth />
+                                )}
+                            />
+                            <Controller
+                                name="receiver"
+                                control={control}
+                                render={({ field }) => (
+                                    <TextField {...field} label="Кому" fullWidth />
+                                )}
+                            />
+                        </Stack>
+                    </LocalizationProvider>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={onCancel}>Отмена</Button>
+                    <Button type="submit" variant="contained">Сохранить</Button>
+                </DialogActions>
+            </form>
+        </Dialog>
+    );
+}

--- a/src/features/letterType/LetterTypeForm.js
+++ b/src/features/letterType/LetterTypeForm.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { Stack, TextField, DialogActions, Button, CircularProgress } from '@mui/material';
+
+export default function LetterTypeForm({ initialData, onSubmit, onCancel }) {
+    const { control, handleSubmit, formState: { isSubmitting } } = useForm({
+        defaultValues: { name: initialData?.name ?? '' },
+    });
+
+    return (
+        <form onSubmit={handleSubmit(onSubmit)} noValidate>
+            <Stack spacing={2} sx={{ minWidth: 320 }}>
+                <Controller
+                    name="name"
+                    control={control}
+                    rules={{ required: 'Название обязательно' }}
+                    render={({ field, fieldState }) => (
+                        <TextField
+                            {...field}
+                            label="Тип письма"
+                            fullWidth
+                            required
+                            error={!!fieldState.error}
+                            helperText={fieldState.error?.message}
+                            autoFocus
+                        />
+                    )}
+                />
+                <DialogActions sx={{ px: 0 }}>
+                    <Button onClick={onCancel}>Отмена</Button>
+                    <Button
+                        type="submit"
+                        variant="contained"
+                        disabled={isSubmitting}
+                        startIcon={isSubmitting && <CircularProgress size={18} color="inherit" />}
+                    >
+                        Сохранить
+                    </Button>
+                </DialogActions>
+            </Stack>
+        </form>
+    );
+}

--- a/src/features/partyType/PartyTypeForm.js
+++ b/src/features/partyType/PartyTypeForm.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { Stack, TextField, DialogActions, Button, CircularProgress } from '@mui/material';
+
+export default function PartyTypeForm({ initialData, onSubmit, onCancel }) {
+    const { control, handleSubmit, formState: { isSubmitting } } = useForm({
+        defaultValues: { name: initialData?.name ?? '' },
+    });
+
+    return (
+        <form onSubmit={handleSubmit(onSubmit)} noValidate>
+            <Stack spacing={2} sx={{ minWidth: 320 }}>
+                <Controller
+                    name="name"
+                    control={control}
+                    rules={{ required: 'Название обязательно' }}
+                    render={({ field, fieldState }) => (
+                        <TextField
+                            {...field}
+                            label="Тип участника"
+                            fullWidth
+                            required
+                            error={!!fieldState.error}
+                            helperText={fieldState.error?.message}
+                            autoFocus
+                        />
+                    )}
+                />
+                <DialogActions sx={{ px: 0 }}>
+                    <Button onClick={onCancel}>Отмена</Button>
+                    <Button
+                        type="submit"
+                        variant="contained"
+                        disabled={isSubmitting}
+                        startIcon={isSubmitting && <CircularProgress size={18} color="inherit" />}
+                    >
+                        Сохранить
+                    </Button>
+                </DialogActions>
+            </Stack>
+        </form>
+    );
+}

--- a/src/pages/CourtCasesPage/CourtCasesPage.js
+++ b/src/pages/CourtCasesPage/CourtCasesPage.js
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { Container, Stack, Button } from '@mui/material';
+import { useCourtCases, useAddCourtCase, useUpdateCourtCase } from '@/entities/courtCase';
+import CourtCaseForm from '@/features/courtCase/CourtCaseForm';
+import CourtCasesTable from '@/widgets/CourtCasesTable';
+
+export default function CourtCasesPage() {
+    const { data: cases = [], isLoading } = useCourtCases();
+    const add = useAddCourtCase();
+    const update = useUpdateCourtCase();
+    const [modal, setModal] = useState(null); // {mode:'add'|'edit', data?}
+
+    const rows = cases.map((c) => ({
+        ...c,
+        unit_name: c.units?.name ?? '',
+        stage_name: c.litigation_stages?.name ?? '',
+    }));
+
+    const handleCreate = async (values) => {
+        await add.mutateAsync(values);
+    };
+
+    const handleUpdate = async (values) => {
+        if (!modal?.data?.id) return;
+        await update.mutateAsync({ id: modal.data.id, updates: values });
+    };
+
+    return (
+        <Container maxWidth="lg" sx={{ py: 4 }}>
+            {modal && (
+                <CourtCaseForm
+                    initialData={modal.data}
+                    onSubmit={modal.mode === 'add' ? handleCreate : handleUpdate}
+                    onCancel={() => setModal(null)}
+                />
+            )}
+            <Stack spacing={2}>
+                <Button variant="contained" onClick={() => setModal({ mode: 'add' })}>
+                    Новое дело
+                </Button>
+                <CourtCasesTable rows={rows} onEdit={(row) => setModal({ mode: 'edit', data: row })} />
+            </Stack>
+        </Container>
+    );
+}

--- a/src/pages/UnitsPage/AdminPage.js
+++ b/src/pages/UnitsPage/AdminPage.js
@@ -8,6 +8,9 @@ import TicketStatusesAdmin   from '../../widgets/TicketStatusesAdmin';
 import TicketTypesAdmin      from '../../widgets/TicketTypesAdmin';
 import UsersTable            from '../../widgets/UsersTable';
 import LitigationStagesAdmin from '../../widgets/LitigationStagesAdmin';
+import CourtCaseStatusesAdmin from '../../widgets/CourtCaseStatusesAdmin';
+import PartyTypesAdmin from '../../widgets/PartyTypesAdmin';
+import LetterTypesAdmin from '../../widgets/LetterTypesAdmin';
 
 export default function AdminPage() {
     return (
@@ -18,6 +21,9 @@ export default function AdminPage() {
                 <TicketStatusesAdmin pageSize={25} rowsPerPageOptions={[10, 25, 50, 100]} />
                 <TicketTypesAdmin pageSize={25} rowsPerPageOptions={[10, 25, 50, 100]} />
                 <LitigationStagesAdmin pageSize={25} rowsPerPageOptions={[10, 25, 50, 100]} />
+                <CourtCaseStatusesAdmin pageSize={25} rowsPerPageOptions={[10, 25, 50, 100]} />
+                <PartyTypesAdmin pageSize={25} rowsPerPageOptions={[10, 25, 50, 100]} />
+                <LetterTypesAdmin pageSize={25} rowsPerPageOptions={[10, 25, 50, 100]} />
                 <UsersTable pageSize={25} rowsPerPageOptions={[10, 25, 50, 100]} />
             </Stack>
         </Container>

--- a/src/widgets/CourtCaseStatusesAdmin.js
+++ b/src/widgets/CourtCaseStatusesAdmin.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import { DataGrid } from '@mui/x-data-grid';
+import { Button, Stack, Dialog, DialogTitle, DialogContent, IconButton } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import {
+    useCourtCaseStatuses,
+    useAddCourtCaseStatus,
+    useUpdateCourtCaseStatus,
+    useDeleteCourtCaseStatus,
+} from '@/entities/courtCaseStatus';
+import CourtCaseStatusForm from '@/features/courtCaseStatus/CourtCaseStatusForm';
+
+export default function CourtCaseStatusesAdmin({ pageSize = 25, rowsPerPageOptions = [10, 25, 50, 100] }) {
+    const { data = [], isLoading } = useCourtCaseStatuses();
+    const add = useAddCourtCaseStatus();
+    const update = useUpdateCourtCaseStatus();
+    const remove = useDeleteCourtCaseStatus();
+    const [open, setOpen] = React.useState(false);
+    const [editRow, setEditRow] = React.useState(null);
+
+    const handleAdd = () => { setEditRow(null); setOpen(true); };
+    const handleEdit = (row) => { setEditRow(row); setOpen(true); };
+    const handleDelete = (id) => { if (window.confirm('Удалить статус?')) remove.mutate(id); };
+    const handleSubmit = async (values) => {
+        if (editRow) {
+            await update.mutateAsync({ id: editRow.id, name: values.name });
+        } else {
+            await add.mutateAsync(values.name);
+        }
+        setOpen(false);
+    };
+
+    return (
+        <Stack spacing={2}>
+            <Stack direction="row" justifyContent="space-between" alignItems="center">
+                <span style={{ fontWeight: 600, fontSize: 18 }}>Статусы дел</span>
+                <Button onClick={handleAdd} variant="contained">Добавить</Button>
+            </Stack>
+            <div style={{ width: '100%' }}>
+                <DataGrid
+                    rows={data}
+                    columns={[
+                        { field: 'id', headerName: 'ID', width: 80 },
+                        { field: 'name', headerName: 'Название статуса', flex: 1 },
+                        {
+                            field: 'actions',
+                            headerName: '',
+                            width: 100,
+                            sortable: false,
+                            renderCell: (params) => (
+                                <Stack direction="row" spacing={0}>
+                                    <IconButton size="small" onClick={() => handleEdit(params.row)} color="primary">
+                                        <EditIcon fontSize="small" />
+                                    </IconButton>
+                                    <IconButton size="small" color="error" onClick={() => handleDelete(params.row.id)}>
+                                        <DeleteIcon fontSize="small" />
+                                    </IconButton>
+                                </Stack>
+                            ),
+                        },
+                    ]}
+                    pageSize={pageSize}
+                    rowsPerPageOptions={rowsPerPageOptions}
+                    autoHeight
+                    loading={isLoading}
+                    disableSelectionOnClick
+                />
+            </div>
+            <Dialog open={open} onClose={() => setOpen(false)} maxWidth="xs" fullWidth>
+                <DialogTitle>{editRow ? 'Редактировать статус' : 'Добавить статус'}</DialogTitle>
+                <DialogContent>
+                    <CourtCaseStatusForm
+                        initialData={editRow}
+                        onSubmit={handleSubmit}
+                        onCancel={() => setOpen(false)}
+                    />
+                </DialogContent>
+            </Dialog>
+        </Stack>
+    );
+}

--- a/src/widgets/CourtCasesTable.js
+++ b/src/widgets/CourtCasesTable.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { DataGrid, GridActionsCellItem } from '@mui/x-data-grid';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { useDeleteCourtCase } from '@/entities/courtCase';
+
+export default function CourtCasesTable({ rows, onEdit }) {
+    const remove = useDeleteCourtCase();
+
+    const columns = [
+        { field: 'id', headerName: 'ID', width: 80 },
+        { field: 'internal_no', headerName: 'Номер', flex: 1 },
+        { field: 'unit_name', headerName: 'Объект', flex: 1 },
+        { field: 'stage_name', headerName: 'Стадия', flex: 1 },
+        { field: 'status', headerName: 'Статус', width: 140 },
+        {
+            field: 'actions',
+            type: 'actions',
+            width: 100,
+            getActions: ({ row }) => [
+                <GridActionsCellItem key="edit" icon={<EditIcon />} label="Edit" onClick={() => onEdit(row)} />,
+                <GridActionsCellItem
+                    key="del"
+                    icon={<DeleteIcon color="error" />}
+                    label="Delete"
+                    onClick={() => {
+                        if (!window.confirm('Удалить дело?')) return;
+                        remove.mutate(row.id);
+                    }}
+                />,
+            ],
+        },
+    ];
+
+    return (
+        <DataGrid
+            autoHeight
+            rows={rows}
+            columns={columns}
+            getRowId={(r) => r.id}
+            density="compact"
+            hideFooterSelectedRowCount
+            disableRowSelectionOnClick
+        />
+    );
+}

--- a/src/widgets/LetterTypesAdmin.js
+++ b/src/widgets/LetterTypesAdmin.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import { DataGrid } from '@mui/x-data-grid';
+import { Button, Stack, Dialog, DialogTitle, DialogContent, IconButton } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import {
+    useLetterTypes,
+    useAddLetterType,
+    useUpdateLetterType,
+    useDeleteLetterType,
+} from '@/entities/letterType';
+import LetterTypeForm from '@/features/letterType/LetterTypeForm';
+
+export default function LetterTypesAdmin({ pageSize = 25, rowsPerPageOptions = [10, 25, 50, 100] }) {
+    const { data = [], isLoading } = useLetterTypes();
+    const add = useAddLetterType();
+    const update = useUpdateLetterType();
+    const remove = useDeleteLetterType();
+    const [open, setOpen] = React.useState(false);
+    const [editRow, setEditRow] = React.useState(null);
+
+    const handleAdd = () => { setEditRow(null); setOpen(true); };
+    const handleEdit = (row) => { setEditRow(row); setOpen(true); };
+    const handleDelete = (id) => { if (window.confirm('Удалить тип?')) remove.mutate(id); };
+    const handleSubmit = async (values) => {
+        if (editRow) {
+            await update.mutateAsync({ id: editRow.id, name: values.name });
+        } else {
+            await add.mutateAsync(values.name);
+        }
+        setOpen(false);
+    };
+
+    return (
+        <Stack spacing={2}>
+            <Stack direction="row" justifyContent="space-between" alignItems="center">
+                <span style={{ fontWeight: 600, fontSize: 18 }}>Типы писем</span>
+                <Button onClick={handleAdd} variant="contained">Добавить</Button>
+            </Stack>
+            <div style={{ width: '100%' }}>
+                <DataGrid
+                    rows={data}
+                    columns={[
+                        { field: 'id', headerName: 'ID', width: 80 },
+                        { field: 'name', headerName: 'Название', flex: 1 },
+                        {
+                            field: 'actions',
+                            headerName: '',
+                            width: 100,
+                            sortable: false,
+                            renderCell: (params) => (
+                                <Stack direction="row" spacing={0}>
+                                    <IconButton size="small" onClick={() => handleEdit(params.row)} color="primary">
+                                        <EditIcon fontSize="small" />
+                                    </IconButton>
+                                    <IconButton size="small" color="error" onClick={() => handleDelete(params.row.id)}>
+                                        <DeleteIcon fontSize="small" />
+                                    </IconButton>
+                                </Stack>
+                            ),
+                        },
+                    ]}
+                    pageSize={pageSize}
+                    rowsPerPageOptions={rowsPerPageOptions}
+                    autoHeight
+                    loading={isLoading}
+                    disableSelectionOnClick
+                />
+            </div>
+            <Dialog open={open} onClose={() => setOpen(false)} maxWidth="xs" fullWidth>
+                <DialogTitle>{editRow ? 'Редактировать тип' : 'Добавить тип'}</DialogTitle>
+                <DialogContent>
+                    <LetterTypeForm
+                        initialData={editRow}
+                        onSubmit={handleSubmit}
+                        onCancel={() => setOpen(false)}
+                    />
+                </DialogContent>
+            </Dialog>
+        </Stack>
+    );
+}

--- a/src/widgets/LettersTable.js
+++ b/src/widgets/LettersTable.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { DataGrid, GridActionsCellItem } from '@mui/x-data-grid';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { useDeleteLetter } from '@/entities/letter';
+
+export default function LettersTable({ rows, onEdit }) {
+    const remove = useDeleteLetter();
+
+    const columns = [
+        { field: 'id', headerName: 'ID', width: 80 },
+        { field: 'number', headerName: 'Номер', flex: 1 },
+        { field: 'letter_date', headerName: 'Дата', width: 120 },
+        { field: 'letter_type', headerName: 'Тип', width: 140 },
+        { field: 'subject', headerName: 'Тема', flex: 1 },
+        {
+            field: 'actions',
+            type: 'actions',
+            width: 80,
+            getActions: ({ row }) => [
+                <GridActionsCellItem key="edit" icon={<EditIcon />} label="Edit" onClick={() => onEdit(row)} />,
+                <GridActionsCellItem
+                    key="del"
+                    icon={<DeleteIcon color="error" />}
+                    label="Delete"
+                    onClick={() => {
+                        if (window.confirm('Удалить письмо?')) {
+                            remove.mutate({ id: row.id, case_id: row.case_id });
+                        }
+                    }}
+                />,
+            ],
+        },
+    ];
+
+    return (
+        <DataGrid
+            autoHeight
+            rows={rows}
+            columns={columns}
+            getRowId={(r) => r.id}
+            density="compact"
+            hideFooterSelectedRowCount
+            disableRowSelectionOnClick
+        />
+    );
+}

--- a/src/widgets/PartyTypesAdmin.js
+++ b/src/widgets/PartyTypesAdmin.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import { DataGrid } from '@mui/x-data-grid';
+import { Button, Stack, Dialog, DialogTitle, DialogContent, IconButton } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import {
+    usePartyTypes,
+    useAddPartyType,
+    useUpdatePartyType,
+    useDeletePartyType,
+} from '@/entities/partyType';
+import PartyTypeForm from '@/features/partyType/PartyTypeForm';
+
+export default function PartyTypesAdmin({ pageSize = 25, rowsPerPageOptions = [10, 25, 50, 100] }) {
+    const { data = [], isLoading } = usePartyTypes();
+    const add = useAddPartyType();
+    const update = useUpdatePartyType();
+    const remove = useDeletePartyType();
+    const [open, setOpen] = React.useState(false);
+    const [editRow, setEditRow] = React.useState(null);
+
+    const handleAdd = () => { setEditRow(null); setOpen(true); };
+    const handleEdit = (row) => { setEditRow(row); setOpen(true); };
+    const handleDelete = (id) => { if (window.confirm('Удалить тип?')) remove.mutate(id); };
+    const handleSubmit = async (values) => {
+        if (editRow) {
+            await update.mutateAsync({ id: editRow.id, name: values.name });
+        } else {
+            await add.mutateAsync(values.name);
+        }
+        setOpen(false);
+    };
+
+    return (
+        <Stack spacing={2}>
+            <Stack direction="row" justifyContent="space-between" alignItems="center">
+                <span style={{ fontWeight: 600, fontSize: 18 }}>Типы участников</span>
+                <Button onClick={handleAdd} variant="contained">Добавить</Button>
+            </Stack>
+            <div style={{ width: '100%' }}>
+                <DataGrid
+                    rows={data}
+                    columns={[
+                        { field: 'id', headerName: 'ID', width: 80 },
+                        { field: 'name', headerName: 'Название', flex: 1 },
+                        {
+                            field: 'actions',
+                            headerName: '',
+                            width: 100,
+                            sortable: false,
+                            renderCell: (params) => (
+                                <Stack direction="row" spacing={0}>
+                                    <IconButton size="small" onClick={() => handleEdit(params.row)} color="primary">
+                                        <EditIcon fontSize="small" />
+                                    </IconButton>
+                                    <IconButton size="small" color="error" onClick={() => handleDelete(params.row.id)}>
+                                        <DeleteIcon fontSize="small" />
+                                    </IconButton>
+                                </Stack>
+                            ),
+                        },
+                    ]}
+                    pageSize={pageSize}
+                    rowsPerPageOptions={rowsPerPageOptions}
+                    autoHeight
+                    loading={isLoading}
+                    disableSelectionOnClick
+                />
+            </div>
+            <Dialog open={open} onClose={() => setOpen(false)} maxWidth="xs" fullWidth>
+                <DialogTitle>{editRow ? 'Редактировать тип' : 'Добавить тип'}</DialogTitle>
+                <DialogContent>
+                    <PartyTypeForm
+                        initialData={editRow}
+                        onSubmit={handleSubmit}
+                        onCancel={() => setOpen(false)}
+                    />
+                </DialogContent>
+            </Dialog>
+        </Stack>
+    );
+}


### PR DESCRIPTION
## Summary
- add CRUD hooks for court cases and related enums
- create forms and admin tables for court case enums
- implement page for court case list and editing
- wire new page into router and admin panel
- enhance court cases with letters management

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: craco not found)*