### PR TITLE
Fix court case form select fields

### DIFF
--- a/src/entities/courtCaseStatus.js
+++ b/src/entities/courtCaseStatus.js
@@ -1,65 +1,38 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/shared/api/supabaseClient';
+import { useQuery, useMutation } from '@tanstack/react-query';
 
-const TABLE = 'court_case_statuses';
-const KEY = [TABLE];
+// В базе статусы представлены типом ENUM, поэтому таблицы нет.
+// Возвращаем фиксированный список значений.
+const STATUSES = [
+    { id: 1, name: 'NEW' },
+    { id: 2, name: 'IN_PROGRESS' },
+    { id: 3, name: 'SETTLED' },
+    { id: 4, name: 'CLOSED' },
+];
 
 export const useCourtCaseStatuses = () =>
     useQuery({
-        queryKey: KEY,
-        queryFn : async () => {
-            const { data, error } = await supabase
-                .from(TABLE)
-                .select('id, name')
-                .order('id');
-            if (error) throw error;
-            return data ?? [];
-        },
-        staleTime: 5 * 60_000,
+        queryKey: ['court_case_statuses'],
+        queryFn : async () => STATUSES,
+        staleTime: Infinity,
     });
 
-const invalidate = (qc) => qc.invalidateQueries({ queryKey: KEY });
-
-export const useAddCourtCaseStatus = () => {
-    const qc = useQueryClient();
-    return useMutation({
-        mutationFn: async (name) => {
-            const { data, error } = await supabase
-                .from(TABLE)
-                .insert({ name })
-                .select('id, name')
-                .single();
-            if (error) throw error;
-            return data;
+export const useAddCourtCaseStatus = () =>
+    useMutation({
+        mutationFn: async () => {
+            throw new Error('Court case statuses are static and cannot be modified');
         },
-        onSuccess: () => invalidate(qc),
     });
-};
 
-export const useUpdateCourtCaseStatus = () => {
-    const qc = useQueryClient();
-    return useMutation({
-        mutationFn: async ({ id, name }) => {
-            const { data, error } = await supabase
-                .from(TABLE)
-                .update({ name })
-                .eq('id', id)
-                .select('id, name')
-                .single();
-            if (error) throw error;
-            return data;
+export const useUpdateCourtCaseStatus = () =>
+    useMutation({
+        mutationFn: async () => {
+            throw new Error('Court case statuses are static and cannot be modified');
         },
-        onSuccess: () => invalidate(qc),
     });
-};
 
-export const useDeleteCourtCaseStatus = () => {
-    const qc = useQueryClient();
-    return useMutation({
-        mutationFn: async (id) => {
-            const { error } = await supabase.from(TABLE).delete().eq('id', id);
-            if (error) throw error;
+export const useDeleteCourtCaseStatus = () =>
+    useMutation({
+        mutationFn: async () => {
+            throw new Error('Court case statuses are static and cannot be modified');
         },
-        onSuccess: () => invalidate(qc),
     });
-};

--- a/src/features/courtCase/CourtCaseForm.js
+++ b/src/features/courtCase/CourtCaseForm.js
@@ -91,9 +91,9 @@ export default function CourtCaseForm({ initialData, onSubmit, onCancel }) {
                             control={control}
                             render={({ field }) => (
                                 <Autocomplete
-                                    {...field}
-                                    onChange={(_, v) => field.onChange(v?.id ?? null)}
                                     options={units}
+                                    value={units.find((u) => u.id === field.value) || null}
+                                    onChange={(_, v) => field.onChange(v?.id ?? null)}
                                     getOptionLabel={(o) => o.name || ''}
                                     isOptionEqualToValue={(o, v) => o.id === v.id}
                                     renderInput={(params) => <TextField {...params} label="Объект" />}
@@ -105,9 +105,9 @@ export default function CourtCaseForm({ initialData, onSubmit, onCancel }) {
                             control={control}
                             render={({ field }) => (
                                 <Autocomplete
-                                    {...field}
-                                    onChange={(_, v) => field.onChange(v?.id ?? null)}
                                     options={stages}
+                                    value={stages.find((s) => s.id === field.value) || null}
+                                    onChange={(_, v) => field.onChange(v?.id ?? null)}
                                     getOptionLabel={(o) => o.name || ''}
                                     isOptionEqualToValue={(o, v) => o.id === v.id}
                                     renderInput={(params) => <TextField {...params} label="Стадия" />}
@@ -119,9 +119,9 @@ export default function CourtCaseForm({ initialData, onSubmit, onCancel }) {
                             control={control}
                             render={({ field }) => (
                                 <Autocomplete
-                                    {...field}
-                                    onChange={(_, v) => field.onChange(v?.name ?? '')}
                                     options={statuses}
+                                    value={statuses.find((s) => s.name === field.value) || null}
+                                    onChange={(_, v) => field.onChange(v?.name ?? '')}
                                     getOptionLabel={(o) => o.name || ''}
                                     isOptionEqualToValue={(o, v) => o.name === v.name}
                                     renderInput={(params) => <TextField {...params} label="Статус" />}
@@ -133,9 +133,9 @@ export default function CourtCaseForm({ initialData, onSubmit, onCancel }) {
                             control={control}
                             render={({ field }) => (
                                 <Autocomplete
-                                    {...field}
-                                    onChange={(_, v) => field.onChange(v?.id ?? null)}
                                     options={users}
+                                    value={users.find((u) => u.id === field.value) || null}
+                                    onChange={(_, v) => field.onChange(v?.id ?? null)}
                                     getOptionLabel={(o) => o.name || o.email || ''}
                                     isOptionEqualToValue={(o, v) => o.id === v.id}
                                     renderInput={(params) => <TextField {...params} label="Ответственный юрист" />}

--- a/src/features/letter/LetterForm.js
+++ b/src/features/letter/LetterForm.js
@@ -68,9 +68,9 @@ export default function LetterForm({ open, initialData, onSubmit, onCancel }) {
                                 control={control}
                                 render={({ field }) => (
                                     <Autocomplete
-                                        {...field}
-                                        onChange={(_, v) => field.onChange(v?.name ?? '')}
                                         options={types}
+                                        value={types.find((t) => t.name === field.value) || null}
+                                        onChange={(_, v) => field.onChange(v?.name ?? '')}
                                         getOptionLabel={(o) => o.name || ''}
                                         isOptionEqualToValue={(o, v) => o.name === v.name}
                                         renderInput={(params) => <TextField {...params} label="Тип" />}


### PR DESCRIPTION
## Summary
- fix object selection in court case form Autocomplete fields
- fix letter type selection in letter form
- replace failing Supabase request for court case statuses with a static enum list

## Testing
- `npm test --silent -- --watchAll=false` *(fails: craco not found)*
- `npm run lint --silent` *(fails: ESLint couldn't find config)*