### PR TITLE
Fix letter type management

### DIFF
--- a/database/migrations/20250524_add_letter_types_table.sql
+++ b/database/migrations/20250524_add_letter_types_table.sql
@@ -1,0 +1,24 @@
+-- 20250524_add_letter_types_table.sql
+-- Создание таблицы letter_types и переход с enum на текстовый тип
+
+CREATE TABLE letter_types (
+  id   BIGSERIAL PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE
+);
+
+INSERT INTO letter_types (name) VALUES
+  ('PRETENSION'),
+  ('CLAIM'),
+  ('ANSWER'),
+  ('NOTICE'),
+  ('OTHER');
+
+-- Преобразуем колонку letters.letter_type из ENUM в TEXT
+ALTER TABLE letters
+  ALTER COLUMN letter_type TYPE TEXT USING letter_type::text;
+
+DROP TYPE IF EXISTS letter_type;
+
+ALTER TABLE letters
+  ADD CONSTRAINT letters_letter_type_fkey
+    FOREIGN KEY (letter_type) REFERENCES letter_types(name);

--- a/database_structure.json
+++ b/database_structure.json
@@ -401,7 +401,7 @@
   {
     "table_name": "letters",
     "column_name": "letter_type",
-    "data_type": "USER-DEFINED",
+    "data_type": "text",
     "is_nullable": "NO",
     "column_default": null
   },
@@ -439,6 +439,20 @@
     "data_type": "timestamp with time zone",
     "is_nullable": "NO",
     "column_default": "now()"
+  },
+  {
+    "table_name": "letter_types",
+    "column_name": "id",
+    "data_type": "bigint",
+    "is_nullable": "NO",
+    "column_default": "nextval('letter_types_id_seq'::regclass)"
+  },
+  {
+    "table_name": "letter_types",
+    "column_name": "name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": null
   },
   {
     "table_name": "litigation_stages",


### PR DESCRIPTION
## Summary
- add `letter_types` reference table and migrate old enum data
- update recorded database structure

## Testing
- `npm test` *(fails: craco not found)*