### PR TITLE
Enable linking defects to court cases

### DIFF
--- a/src/entities/caseDefect.js
+++ b/src/entities/caseDefect.js
@@ -1,0 +1,70 @@
+import { supabase } from '@/shared/api/supabaseClient';
+import { useProjectId } from '@/shared/hooks/useProjectId';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const useCaseDefects = (caseId) => {
+    const projectId = useProjectId();
+    return useQuery({
+        queryKey: ['case_defects', projectId, caseId],
+        enabled: !!projectId && !!caseId,
+        queryFn: async () => {
+            const { data, error } = await supabase
+                .from('court_case_defects')
+                .select('case_id, defect:defects ( id, description, fix_cost )')
+                .eq('case_id', caseId)
+                .eq('defects.project_id', projectId);
+            if (error) throw error;
+            return (
+                data?.map((d) => ({
+                    case_id: d.case_id,
+                    id: d.defect.id,
+                    description: d.defect.description,
+                    fix_cost: d.defect.fix_cost,
+                })) ?? []
+            );
+        },
+        staleTime: 5 * 60_000,
+    });
+};
+
+const insertLink = async ({ case_id, defect_id }) => {
+    const { error } = await supabase
+        .from('court_case_defects')
+        .upsert({ case_id, defect_id }, { ignoreDuplicates: true });
+    if (error) throw error;
+};
+
+export const useAddCaseDefect = () => {
+    const qc = useQueryClient();
+    const projectId = useProjectId();
+    return useMutation({
+        mutationFn: insertLink,
+        onSuccess: (_, vars) => {
+            qc.invalidateQueries({
+                queryKey: ['case_defects', projectId, vars.case_id],
+            });
+        },
+    });
+};
+
+const deleteLink = async ({ case_id, defect_id }) => {
+    const { error } = await supabase
+        .from('court_case_defects')
+        .delete()
+        .eq('case_id', case_id)
+        .eq('defect_id', defect_id);
+    if (error) throw error;
+};
+
+export const useDeleteCaseDefect = () => {
+    const qc = useQueryClient();
+    const projectId = useProjectId();
+    return useMutation({
+        mutationFn: deleteLink,
+        onSuccess: (_, vars) => {
+            qc.invalidateQueries({
+                queryKey: ['case_defects', projectId, vars.case_id],
+            });
+        },
+    });
+};

--- a/src/entities/defect.js
+++ b/src/entities/defect.js
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/shared/api/supabaseClient';
+import { useProjectId } from '@/shared/hooks/useProjectId';
+
+export const useProjectDefects = () => {
+    const projectId = useProjectId();
+    return useQuery({
+        queryKey: ['defects', projectId],
+        enabled: !!projectId,
+        queryFn: async () => {
+            const { data, error } = await supabase
+                .from('defects')
+                .select('id, description, fix_cost')
+                .eq('project_id', projectId)
+                .order('id');
+            if (error) throw error;
+            return data ?? [];
+        },
+        staleTime: 5 * 60_000,
+    });
+};

--- a/src/features/caseDefect/CaseDefectForm.js
+++ b/src/features/caseDefect/CaseDefectForm.js
@@ -1,0 +1,56 @@
+import React, { useEffect } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField, Autocomplete } from '@mui/material';
+import { useProjectDefects } from '@/entities/defect';
+
+export default function CaseDefectForm({ open, initialData, onSubmit, onCancel }) {
+    const { data: defects = [] } = useProjectDefects();
+    const { control, handleSubmit, reset } = useForm({
+        defaultValues: { defect_id: null },
+    });
+
+    useEffect(() => {
+        if (initialData) {
+            reset({ defect_id: initialData.id });
+        } else {
+            reset({ defect_id: null });
+        }
+    }, [initialData, reset]);
+
+    return (
+        <Dialog open={open} onClose={onCancel} fullWidth maxWidth="sm">
+            <form onSubmit={handleSubmit((vals) => onSubmit(vals.defect_id))} noValidate>
+                <DialogTitle>Добавить недостаток</DialogTitle>
+                <DialogContent dividers>
+                    <Controller
+                        name="defect_id"
+                        control={control}
+                        rules={{ required: 'Недостаток обязателен' }}
+                        render={({ field, fieldState }) => (
+                            <Autocomplete
+                                options={defects}
+                                value={defects.find((d) => d.id === field.value) || null}
+                                onChange={(_, v) => field.onChange(v?.id ?? null)}
+                                getOptionLabel={(o) => o.description || ''}
+                                isOptionEqualToValue={(o, v) => o.id === v.id}
+                                renderInput={(params) => (
+                                    <TextField
+                                        {...params}
+                                        label="Недостаток"
+                                        required
+                                        error={!!fieldState.error}
+                                        helperText={fieldState.error?.message}
+                                    />
+                                )}
+                            />
+                        )}
+                    />
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={onCancel}>Отмена</Button>
+                    <Button type="submit" variant="contained">Сохранить</Button>
+                </DialogActions>
+            </form>
+        </Dialog>
+    );
+}

--- a/src/features/courtCase/CourtCaseForm.js
+++ b/src/features/courtCase/CourtCaseForm.js
@@ -14,7 +14,13 @@ import {
     useAddLetter,
     useUpdateLetter,
 } from '@/entities/letter';
+import {
+    useCaseDefects,
+    useAddCaseDefect,
+} from '@/entities/caseDefect';
 import LetterForm from '@/features/letter/LetterForm';
+import CaseDefectForm from '@/features/caseDefect/CaseDefectForm';
+import CaseDefectsTable from '@/widgets/CaseDefectsTable';
 import LettersTable from '@/widgets/LettersTable';
 
 export default function CourtCaseForm({ initialData, onSubmit, onCancel }) {
@@ -28,6 +34,10 @@ export default function CourtCaseForm({ initialData, onSubmit, onCancel }) {
     const addLetter = useAddLetter();
     const updateLetter = useUpdateLetter();
     const [letterModal, setLetterModal] = useState(null); // {mode, data}
+
+    const { data: caseDefects = [] } = useCaseDefects(initialData?.id);
+    const addCaseDefect = useAddCaseDefect();
+    const [defectModal, setDefectModal] = useState(false);
 
     const { control, handleSubmit, reset, setValue } = useForm({
         defaultValues: {
@@ -177,6 +187,14 @@ export default function CourtCaseForm({ initialData, onSubmit, onCancel }) {
                 </LocalizationProvider>
                 {initialData && (
                     <Stack spacing={2} sx={{ mt: 3 }}>
+                        <Button variant="outlined" onClick={() => setDefectModal(true)}>
+                            Добавить недостаток
+                        </Button>
+                        <CaseDefectsTable rows={caseDefects} />
+                    </Stack>
+                )}
+                {initialData && (
+                    <Stack spacing={2} sx={{ mt: 3 }}>
                         <Button variant="outlined" onClick={() => setLetterModal({ mode: 'add', data: null })}>
                             Добавить письмо
                         </Button>
@@ -203,6 +221,20 @@ export default function CourtCaseForm({ initialData, onSubmit, onCancel }) {
                             await updateLetter.mutateAsync({ id: letterModal.data.id, case_id: initialData.id, updates: vals });
                         }
                         setLetterModal(null);
+                    }}
+                />
+            )}
+            {defectModal && initialData && (
+                <CaseDefectForm
+                    open
+                    initialData={null}
+                    onCancel={() => setDefectModal(false)}
+                    onSubmit={async (defect_id) => {
+                        await addCaseDefect.mutateAsync({
+                            case_id: initialData.id,
+                            defect_id,
+                        });
+                        setDefectModal(false);
                     }}
                 />
             )}

--- a/src/widgets/CaseDefectsTable.js
+++ b/src/widgets/CaseDefectsTable.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { DataGrid, GridActionsCellItem } from '@mui/x-data-grid';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { useDeleteCaseDefect } from '@/entities/caseDefect';
+
+export default function CaseDefectsTable({ rows }) {
+    const remove = useDeleteCaseDefect();
+
+    const columns = [
+        { field: 'id', headerName: 'ID', width: 80 },
+        { field: 'description', headerName: 'Недостаток', flex: 1 },
+        { field: 'fix_cost', headerName: 'Стоимость устранения', width: 160 },
+        {
+            field: 'actions',
+            type: 'actions',
+            width: 80,
+            getActions: ({ row }) => [
+                <GridActionsCellItem
+                    key="del"
+                    icon={<DeleteIcon color="error" />}
+                    label="Delete"
+                    onClick={() => {
+                        if (window.confirm('Удалить недостаток из дела?')) {
+                            remove.mutate({ case_id: row.case_id, defect_id: row.id });
+                        }
+                    }}
+                />,
+            ],
+        },
+    ];
+
+    return (
+        <DataGrid
+            autoHeight
+            rows={rows}
+            columns={columns}
+            getRowId={(r) => r.id}
+            density="compact"
+            hideFooterSelectedRowCount
+            disableRowSelectionOnClick
+        />
+    );
+}


### PR DESCRIPTION
## Summary
- add `useProjectDefects` entity hook
- add entity hooks to link defects with court cases
- add defect selection form and table widgets
- extend court case form with ability to add defects

## Testing
- `npm test` *(fails: craco not found)*
- `npm run lint` *(fails: ESLint configuration missing)*