### PR TITLE
Improve court cases page

### DIFF
--- a/src/pages/CourtCasesPage/CourtCasesPage.js
+++ b/src/pages/CourtCasesPage/CourtCasesPage.js
@@ -1,20 +1,51 @@
 import React, { useState } from 'react';
-import { Container, Stack, Button } from '@mui/material';
+import {
+    Container,
+    Stack,
+    Button,
+    TextField,
+    MenuItem,
+    FormControl,
+    InputLabel,
+    Select,
+} from '@mui/material';
 import { useCourtCases, useAddCourtCase, useUpdateCourtCase } from '@/entities/courtCase';
 import CourtCaseForm from '@/features/courtCase/CourtCaseForm';
 import CourtCasesTable from '@/widgets/CourtCasesTable';
+import { useCourtCaseStatuses } from '@/entities/courtCaseStatus';
+import CourtCaseDetailsDialog from '@/widgets/CourtCaseDetailsDialog';
 
 export default function CourtCasesPage() {
     const { data: cases = [], isLoading } = useCourtCases();
     const add = useAddCourtCase();
     const update = useUpdateCourtCase();
+    const { data: statuses = [] } = useCourtCaseStatuses();
     const [modal, setModal] = useState(null); // {mode:'add'|'edit', data?}
+    const [viewCase, setViewCase] = useState(null);
+    const [search, setSearch] = useState('');
+    const [statusFilter, setStatusFilter] = useState('');
+    const [unitFilter, setUnitFilter] = useState('');
+    const [lawyerFilter, setLawyerFilter] = useState('');
 
     const rows = cases.map((c) => ({
         ...c,
         unit_name: c.units?.name ?? '',
         stage_name: c.litigation_stages?.name ?? '',
+        lawyer_name: c.profiles?.name ?? '',
     }));
+
+    const filteredRows = rows.filter((r) => {
+        const s = search.toLowerCase();
+        const matchesSearch =
+            r.internal_no.toLowerCase().includes(s) ||
+            r.unit_name.toLowerCase().includes(s) ||
+            r.lawyer_name.toLowerCase().includes(s) ||
+            r.comments?.toLowerCase().includes(s);
+        const matchesStatus = !statusFilter || r.status === statusFilter;
+        const matchesUnit = !unitFilter || r.unit_name.toLowerCase().includes(unitFilter.toLowerCase());
+        const matchesLawyer = !lawyerFilter || r.lawyer_name.toLowerCase().includes(lawyerFilter.toLowerCase());
+        return matchesSearch && matchesStatus && matchesUnit && matchesLawyer;
+    });
 
     const handleCreate = async (values) => {
         await add.mutateAsync(values);
@@ -34,11 +65,42 @@ export default function CourtCasesPage() {
                     onCancel={() => setModal(null)}
                 />
             )}
+            {viewCase && (
+                <CourtCaseDetailsDialog
+                    open
+                    caseData={viewCase}
+                    onClose={() => setViewCase(null)}
+                />
+            )}
             <Stack spacing={2}>
                 <Button variant="contained" onClick={() => setModal({ mode: 'add' })}>
                     Новое дело
                 </Button>
-                <CourtCasesTable rows={rows} onEdit={(row) => setModal({ mode: 'edit', data: row })} />
+                <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+                    <TextField label="Поиск" value={search} onChange={(e) => setSearch(e.target.value)} />
+                    <FormControl sx={{ minWidth: 160 }}>
+                        <InputLabel>Статус</InputLabel>
+                        <Select
+                            label="Статус"
+                            value={statusFilter}
+                            onChange={(e) => setStatusFilter(e.target.value)}
+                        >
+                            <MenuItem value="">Все</MenuItem>
+                            {statuses.map((s) => (
+                                <MenuItem key={s.name} value={s.name}>
+                                    {s.name}
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </FormControl>
+                    <TextField label="Объект" value={unitFilter} onChange={(e) => setUnitFilter(e.target.value)} />
+                    <TextField label="Юрист" value={lawyerFilter} onChange={(e) => setLawyerFilter(e.target.value)} />
+                </Stack>
+                <CourtCasesTable
+                    rows={filteredRows}
+                    onEdit={(row) => setModal({ mode: 'edit', data: row })}
+                    onView={(row) => setViewCase(row)}
+                />
             </Stack>
         </Container>
     );

--- a/src/widgets/CourtCaseDetailsDialog.js
+++ b/src/widgets/CourtCaseDetailsDialog.js
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import {
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    Button,
+    Stack,
+    Typography,
+    Tabs,
+    Tab,
+} from '@mui/material';
+import dayjs from 'dayjs';
+import LettersTable from './LettersTable';
+import CaseDefectsTable from './CaseDefectsTable';
+import { useCaseLetters } from '@/entities/letter';
+import { useCaseDefects } from '@/entities/caseDefect';
+
+export default function CourtCaseDetailsDialog({ open, caseData, onClose }) {
+    const { data: letters = [] } = useCaseLetters(caseData?.id);
+    const { data: defects = [] } = useCaseDefects(caseData?.id);
+    const [tab, setTab] = useState(0);
+
+    if (!caseData) return null;
+
+    return (
+        <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+            <DialogTitle>Дело № {caseData.internal_no}</DialogTitle>
+            <DialogContent dividers>
+                <Stack spacing={1} mb={2}>
+                    <Typography variant="body2">Объект: {caseData.unit_name}</Typography>
+                    <Typography variant="body2">Стадия: {caseData.stage_name}</Typography>
+                    <Typography variant="body2">Статус: {caseData.status}</Typography>
+                    {caseData.fix_start_date && (
+                        <Typography variant="body2">
+                            Начало устранения: {dayjs(caseData.fix_start_date).format('DD.MM.YYYY')}
+                        </Typography>
+                    )}
+                    {caseData.fix_end_date && (
+                        <Typography variant="body2">
+                            Завершение устранения: {dayjs(caseData.fix_end_date).format('DD.MM.YYYY')}
+                        </Typography>
+                    )}
+                    {caseData.comments && (
+                        <Typography variant="body2">Заметки: {caseData.comments}</Typography>
+                    )}
+                </Stack>
+                <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }}>
+                    <Tab label="Письма" />
+                    <Tab label="Недостатки" />
+                </Tabs>
+                {tab === 0 && <LettersTable rows={letters} onEdit={() => {}} />}
+                {tab === 1 && <CaseDefectsTable rows={defects} />}
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose}>Закрыть</Button>
+            </DialogActions>
+        </Dialog>
+    );
+}

--- a/src/widgets/CourtCasesTable.js
+++ b/src/widgets/CourtCasesTable.js
@@ -2,9 +2,10 @@ import React from 'react';
 import { DataGrid, GridActionsCellItem } from '@mui/x-data-grid';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
+import VisibilityIcon from '@mui/icons-material/Visibility';
 import { useDeleteCourtCase } from '@/entities/courtCase';
 
-export default function CourtCasesTable({ rows, onEdit }) {
+export default function CourtCasesTable({ rows, onEdit, onView }) {
     const remove = useDeleteCourtCase();
 
     const columns = [
@@ -16,8 +17,9 @@ export default function CourtCasesTable({ rows, onEdit }) {
         {
             field: 'actions',
             type: 'actions',
-            width: 100,
+            width: 120,
             getActions: ({ row }) => [
+                <GridActionsCellItem key="view" icon={<VisibilityIcon />} label="View" onClick={() => onView?.(row)} />,
                 <GridActionsCellItem key="edit" icon={<EditIcon />} label="Edit" onClick={() => onEdit(row)} />,
                 <GridActionsCellItem
                     key="del"


### PR DESCRIPTION
## Summary
- add `CourtCaseDetailsDialog` widget to show full case info with tabs for letters and defects
- extend `CourtCasesTable` with view action
- enhance `CourtCasesPage` with filtering options, search and details dialog

## Testing
- `npm test` *(fails: craco not found)*