### PR TITLE
Fix types and imports

### DIFF
--- a/src/features/courtCase/CourtCaseCreateForm.tsx
+++ b/src/features/courtCase/CourtCaseCreateForm.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-    Grid,
     TextField,
     Button,
     MenuItem,
@@ -9,6 +8,7 @@ import {
     Select,
     Box,
 } from '@mui/material';
+import Grid from '@mui/material/Unstable_Grid2';
 import { useForm, Controller } from 'react-hook-form';
 
 const statusesRu = [

--- a/src/features/litigationStage/LitigationStageForm.tsx
+++ b/src/features/litigationStage/LitigationStageForm.tsx
@@ -3,21 +3,19 @@
 // Модальная форма добавления / редактирования стадии судебного дела
 // -----------------------------------------------------------------------------
 
-import React, { useState }    from 'react';
+import React, { useState } from 'react';
 import {
     Dialog, DialogTitle, DialogContent, DialogActions,
     TextField, Button, Stack,
 } from '@mui/material';
 
-/**
- * @typedef {Object} LitigationStageFormProps
- * @property {Object}  [initialData]
- * @property {function(Object):void} onSubmit
- * @property {function():void} onCancel
- */
+interface LitigationStageFormProps {
+    initialData?: { id?: number; name?: string };
+    onSubmit: (values: { name: string }) => void;
+    onCancel: () => void;
+}
 
-/** @param {LitigationStageFormProps} props */
-export default function LitigationStageForm({ initialData = {}, onSubmit, onCancel }) {
+export default function LitigationStageForm({ initialData = {}, onSubmit, onCancel }: LitigationStageFormProps) {
     const [name, setName] = useState(initialData.name ?? '');
 
     const handleSave = (e) => {

--- a/src/features/project/ProjectForm.tsx
+++ b/src/features/project/ProjectForm.tsx
@@ -14,11 +14,17 @@ const makeSchema = (min = 2, max = 120) =>
 /**
  * Форма создания/редактирования проекта.
  */
+interface ProjectFormProps {
+    initialData?: { name?: string };
+    onSubmit: (values: { name: string }) => void;
+    onCancel?: () => void;
+}
+
 const ProjectForm = ({
                          initialData = {},
                          onSubmit,
                          onCancel,
-                     }) => {
+                     }: ProjectFormProps) => {
     const {
         handleSubmit,
         control,

--- a/src/features/unit/UnitForm.tsx
+++ b/src/features/unit/UnitForm.tsx
@@ -65,8 +65,8 @@ export default function UnitForm({ initialData, onSuccess, onCancel }) {
             }
         } catch (err) {
             if (/уже существует/i.test(err.message)) {
-                ['project_id', 'name'].forEach((f) =>
-                    setError(f, { type: 'duplicate', message: 'Дубликат', shouldFocus: true }),
+                (['project_id', 'name'] as const).forEach((f) =>
+                    setError(f as any, { type: 'duplicate', message: 'Дубликат', shouldFocus: true }),
                 );
             }
             notify.error(err.message);
@@ -114,7 +114,7 @@ export default function UnitForm({ initialData, onSuccess, onCancel }) {
                 />
 
                 {/* Корпус / Секция / Этаж */}
-                {['building', 'section', 'floor'].map((field) => (
+                {(['building', 'section', 'floor'] as const).map((field) => (
                     <Controller
                         key={field} name={field} control={control}
                         render={({ field: f }) => (

--- a/src/pages/TicketsPage/TicketFormPage.tsx
+++ b/src/pages/TicketsPage/TicketFormPage.tsx
@@ -39,7 +39,12 @@ export default function TicketFormPage() {
                 </Box>
                 {/* --- форма --- */}
                 <Box sx={{ p: { xs: 3, md: 5 } }}>
-                    <TicketForm key={`${projectId ?? 'none'}-${ticketId ?? 'new'}`} />
+                    <TicketForm
+                        key={`${projectId ?? 'none'}-${ticketId ?? 'new'}`}
+                        ticketId={ticketId}
+                        onCreated={() => {}}
+                        onCancel={() => {}}
+                    />
                 </Box>
             </Paper>
         </Box>

--- a/src/widgets/CaseDefectsTable.tsx
+++ b/src/widgets/CaseDefectsTable.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { DataGrid, GridActionsCellItem } from '@mui/x-data-grid';
+import { DataGrid, GridActionsCellItem, GridColDef } from '@mui/x-data-grid';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { useDeleteCaseDefect } from '@/entities/caseDefect';
 
 export default function CaseDefectsTable({ rows }) {
     const remove = useDeleteCaseDefect();
 
-    const columns = [
+    const columns: GridColDef[] = [
         { field: 'id', headerName: 'ID', width: 80 },
         { field: 'description', headerName: 'Недостаток', flex: 1 },
         { field: 'fix_cost', headerName: 'Стоимость устранения', width: 160 },

--- a/src/widgets/CourtCasesFilters.tsx
+++ b/src/widgets/CourtCasesFilters.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-    Grid,
     TextField,
     MenuItem,
     FormControl,
@@ -8,6 +7,7 @@ import {
     Select,
     Button,
 } from '@mui/material';
+import Grid from '@mui/material/Unstable_Grid2';
 
 const statusesRu = [
     { value: '', label: 'Все статусы' },

--- a/src/widgets/LetterTypesAdmin.tsx
+++ b/src/widgets/LetterTypesAdmin.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/entities/letterType';
 import LetterTypeForm from '@/features/letterType/LetterTypeForm';
 
-export default function LetterTypesAdmin({ pageSize = 25, rowsPerPageOptions = [10, 25, 50, 100] }) {
+export default function LetterTypesAdmin() {
     const { data = [], isLoading } = useLetterTypes();
     const add = useAddLetterType();
     const update = useUpdateLetterType();
@@ -60,8 +60,6 @@ export default function LetterTypesAdmin({ pageSize = 25, rowsPerPageOptions = [
                             ),
                         },
                     ]}
-                    pageSize={pageSize}
-                    rowsPerPageOptions={rowsPerPageOptions}
                     autoHeight
                     loading={isLoading}
                     disableSelectionOnClick

--- a/src/widgets/LettersTable.tsx
+++ b/src/widgets/LettersTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DataGrid, GridActionsCellItem } from '@mui/x-data-grid';
+import { DataGrid, GridActionsCellItem, GridColDef } from '@mui/x-data-grid';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { useDeleteLetter } from '@/entities/letter';
@@ -7,7 +7,7 @@ import { useDeleteLetter } from '@/entities/letter';
 export default function LettersTable({ rows, onEdit }) {
     const remove = useDeleteLetter();
 
-    const columns = [
+    const columns: GridColDef[] = [
         { field: 'id', headerName: 'ID', width: 80 },
         { field: 'number', headerName: 'Номер', flex: 1 },
         { field: 'letter_date', headerName: 'Дата', width: 120 },

--- a/src/widgets/PartyTypesAdmin.tsx
+++ b/src/widgets/PartyTypesAdmin.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/entities/partyType';
 import PartyTypeForm from '@/features/partyType/PartyTypeForm';
 
-export default function PartyTypesAdmin({ pageSize = 25, rowsPerPageOptions = [10, 25, 50, 100] }) {
+export default function PartyTypesAdmin() {
     const { data = [], isLoading } = usePartyTypes();
     const add = useAddPartyType();
     const update = useUpdatePartyType();
@@ -60,8 +60,6 @@ export default function PartyTypesAdmin({ pageSize = 25, rowsPerPageOptions = [1
                             ),
                         },
                     ]}
-                    pageSize={pageSize}
-                    rowsPerPageOptions={rowsPerPageOptions}
                     autoHeight
                     loading={isLoading}
                     disableSelectionOnClick

--- a/src/widgets/TicketStatusesAdmin.tsx
+++ b/src/widgets/TicketStatusesAdmin.tsx
@@ -7,7 +7,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import TicketStatusForm from '@/features/ticketStatus/TicketStatusForm';
 
-export default function TicketStatusesAdmin({ pageSize = 25, rowsPerPageOptions = [10, 25, 50, 100] }) {
+export default function TicketStatusesAdmin() {
     const { data = [], isLoading } = useTicketStatuses();
     const addMutation = useAddTicketStatus();
     const updateMutation = useUpdateTicketStatus();
@@ -82,8 +82,6 @@ export default function TicketStatusesAdmin({ pageSize = 25, rowsPerPageOptions 
                             ),
                         },
                     ]}
-                    pageSize={pageSize}
-                    rowsPerPageOptions={rowsPerPageOptions}
                     autoHeight
                     loading={isLoading}
                     disableSelectionOnClick

--- a/src/widgets/TicketTypesAdmin.tsx
+++ b/src/widgets/TicketTypesAdmin.tsx
@@ -12,7 +12,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import TicketTypeForm from '@/features/ticketType/TicketTypeForm'; // без ProjectForm!
 
-export default function TicketTypesAdmin({ pageSize = 25, rowsPerPageOptions = [10, 25, 50, 100] }) {
+export default function TicketTypesAdmin() {
     const { data = [], isLoading } = useTicketTypes();
     const addMutation = useAddTicketType();
     const updateMutation = useUpdateTicketType();
@@ -83,8 +83,6 @@ export default function TicketTypesAdmin({ pageSize = 25, rowsPerPageOptions = [
                             ),
                         },
                     ]}
-                    pageSize={pageSize}
-                    rowsPerPageOptions={rowsPerPageOptions}
                     autoHeight
                     loading={isLoading}
                     disableSelectionOnClick

--- a/src/widgets/UsersTable.tsx
+++ b/src/widgets/UsersTable.tsx
@@ -32,7 +32,7 @@ export default function UsersTable({
 
     // Мутация для смены project_id пользователя
     const updateProject = useMutation({
-        mutationFn: async ({ id, project_id }) => {
+        mutationFn: async ({ id, project_id }: any) => {
             const { data, error } = await supabase
                 .from('profiles')
                 .update({ project_id })
@@ -43,7 +43,7 @@ export default function UsersTable({
             return data;
         },
         onSuccess: () => {
-            qc.invalidateQueries(['users', 'all']);
+            qc.invalidateQueries({ queryKey: ['users', 'all'] });
             notify.success('Проект пользователя обновлен');
         },
         onError: (e) => notify.error(e.message)
@@ -59,7 +59,7 @@ export default function UsersTable({
             headerName: 'Роль',
             flex: 0.7,
             renderCell: ({ row }) => (
-                <RoleSelect user={row} roles={roles} disabled={rLoad} />
+                <RoleSelect user={row} roles={roles} />
             ),
         },
         {


### PR DESCRIPTION
## Summary
- switch to Unstable_Grid2 for layouts
- define prop types for some forms
- adjust DataGrid columns typings
- fix users table mutation types
- remove unsupported pagination props

## Testing
- `npm run build` *(fails: vite not found)*