### PR TITLE
Fix imports and validation resolver

### DIFF
--- a/src/features/courtCase/CourtCaseCreateForm.tsx
+++ b/src/features/courtCase/CourtCaseCreateForm.tsx
@@ -8,7 +8,7 @@ import {
     Select,
     Box,
 } from '@mui/material';
-import Grid from '@mui/material/Unstable_Grid2';
+import Grid from '@mui/material/Grid';
 import { useForm, Controller } from 'react-hook-form';
 
 const statusesRu = [

--- a/src/features/ticket/TicketForm.tsx
+++ b/src/features/ticket/TicketForm.tsx
@@ -87,7 +87,7 @@ export default function TicketForm({
     const { data: users    = [], isLoading: isLoadingUsers    } = useUsers();
 
     const methods = useForm<TicketFormValues>({
-        resolver      : yupResolver<TicketFormValues>(schema),
+        resolver      : yupResolver(schema),
         defaultValues : {
             project_id  : projectId,
             unit_id     : initialUnitId ?? null,

--- a/src/widgets/CourtCasesFilters.tsx
+++ b/src/widgets/CourtCasesFilters.tsx
@@ -7,7 +7,7 @@ import {
     Select,
     Button,
 } from '@mui/material';
-import Grid from '@mui/material/Unstable_Grid2';
+import Grid from '@mui/material/Grid';
 
 const statusesRu = [
     { value: '', label: 'Все статусы' },


### PR DESCRIPTION
## Summary
- fix imports for Grid to use stable package
- adjust yupResolver usage to avoid wrong generics

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build` *(fails: vite not found)*