### PR TITLE
Fix MUI Grid import and resolver type

### DIFF
--- a/src/features/courtCase/CourtCaseCreateForm.tsx
+++ b/src/features/courtCase/CourtCaseCreateForm.tsx
@@ -8,7 +8,7 @@ import {
     Select,
     Box,
 } from '@mui/material';
-import Grid from '@mui/material/Grid';
+import Grid from '@mui/material/Unstable_Grid2';
 import { useForm, Controller } from 'react-hook-form';
 
 const statusesRu = [

--- a/src/features/ticket/TicketForm.tsx
+++ b/src/features/ticket/TicketForm.tsx
@@ -87,7 +87,7 @@ export default function TicketForm({
     const { data: users    = [], isLoading: isLoadingUsers    } = useUsers();
 
     const methods = useForm<TicketFormValues>({
-        resolver      : yupResolver(schema),
+        resolver      : yupResolver<TicketFormValues>(schema),
         defaultValues : {
             project_id  : projectId,
             unit_id     : initialUnitId ?? null,

--- a/src/widgets/CourtCasesFilters.tsx
+++ b/src/widgets/CourtCasesFilters.tsx
@@ -7,7 +7,7 @@ import {
     Select,
     Button,
 } from '@mui/material';
-import Grid from '@mui/material/Grid';
+import Grid from '@mui/material/Unstable_Grid2';
 
 const statusesRu = [
     { value: '', label: 'Все статусы' },


### PR DESCRIPTION
## Summary
- use `Unstable_Grid2` from MUI for grid layouts
- type yup resolver with `TicketFormValues`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*