### PR TITLE
Fix missing QueryClientProvider setup

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,11 +2,18 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './app/App';
 import { BrowserRouter } from 'react-router-dom';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { queryClient } from '@/shared/config/queryClient';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
-        <BrowserRouter>
-            <App />
-        </BrowserRouter>
+        <QueryClientProvider client={queryClient}>
+            <BrowserRouter>
+                <App />
+            </BrowserRouter>
+            <ReactQueryDevtools initialIsOpen={false} />
+        </QueryClientProvider>
     </React.StrictMode>,
 );
+

--- a/src/shared/config/queryClient.js
+++ b/src/shared/config/queryClient.js
@@ -10,3 +10,4 @@ export const queryClient = new QueryClient({
         }
     }
 });
+


### PR DESCRIPTION
## Summary
- provide QueryClientProvider and ReactQueryDevtools in `main.tsx`
- ensure newline at end of `queryClient.js`

## Testing
- `node -v`
- `npm -v`