### PR TITLE
Add court cases hooks and page refactor

### DIFF
--- a/src/app/Router.tsx
+++ b/src/app/Router.tsx
@@ -11,6 +11,7 @@ import DashboardPage from "@/pages/DashboardPage/DashboardPage";
 import TicketsPage from "@/pages/TicketsPage/TicketsPage";
 import TicketFormPage from "@/pages/TicketsPage/TicketFormPage";
 import StatsPage from "@/pages/StatsPage/StatsPage";
+import CourtCasesPage from "@/pages/CourtCasesPage/CourtCasesPage";
 import LoginPage from "@/pages/UnitsPage/LoginPage"; // ← CHANGE
 import RegisterPage from "@/pages/UnitsPage/RegisterPage"; // ← CHANGE
 import AdminPage from "@/pages/UnitsPage/AdminPage";
@@ -75,6 +76,15 @@ export default function AppRouter() {
           </RequireAuth>
         }
         data-oid="41m4r4h"
+      />
+
+      <Route
+        path="/court-cases"
+        element={
+          <RequireAuth>
+            <CourtCasesPage />
+          </RequireAuth>
+        }
       />
 
       <Route

--- a/src/entities/courtCase/index.ts
+++ b/src/entities/courtCase/index.ts
@@ -1,0 +1,164 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/shared/api/supabaseClient';
+import { useProjectId } from '@/shared/hooks/useProjectId';
+import type { CourtCase, Letter, Defect } from '@/shared/types/courtCase';
+
+const CASES_TABLE = 'court_cases';
+const LETTERS_TABLE = 'letters';
+const DEFECTS_TABLE = 'defects';
+const CASE_DEFECTS_TABLE = 'court_case_defects';
+
+export function useCourtCases() {
+  const projectId = useProjectId();
+  return useQuery({
+    queryKey: [CASES_TABLE, projectId],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from(CASES_TABLE)
+        .select('*')
+        .eq('project_id', projectId)
+        .order('created_at', { ascending: false });
+      if (error) throw error;
+      return (data ?? []) as CourtCase[];
+    },
+    enabled: !!projectId,
+    staleTime: 5 * 60_000,
+  });
+}
+
+export function useAddCourtCase() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: Omit<CourtCase, 'id' | 'created_at' | 'updated_at'>) => {
+      const { data, error } = await supabase
+        .from(CASES_TABLE)
+        .insert(payload)
+        .select('*')
+        .single();
+      if (error) throw error;
+      return data as CourtCase;
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: [CASES_TABLE] }),
+  });
+}
+
+export function useDeleteCourtCase() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: number) => {
+      const { error } = await supabase.from(CASES_TABLE).delete().eq('id', id);
+      if (error) throw error;
+      return id;
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: [CASES_TABLE] }),
+  });
+}
+
+export function useCaseLetters(caseId: number) {
+  return useQuery({
+    queryKey: [LETTERS_TABLE, caseId],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from(LETTERS_TABLE)
+        .select('*')
+        .eq('case_id', caseId)
+        .order('letter_date');
+      if (error) throw error;
+      return (data ?? []) as Letter[];
+    },
+    enabled: !!caseId,
+    staleTime: 5 * 60_000,
+  });
+}
+
+export function useAddLetter() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: Omit<Letter, 'id'>) => {
+      const { data, error } = await supabase
+        .from(LETTERS_TABLE)
+        .insert(payload)
+        .select('*')
+        .single();
+      if (error) throw error;
+      return data as Letter;
+    },
+    onSuccess: (_d, vars) => {
+      qc.invalidateQueries({ queryKey: [LETTERS_TABLE, vars.case_id] });
+    },
+  });
+}
+
+export function useDeleteLetter() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, case_id }: { id: number; case_id: number }) => {
+      const { error } = await supabase.from(LETTERS_TABLE).delete().eq('id', id);
+      if (error) throw error;
+      return { id, case_id };
+    },
+    onSuccess: (_res, vars) => {
+      qc.invalidateQueries({ queryKey: [LETTERS_TABLE, vars.case_id] });
+    },
+  });
+}
+
+export function useCaseDefects(caseId: number) {
+  return useQuery({
+    queryKey: [CASE_DEFECTS_TABLE, caseId],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from(CASE_DEFECTS_TABLE)
+        .select(`defect_id, defects(*)`)
+        .eq('case_id', caseId);
+      if (error) throw error;
+      const rows = data ?? [];
+      return rows.map((r) => ({ ...r.defects, case_id: caseId })) as Defect[];
+    },
+    enabled: !!caseId,
+    staleTime: 5 * 60_000,
+  });
+}
+
+export function useAddDefect() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: { case_id: number } & Omit<Defect, 'id' | 'case_id'>) => {
+      const { data, error } = await supabase
+        .from(DEFECTS_TABLE)
+        .insert({
+          project_id: payload.project_id ?? null,
+          description: payload.description,
+          fix_cost: payload.cost,
+        })
+        .select('id')
+        .single();
+      if (error) throw error;
+      const defId = data.id;
+      const { error: linkErr } = await supabase
+        .from(CASE_DEFECTS_TABLE)
+        .insert({ case_id: payload.case_id, defect_id: defId });
+      if (linkErr) throw linkErr;
+      qc.invalidateQueries({ queryKey: [CASE_DEFECTS_TABLE, payload.case_id] });
+      return { ...payload, id: defId } as Defect;
+    },
+  });
+}
+
+export function useDeleteDefect() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, case_id }: { id: number; case_id: number }) => {
+      const { error } = await supabase
+        .from(CASE_DEFECTS_TABLE)
+        .delete()
+        .eq('case_id', case_id)
+        .eq('defect_id', id);
+      if (error) throw error;
+      return { id, case_id };
+    },
+    onSuccess: (_res, vars) => {
+      qc.invalidateQueries({ queryKey: [CASE_DEFECTS_TABLE, vars.case_id] });
+    },
+  });
+}

--- a/src/features/courtCase/CourtCaseForm.tsx
+++ b/src/features/courtCase/CourtCaseForm.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { TextField, Stack, Select, MenuItem, Button, DialogActions } from '@mui/material';
+import { DatePicker } from '@mui/x-date-pickers';
+import dayjs from 'dayjs';
+import type { CaseStatus } from '@/shared/types/courtCase';
+
+export interface CourtCaseFormValues {
+  number: string;
+  date: string | null;
+  project_object: string;
+  plaintiff: string;
+  defendant: string;
+  responsible_lawyer: string;
+  court: string;
+  status: CaseStatus;
+  claim_amount: number | '';
+  remediation_start_date: string | null;
+  remediation_end_date: string | null;
+  description: string;
+}
+
+interface Props {
+  onSubmit: (values: CourtCaseFormValues) => void;
+}
+
+export default function CourtCaseForm({ onSubmit }: Props) {
+  const { control, handleSubmit, reset } = useForm<CourtCaseFormValues>({
+    defaultValues: {
+      number: '',
+      date: null,
+      project_object: '',
+      plaintiff: '',
+      defendant: '',
+      responsible_lawyer: '',
+      court: '',
+      status: 'active',
+      claim_amount: '',
+      remediation_start_date: null,
+      remediation_end_date: null,
+      description: '',
+    },
+  });
+
+  const submit = (values: CourtCaseFormValues) => {
+    onSubmit(values);
+    reset();
+  };
+
+  return (
+    <form onSubmit={handleSubmit(submit)} noValidate>
+      <Stack spacing={2}>
+        <Controller
+          name="number"
+          control={control}
+          rules={{ required: 'Номер обязателен' }}
+          render={({ field, fieldState }) => (
+            <TextField {...field} label="Номер дела" fullWidth required error={!!fieldState.error} helperText={fieldState.error?.message} />
+          )}
+        />
+        <Controller
+          name="date"
+          control={control}
+          rules={{ required: 'Дата обязательна' }}
+          render={({ field, fieldState }) => (
+            <DatePicker
+              {...field}
+              format="DD.MM.YYYY"
+              value={field.value ? dayjs(field.value) : null}
+              onChange={(d) => field.onChange(d ? d.format('YYYY-MM-DD') : null)}
+              slotProps={{ textField: { fullWidth: true, required: true, error: !!fieldState.error, helperText: fieldState.error?.message } }}
+            />
+          )}
+        />
+        <Controller
+          name="project_object"
+          control={control}
+          rules={{ required: 'Объект обязателен' }}
+          render={({ field, fieldState }) => (
+            <TextField {...field} label="Объект" fullWidth required error={!!fieldState.error} helperText={fieldState.error?.message} />
+          )}
+        />
+        <Controller
+          name="plaintiff"
+          control={control}
+          rules={{ required: 'Истец обязателен' }}
+          render={({ field, fieldState }) => (
+            <TextField {...field} label="Истец" fullWidth required error={!!fieldState.error} helperText={fieldState.error?.message} />
+          )}
+        />
+        <Controller
+          name="defendant"
+          control={control}
+          rules={{ required: 'Ответчик обязателен' }}
+          render={({ field, fieldState }) => (
+            <TextField {...field} label="Ответчик" fullWidth required error={!!fieldState.error} helperText={fieldState.error?.message} />
+          )}
+        />
+        <Controller
+          name="responsible_lawyer"
+          control={control}
+          rules={{ required: 'Юрист обязателен' }}
+          render={({ field, fieldState }) => (
+            <TextField {...field} label="Ответственный юрист" fullWidth required error={!!fieldState.error} helperText={fieldState.error?.message} />
+          )}
+        />
+        <Controller
+          name="court"
+          control={control}
+          rules={{ required: 'Наименование суда обязательно' }}
+          render={({ field, fieldState }) => (
+            <TextField {...field} label="Наименование суда" fullWidth required error={!!fieldState.error} helperText={fieldState.error?.message} />
+          )}
+        />
+        <Controller
+          name="status"
+          control={control}
+          render={({ field }) => (
+            <Select {...field} fullWidth>
+              <MenuItem value="active">В процессе</MenuItem>
+              <MenuItem value="won">Выиграно</MenuItem>
+              <MenuItem value="lost">Проиграно</MenuItem>
+              <MenuItem value="settled">Урегулировано</MenuItem>
+            </Select>
+          )}
+        />
+        <Controller
+          name="claim_amount"
+          control={control}
+          render={({ field }) => (
+            <TextField {...field} label="Сумма иска" type="number" fullWidth />
+          )}
+        />
+        <Controller
+          name="remediation_start_date"
+          control={control}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              format="DD.MM.YYYY"
+              value={field.value ? dayjs(field.value) : null}
+              onChange={(d) => field.onChange(d ? d.format('YYYY-MM-DD') : null)}
+              slotProps={{ textField: { fullWidth: true, label: 'Дата начала устранения' } }}
+            />
+          )}
+        />
+        <Controller
+          name="remediation_end_date"
+          control={control}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              format="DD.MM.YYYY"
+              value={field.value ? dayjs(field.value) : null}
+              onChange={(d) => field.onChange(d ? d.format('YYYY-MM-DD') : null)}
+              slotProps={{ textField: { fullWidth: true, label: 'Дата завершения устранения' } }}
+            />
+          )}
+        />
+        <Controller
+          name="description"
+          control={control}
+          render={({ field }) => (
+            <TextField {...field} label="Описание дела" fullWidth multiline rows={3} />
+          )}
+        />
+        <DialogActions sx={{ px: 0 }}>
+          <Button type="submit" variant="contained">Добавить дело</Button>
+        </DialogActions>
+      </Stack>
+    </form>
+  );
+}

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -1,0 +1,111 @@
+import React, { useState, useMemo } from 'react';
+import { Grid, Paper, Typography, TextField, Select, MenuItem } from '@mui/material';
+import CourtCaseForm from '@/features/courtCase/CourtCaseForm';
+import CourtCasesTable from '@/widgets/CourtCasesTable';
+import { useCourtCases, useAddCourtCase, useDeleteCourtCase } from '@/entities/courtCase';
+import { useNotify } from '@/shared/hooks/useNotify';
+import { useProjectId } from '@/shared/hooks/useProjectId';
+import type { CourtCase } from '@/shared/types/courtCase';
+
+export default function CourtCasesPage() {
+  const notify = useNotify();
+  const projectId = useProjectId();
+  const { data: cases = [], isPending } = useCourtCases();
+  const addCase = useAddCourtCase();
+  const delCase = useDeleteCourtCase();
+
+  const [filters, setFilters] = useState({ status: '', object: '', lawyer: '', search: '' });
+
+  const handleAdd = async (values: any) => {
+    try {
+      await addCase.mutateAsync({ ...values, project_id: projectId });
+      notify.success('Дело добавлено');
+    } catch (e: any) {
+      notify.error(e.message);
+    }
+  };
+
+  const handleDelete = async (c: CourtCase) => {
+    if (!window.confirm('Удалить дело?')) return;
+    try {
+      await delCase.mutateAsync(c.id);
+      notify.success('Дело удалено');
+    } catch (e: any) {
+      notify.error(e.message);
+    }
+  };
+
+  const filteredCases = useMemo(() => {
+    return cases.filter((c) => {
+      const search = filters.search.toLowerCase();
+      const matchesSearch =
+        c.number.toLowerCase().includes(search) ||
+        c.plaintiff.toLowerCase().includes(search) ||
+        c.defendant.toLowerCase().includes(search) ||
+        c.description.toLowerCase().includes(search);
+      const matchesStatus = !filters.status || c.status === filters.status;
+      const matchesObject = !filters.object || c.project_object.toLowerCase().includes(filters.object.toLowerCase());
+      const matchesLawyer = !filters.lawyer || c.responsible_lawyer.toLowerCase().includes(filters.lawyer.toLowerCase());
+      return matchesSearch && matchesStatus && matchesObject && matchesLawyer;
+    });
+  }, [cases, filters]);
+
+  return (
+    <Grid container spacing={3}>
+      <Grid item xs={12}>
+        <Paper sx={{ p: 3 }}>
+          <Typography variant="h5" gutterBottom>
+            Добавить новое судебное дело
+          </Typography>
+          <CourtCaseForm onSubmit={handleAdd} />
+        </Paper>
+      </Grid>
+      <Grid item xs={12}>
+        <Paper sx={{ p: 3 }}>
+          <Typography variant="h5" gutterBottom>
+            Таблица судебных дел
+          </Typography>
+          <Grid container spacing={2} sx={{ mb: 2 }}>
+            <Grid item>
+              <Select
+                fullWidth
+                value={filters.status}
+                onChange={(e) => setFilters({ ...filters, status: e.target.value })}
+                displayEmpty
+              >
+                <MenuItem value="">Все статусы</MenuItem>
+                <MenuItem value="active">В процессе</MenuItem>
+                <MenuItem value="won">Выиграно</MenuItem>
+                <MenuItem value="lost">Проиграно</MenuItem>
+                <MenuItem value="settled">Урегулировано</MenuItem>
+              </Select>
+            </Grid>
+            <Grid item>
+              <TextField
+                placeholder="Фильтр по объекту"
+                value={filters.object}
+                onChange={(e) => setFilters({ ...filters, object: e.target.value })}
+              />
+            </Grid>
+            <Grid item>
+              <TextField
+                placeholder="Фильтр по юристу"
+                value={filters.lawyer}
+                onChange={(e) => setFilters({ ...filters, lawyer: e.target.value })}
+              />
+            </Grid>
+            <Grid item xs>
+              <TextField
+                placeholder="Поиск по номеру, истцу, ответчику..."
+                fullWidth
+                value={filters.search}
+                onChange={(e) => setFilters({ ...filters, search: e.target.value })}
+              />
+            </Grid>
+          </Grid>
+          <CourtCasesTable cases={filteredCases} loading={isPending} onView={() => {}} onDelete={handleDelete} />
+        </Paper>
+      </Grid>
+    </Grid>
+  );
+}

--- a/src/shared/types/courtCase.ts
+++ b/src/shared/types/courtCase.ts
@@ -1,0 +1,36 @@
+export interface Letter {
+  id: number;
+  case_id: number;
+  number: string;
+  letter_date: string;
+  content: string;
+}
+
+export interface Defect {
+  id: number;
+  case_id: number;
+  name: string;
+  location: string | null;
+  description: string;
+  cost: number;
+  duration?: number | null;
+}
+
+export type CaseStatus = 'active' | 'won' | 'lost' | 'settled';
+
+export interface CourtCase {
+  id: number;
+  project_id: number;
+  number: string;
+  date: string;
+  project_object: string;
+  plaintiff: string;
+  defendant: string;
+  responsible_lawyer: string;
+  court: string;
+  status: CaseStatus;
+  claim_amount: number;
+  remediation_start_date?: string | null;
+  remediation_end_date?: string | null;
+  description: string;
+}

--- a/src/widgets/CourtCasesTable.tsx
+++ b/src/widgets/CourtCasesTable.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import {
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Chip,
+  Button,
+  Skeleton,
+} from '@mui/material';
+import dayjs from 'dayjs';
+import type { CourtCase } from '@/shared/types/courtCase';
+
+const statusText: Record<string, string> = {
+  active: 'В процессе',
+  won: 'Выиграно',
+  lost: 'Проиграно',
+  settled: 'Урегулировано',
+};
+
+const statusColor: Record<string, 'warning' | 'success' | 'error' | 'info'> = {
+  active: 'warning',
+  won: 'success',
+  lost: 'error',
+  settled: 'info',
+};
+
+interface Props {
+  cases: CourtCase[];
+  loading: boolean;
+  onView: (c: CourtCase) => void;
+  onDelete: (c: CourtCase) => void;
+}
+
+export default function CourtCasesTable({ cases, loading, onView, onDelete }: Props) {
+  if (loading) {
+    return <Skeleton variant="rectangular" height={160} />;
+  }
+
+  return (
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell>№ дела</TableCell>
+          <TableCell>Дата</TableCell>
+          <TableCell>Объект</TableCell>
+          <TableCell>Истец</TableCell>
+          <TableCell>Ответчик</TableCell>
+          <TableCell>Юрист</TableCell>
+          <TableCell>Статус</TableCell>
+          <TableCell>Сумма иска</TableCell>
+          <TableCell>Действия</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {cases.map((c) => (
+          <TableRow key={c.id} hover>
+            <TableCell>{c.number}</TableCell>
+            <TableCell>{dayjs(c.date).format('DD.MM.YYYY')}</TableCell>
+            <TableCell>{c.project_object}</TableCell>
+            <TableCell>{c.plaintiff}</TableCell>
+            <TableCell>{c.defendant}</TableCell>
+            <TableCell>{c.responsible_lawyer}</TableCell>
+            <TableCell>
+              <Chip size="small" label={statusText[c.status]} color={statusColor[c.status]} />
+            </TableCell>
+            <TableCell>
+              {new Intl.NumberFormat('ru-RU', { style: 'currency', currency: 'RUB', maximumFractionDigits: 0 }).format(
+                c.claim_amount || 0,
+              )}
+            </TableCell>
+            <TableCell>
+              <Button size="small" onClick={() => onView(c)}>
+                Просмотр
+              </Button>
+              <Button size="small" color="error" onClick={() => onDelete(c)}>
+                Удалить
+              </Button>
+            </TableCell>
+          </TableRow>
+        ))}
+        {cases.length === 0 && (
+          <TableRow>
+            <TableCell colSpan={9} align="center">
+              Нет судебных дел для отображения
+            </TableCell>
+          </TableRow>
+        )}
+      </TableBody>
+    </Table>
+  );
+}


### PR DESCRIPTION
## Summary
- implement supabase hooks for court cases
- add court case form feature
- create cases table widget
- refactor page to use new hooks and components

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*
