### PR TITLE
Remove description field from ticket status admin

### DIFF
--- a/src/features/ticketStatus/TicketStatusForm.tsx
+++ b/src/features/ticketStatus/TicketStatusForm.tsx
@@ -18,9 +18,8 @@ export default function TicketStatusForm({ initialData, onSubmit, onCancel }) {
         formState: { isSubmitting },
     } = useForm({
         defaultValues: {
-            name       : initialData?.name        ?? '',
-            description: initialData?.description ?? '',
-            color      : initialData?.color       ?? '#1976d2', // CHANGE
+            name : initialData?.name  ?? '',
+            color: initialData?.color ?? '#1976d2', // CHANGE
         },
     });
 
@@ -43,19 +42,6 @@ export default function TicketStatusForm({ initialData, onSubmit, onCancel }) {
                     )}
                 />
 
-                    <Controller
-                        name="description"
-                        control={control}
-                        render={({ field }) => (
-                            <TextField
-                                {...field}
-                                label="Описание"
-                                multiline
-                                rows={3}
-                                fullWidth
-                            />
-                        )}
-                    />
 
                 <Controller
                     name="color"

--- a/src/widgets/TicketStatusesAdmin.tsx
+++ b/src/widgets/TicketStatusesAdmin.tsx
@@ -38,7 +38,6 @@ export default function TicketStatusesAdmin({
     const columns = [
         { field: 'id', headerName: 'ID', width: 80 },
         { field: 'name', headerName: 'Название статуса', flex: 1 },
-        { field: 'description', headerName: 'Описание', flex: 1 },
         {
             field: 'color',
             headerName: 'Цвет',


### PR DESCRIPTION
## Summary
- drop deprecated `description` field from ticket status form and admin table

## Testing
- `npm run lint` *(fails: ESLint config missing)*