### PR TITLE
Add correspondence tracking page

### DIFF
--- a/src/app/Router.tsx
+++ b/src/app/Router.tsx
@@ -12,6 +12,7 @@ import TicketsPage from "@/pages/TicketsPage/TicketsPage";
 import TicketFormPage from "@/pages/TicketsPage/TicketFormPage";
 import StatsPage from "@/pages/StatsPage/StatsPage";
 import CourtCasesPage from "@/pages/CourtCasesPage/CourtCasesPage";
+import CorrespondencePage from "@/pages/CorrespondencePage/CorrespondencePage";
 import LoginPage from "@/pages/UnitsPage/LoginPage"; // ← CHANGE
 import RegisterPage from "@/pages/UnitsPage/RegisterPage"; // ← CHANGE
 import AdminPage from "@/pages/UnitsPage/AdminPage";
@@ -83,6 +84,15 @@ export default function AppRouter() {
         element={
           <RequireAuth>
             <CourtCasesPage />
+          </RequireAuth>
+        }
+      />
+
+      <Route
+        path="/correspondence"
+        element={
+          <RequireAuth>
+            <CorrespondencePage />
           </RequireAuth>
         }
       />

--- a/src/entities/correspondence/index.ts
+++ b/src/entities/correspondence/index.ts
@@ -1,0 +1,55 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { CorrespondenceLetter } from '@/shared/types/correspondence';
+
+const LS_KEY = 'correspondenceLetters';
+
+function loadLetters(): CorrespondenceLetter[] {
+  try {
+    const raw = localStorage.getItem(LS_KEY);
+    return raw ? (JSON.parse(raw) as CorrespondenceLetter[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveLetters(letters: CorrespondenceLetter[]) {
+  localStorage.setItem(LS_KEY, JSON.stringify(letters));
+}
+
+export function useLetters() {
+  return useQuery({
+    queryKey: [LS_KEY],
+    queryFn: async () => loadLetters(),
+  });
+}
+
+export function useAddLetter() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: Omit<CorrespondenceLetter, 'id'>) => {
+      const letters = loadLetters();
+      const newLetter = { ...payload, id: Date.now().toString() } as CorrespondenceLetter;
+      letters.push(newLetter);
+      saveLetters(letters);
+      return newLetter;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: [LS_KEY] });
+    },
+  });
+}
+
+export function useDeleteLetter() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const letters = loadLetters();
+      const updated = letters.filter((l) => l.id !== id);
+      saveLetters(updated);
+      return id;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: [LS_KEY] });
+    },
+  });
+}

--- a/src/features/correspondence/AddLetterForm.tsx
+++ b/src/features/correspondence/AddLetterForm.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import {
+  Stack,
+  TextField,
+  Select,
+  MenuItem,
+  Button,
+} from '@mui/material';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import dayjs, { Dayjs } from 'dayjs';
+
+export interface AddLetterFormData {
+  type: 'incoming' | 'outgoing';
+  number: string;
+  date: Dayjs | null;
+  correspondent: string;
+  subject: string;
+  content: string;
+}
+
+interface AddLetterFormProps {
+  onSubmit: (data: AddLetterFormData) => void;
+}
+
+/** Форма добавления письма */
+export default function AddLetterForm({ onSubmit }: AddLetterFormProps) {
+  const { control, handleSubmit, reset } = useForm<AddLetterFormData>({
+    defaultValues: {
+      type: 'incoming',
+      number: '',
+      date: dayjs(),
+      correspondent: '',
+      subject: '',
+      content: '',
+    },
+  });
+
+  const submit = (data: AddLetterFormData) => {
+    onSubmit(data);
+    reset();
+  };
+
+  return (
+    <form onSubmit={handleSubmit(submit)} noValidate>
+      <Stack spacing={2} sx={{ maxWidth: 400 }}>
+        <Controller
+          name="type"
+          control={control}
+          render={({ field }) => (
+            <Select {...field} label="Тип письма">
+              <MenuItem value="incoming">Входящее</MenuItem>
+              <MenuItem value="outgoing">Исходящее</MenuItem>
+            </Select>
+          )}
+        />
+        <Controller
+          name="number"
+          control={control}
+          rules={{ required: 'Номер обязателен' }}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              label="Номер письма"
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+            />
+          )}
+        />
+        <Controller
+          name="date"
+          control={control}
+          rules={{ required: 'Дата обязательна' }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата"
+              format="DD.MM.YYYY"
+            />
+          )}
+        />
+        <Controller
+          name="correspondent"
+          control={control}
+          render={({ field }) => (
+            <TextField {...field} label="Корреспондент" />
+          )}
+        />
+        <Controller
+          name="subject"
+          control={control}
+          render={({ field }) => (
+            <TextField {...field} label="Тема" />
+          )}
+        />
+        <Controller
+          name="content"
+          control={control}
+          render={({ field }) => (
+            <TextField {...field} label="Содержание" multiline rows={3} />
+          )}
+        />
+        <Button variant="contained" type="submit" sx={{ alignSelf: 'flex-end' }}>
+          Добавить письмо
+        </Button>
+      </Stack>
+    </form>
+  );
+}

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -1,0 +1,166 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Paper,
+  Stack,
+  Typography,
+  Select,
+  MenuItem,
+  TextField,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Snackbar,
+} from '@mui/material';
+import dayjs from 'dayjs';
+import { AddLetterFormData } from '@/features/correspondence/AddLetterForm';
+import AddLetterForm from '@/features/correspondence/AddLetterForm';
+import CorrespondenceTable from '@/widgets/CorrespondenceTable';
+import {
+  useLetters,
+  useAddLetter,
+  useDeleteLetter,
+} from '@/entities/correspondence';
+import { CorrespondenceLetter } from '@/shared/types/correspondence';
+
+interface Filters {
+  type?: 'incoming' | 'outgoing' | '';
+  search?: string;
+}
+
+/** Страница учёта корреспонденции */
+export default function CorrespondencePage() {
+  const { data: letters = [] } = useLetters();
+  const add = useAddLetter();
+  const remove = useDeleteLetter();
+  const [filters, setFilters] = useState<Filters>({ type: '', search: '' });
+  const [view, setView] = useState<CorrespondenceLetter | null>(null);
+  const [snackbar, setSnackbar] = useState<string | null>(null);
+
+  const handleAdd = (data: AddLetterFormData) => {
+    add.mutate(
+      {
+        type: data.type,
+        number: data.number,
+        date: data.date ? data.date.toISOString() : dayjs().toISOString(),
+        correspondent: data.correspondent,
+        subject: data.subject,
+        content: data.content,
+      },
+      {
+        onSuccess: () => setSnackbar('Письмо добавлено'),
+      },
+    );
+  };
+
+  const handleDelete = (id: string) => {
+    if (!window.confirm('Удалить письмо?')) return;
+    remove.mutate(id, {
+      onSuccess: () => setSnackbar('Письмо удалено'),
+    });
+  };
+
+  const filtered = letters.filter((l) => {
+    if (filters.type && l.type !== filters.type) return false;
+    if (
+      filters.search &&
+      !(
+        l.number.includes(filters.search) ||
+        l.correspondent.toLowerCase().includes(filters.search.toLowerCase()) ||
+        l.subject.toLowerCase().includes(filters.search.toLowerCase())
+      )
+    )
+      return false;
+    return true;
+  });
+
+  const total = letters.length;
+
+  return (
+    <Stack spacing={3} sx={{ mt: 2 }}>
+      <Paper sx={{ p: 3 }}>
+        <Typography variant="h5" gutterBottom>
+          Система учета корреспонденции
+        </Typography>
+        <Typography>Управление входящими и исходящими письмами</Typography>
+      </Paper>
+
+      <Paper sx={{ p: 3 }}>
+        <AddLetterForm onSubmit={handleAdd} />
+      </Paper>
+
+      <Paper sx={{ p: 2 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: 2,
+            mb: 2,
+          }}
+        >
+          <Select
+            value={filters.type}
+            onChange={(e) =>
+              setFilters((f) => ({ ...f, type: e.target.value as any }))
+            }
+            displayEmpty
+            size="small"
+          >
+            <MenuItem value="">Все типы</MenuItem>
+            <MenuItem value="incoming">Входящее</MenuItem>
+            <MenuItem value="outgoing">Исходящее</MenuItem>
+          </Select>
+          <TextField
+            size="small"
+            placeholder="Поиск"
+            value={filters.search}
+            onChange={(e) =>
+              setFilters((f) => ({ ...f, search: e.target.value }))
+            }
+          />
+          <Button onClick={() => setFilters({ type: '', search: '' })}>
+            Сбросить фильтры
+          </Button>
+        </Box>
+        <CorrespondenceTable
+          letters={filtered}
+          onView={setView}
+          onDelete={handleDelete}
+        />
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 1 }}>
+          <Typography variant="body2">Всего писем: {total}</Typography>
+        </Box>
+      </Paper>
+
+      <Dialog open={!!view} onClose={() => setView(null)} maxWidth="sm" fullWidth>
+        <DialogTitle>Детали письма</DialogTitle>
+        {view && (
+          <DialogContent dividers>
+            <Typography variant="subtitle2" gutterBottom>
+              {view.type === 'incoming' ? 'Входящее' : 'Исходящее'} письмо №{' '}
+              {view.number}
+            </Typography>
+            <Typography gutterBottom>
+              Дата: {dayjs(view.date).format('DD.MM.YYYY')}
+            </Typography>
+            <Typography gutterBottom>Корреспондент: {view.correspondent}</Typography>
+            <Typography gutterBottom>Тема: {view.subject}</Typography>
+            <Typography sx={{ whiteSpace: 'pre-wrap' }}>{view.content}</Typography>
+          </DialogContent>
+        )}
+        <DialogActions>
+          <Button onClick={() => setView(null)}>Закрыть</Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={!!snackbar}
+        autoHideDuration={3000}
+        onClose={() => setSnackbar(null)}
+        message={snackbar}
+      />
+    </Stack>
+  );
+}

--- a/src/shared/types/correspondence.ts
+++ b/src/shared/types/correspondence.ts
@@ -1,0 +1,16 @@
+export interface CorrespondenceLetter {
+  /** Идентификатор письма */
+  id: string;
+  /** Тип письма: входящее или исходящее */
+  type: 'incoming' | 'outgoing';
+  /** Номер письма */
+  number: string;
+  /** Дата письма ISO */
+  date: string;
+  /** Корреспондент */
+  correspondent: string;
+  /** Тема письма */
+  subject: string;
+  /** Содержание письма */
+  content: string;
+}

--- a/src/widgets/CorrespondenceTable.tsx
+++ b/src/widgets/CorrespondenceTable.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import {
+  Paper,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Chip,
+  IconButton,
+  Typography,
+} from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import { CorrespondenceLetter } from '@/shared/types/correspondence';
+
+interface CorrespondenceTableProps {
+  letters: CorrespondenceLetter[];
+  onView: (letter: CorrespondenceLetter) => void;
+  onDelete: (id: string) => void;
+}
+
+/** Таблица писем */
+export default function CorrespondenceTable({
+  letters,
+  onView,
+  onDelete,
+}: CorrespondenceTableProps) {
+  return (
+    <Paper sx={{ p: 2 }}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Тип</TableCell>
+            <TableCell>Номер</TableCell>
+            <TableCell>Дата</TableCell>
+            <TableCell>Корреспондент</TableCell>
+            <TableCell>Тема</TableCell>
+            <TableCell align="right">Действия</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {letters.map((l) => (
+            <TableRow key={l.id} hover>
+              <TableCell>
+                <Chip
+                  label={l.type === 'incoming' ? 'Входящее' : 'Исходящее'}
+                  color={l.type === 'incoming' ? 'success' : 'primary'}
+                  size="small"
+                />
+              </TableCell>
+              <TableCell>{l.number}</TableCell>
+              <TableCell>{dayjs(l.date).format('DD.MM.YYYY')}</TableCell>
+              <TableCell>{l.correspondent}</TableCell>
+              <TableCell>{l.subject}</TableCell>
+              <TableCell align="right">
+                <IconButton size="small" onClick={() => onView(l)}>
+                  <VisibilityIcon />
+                </IconButton>
+                <IconButton
+                  size="small"
+                  color="error"
+                  onClick={() => onDelete(l.id)}
+                >
+                  <DeleteIcon />
+                </IconButton>
+              </TableCell>
+            </TableRow>
+          ))}
+          {letters.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={6} align="center">
+                <Typography variant="body2" sx={{ py: 3 }}>
+                  Нет писем
+                </Typography>
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </Paper>
+  );
+}

--- a/src/widgets/NavBar.tsx
+++ b/src/widgets/NavBar.tsx
@@ -62,6 +62,9 @@ const NavBar = () => {
         <Button color="inherit" component={RouterLink} to="/court-cases">
           Судебные&nbsp;дела
         </Button>
+        <Button color="inherit" component={RouterLink} to="/correspondence">
+          Система&nbsp;учета
+        </Button>
         {profile?.role === "ADMIN" && (
           <Button color="inherit" component={RouterLink} to="/admin">
             Администрирование


### PR DESCRIPTION
## Summary
- add local storage entity for correspondence letters
- create letter add form and correspondence table widgets
- implement correspondence tracking page
- integrate new page into router and navigation

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'react', etc.)*
- `npm run lint` *(fails: ESLint couldn't find config)*