### PR TITLE
Fix query usage on court cases page

### DIFF
--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -93,9 +93,12 @@ export default function CourtCasesPage() {
     });
     return map;
   }, [stages]);
-  const { data: persons = [], isPending: personsLoading } = useQuery(
-    ["persons", newCase.project],
-    async () => {
+  const {
+    data: persons = [],
+    isPending: personsLoading,
+  } = useQuery({
+    queryKey: ["persons", newCase.project],
+    queryFn: async () => {
       const { data, error } = await supabase
         .from("persons")
         .select("id, full_name")
@@ -104,8 +107,8 @@ export default function CourtCasesPage() {
       if (error) throw error;
       return data ?? [];
     },
-    { enabled: !!newCase.project }
-  );
+    enabled: !!newCase.project,
+  });
 
   const { data: letters = [] } = useCaseLetters(
     dialogCase ? Number(dialogCase.id) : 0,


### PR DESCRIPTION
## Summary
- update `useQuery` usage in `CourtCasesPage` to use object form

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: vite not found)*