### PR TITLE
Fix court field usage

### DIFF
--- a/src/features/courtCase/CourtCaseForm.tsx
+++ b/src/features/courtCase/CourtCaseForm.tsx
@@ -12,7 +12,6 @@ export interface CourtCaseFormValues {
   plaintiff: string;
   defendant: string;
   responsible_lawyer: string;
-  court: string;
   status: CaseStatus;
   claim_amount: number | '';
   remediation_start_date: string | null;
@@ -33,7 +32,6 @@ export default function CourtCaseForm({ onSubmit }: Props) {
       plaintiff: '',
       defendant: '',
       responsible_lawyer: '',
-      court: '',
       status: 'active',
       claim_amount: '',
       remediation_start_date: null,
@@ -102,14 +100,6 @@ export default function CourtCaseForm({ onSubmit }: Props) {
           rules={{ required: 'Юрист обязателен' }}
           render={({ field, fieldState }) => (
             <TextField {...field} label="Ответственный юрист" fullWidth required error={!!fieldState.error} helperText={fieldState.error?.message} />
-          )}
-        />
-        <Controller
-          name="court"
-          control={control}
-          rules={{ required: 'Наименование суда обязательно' }}
-          render={({ field, fieldState }) => (
-            <TextField {...field} label="Наименование суда" fullWidth required error={!!fieldState.error} helperText={fieldState.error?.message} />
           )}
         />
         <Controller

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -71,7 +71,6 @@ export default function CourtCasesPage() {
     plaintiff: null as number | null,
     defendant: null as number | null,
     lawyer: null as string | null,
-    court: "",
     status: null as number | null,
     fixStart: null as Dayjs | null,
     fixEnd: null as Dayjs | null,
@@ -144,7 +143,6 @@ export default function CourtCasesPage() {
         plaintiff_id: newCase.plaintiff,
         defendant_id: newCase.defendant,
         responsible_lawyer_id: newCase.lawyer,
-        court: newCase.court,
         status: newCase.status,
         fix_start_date: newCase.fixStart ? newCase.fixStart.format("YYYY-MM-DD") : null,
         fix_end_date: newCase.fixEnd ? newCase.fixEnd.format("YYYY-MM-DD") : null,
@@ -160,7 +158,6 @@ export default function CourtCasesPage() {
             plaintiff: null,
             defendant: null,
             lawyer: null,
-            court: "",
             status: null,
             fixStart: null,
             fixEnd: null,
@@ -354,15 +351,6 @@ export default function CourtCasesPage() {
                   </Select>
                 </Grid>
                 <Grid item xs={12} md={4}>
-                  <TextField
-                    label="Наименование суда"
-                    fullWidth
-                    required
-                    value={newCase.court}
-                    onChange={(e) => setNewCase({ ...newCase, court: e.target.value })}
-                  />
-                </Grid>
-                <Grid item xs={12} md={4}>
                   <Select
                     fullWidth
                     value={newCase.status ?? ""}
@@ -546,10 +534,6 @@ export default function CourtCasesPage() {
                 <Grid item xs={12} md={4}>
                   <Typography variant="caption">Ответственный юрист</Typography>
                   <Typography>{dialogCase.responsibleLawyer}</Typography>
-                </Grid>
-                <Grid item xs={12} md={4}>
-                  <Typography variant="caption">Наименование суда</Typography>
-                  <Typography>{dialogCase.court}</Typography>
                 </Grid>
                 <Grid item xs={12} md={4}>
                   <Typography variant="caption">Статус дела</Typography>

--- a/src/shared/types/courtCase.ts
+++ b/src/shared/types/courtCase.ts
@@ -25,7 +25,6 @@ export interface CourtCase {
   plaintiff_id: number;
   defendant_id: number;
   responsible_lawyer_id: string | null;
-  court: string;
   status: number;
   fix_start_date?: string | null;
   fix_end_date?: string | null;


### PR DESCRIPTION
## Summary
- remove `court` column usage from CourtCase interfaces
- drop `court` field from CourtCaseForm and CourtCasesPage

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: vite not found)*