### PR TITLE
Добавлены списки корреспондентов и выбор нескольких объектов

### DIFF
--- a/src/entities/correspondence/index.ts
+++ b/src/entities/correspondence/index.ts
@@ -6,7 +6,15 @@ const LS_KEY = 'correspondenceLetters';
 function loadLetters(): CorrespondenceLetter[] {
   try {
     const raw = localStorage.getItem(LS_KEY);
-    return raw ? (JSON.parse(raw) as CorrespondenceLetter[]) : [];
+    const arr = raw ? (JSON.parse(raw) as any[]) : [];
+    return arr.map((l) => ({
+      ...l,
+      unit_ids: Array.isArray(l.unit_ids)
+        ? l.unit_ids
+        : l.unit_id
+        ? [l.unit_id]
+        : [],
+    }));
   } catch {
     return [];
   }

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -85,7 +85,7 @@ export default function CorrespondencePage() {
         responsible_user_id: data.responsible_user_id,
         letter_type_id: data.letter_type_id,
         project_id: data.project_id,
-        unit_id: data.unit_id,
+        unit_ids: data.unit_ids,
 
       },
       {
@@ -104,7 +104,7 @@ export default function CorrespondencePage() {
   const filtered = letters.filter((l) => {
     if (filters.type && l.type !== filters.type) return false;
     if (filters.project && l.project_id !== Number(filters.project)) return false;
-    if (filters.unit && l.unit_id !== Number(filters.unit)) return false;
+    if (filters.unit && !l.unit_ids.includes(Number(filters.unit))) return false;
     if (
       filters.correspondent &&
       !l.correspondent.toLowerCase().includes(filters.correspondent.toLowerCase())
@@ -290,9 +290,13 @@ export default function CorrespondencePage() {
                 Проект: {projects.find((p) => p.id === view.project_id)?.name}
               </Typography>
             )}
-            {view.unit_id && (
+            {view.unit_ids.length > 0 && (
               <Typography gutterBottom>
-                Объект: {units.find((u) => u.id === view.unit_id)?.name}
+                Объекты:{' '}
+                {view.unit_ids
+                  .map((id) => units.find((u) => u.id === id)?.name)
+                  .filter(Boolean)
+                  .join(', ')}
               </Typography>
             )}
             {view.letter_type_id && (

--- a/src/shared/types/correspondence.ts
+++ b/src/shared/types/correspondence.ts
@@ -10,8 +10,8 @@ export interface CorrespondenceLetter {
   letter_type_id: number | null;
   /** Проект */
   project_id: number | null;
-  /** Объект проекта */
-  unit_id: number | null;
+  /** Объекты проекта */
+  unit_ids: number[];
 
 
   /** Номер письма */

--- a/src/widgets/CorrespondenceTable.tsx
+++ b/src/widgets/CorrespondenceTable.tsx
@@ -82,9 +82,9 @@ export default function CorrespondenceTable({
       sorter: (a, b) => (a.projectName || '').localeCompare(b.projectName || ''),
     },
     {
-      title: 'Объект',
-      dataIndex: 'unitName',
-      sorter: (a, b) => (a.unitName || '').localeCompare(b.unitName || ''),
+      title: 'Объекты',
+      dataIndex: 'unitNames',
+      sorter: (a, b) => (a.unitNames || '').localeCompare(b.unitNames || ''),
     },
     {
       title: 'Категория',
@@ -127,7 +127,10 @@ export default function CorrespondenceTable({
       letters.map((l) => ({
         ...l,
         projectName: l.project_id ? maps.project[l.project_id] : null,
-        unitName: l.unit_id ? maps.unit[l.unit_id] : null,
+        unitNames: l.unit_ids
+          .map((id) => maps.unit[id])
+          .filter(Boolean)
+          .join(', '),
         letterTypeName: l.letter_type_id ? maps.type[l.letter_type_id] : null,
         responsibleName: l.responsible_user_id
           ? maps.user[l.responsible_user_id]


### PR DESCRIPTION
## Summary
- расширен тип CorrespondenceLetter, теперь хранит массив ID объектов
- обновлена форма добавления письма: выбор корреспондента из таблиц `contractors` и `persons`, поддержка множественного выбора объектов
- доработано сохранение и отображение писем с несколькими объектами
- при загрузке локальных данных производится миграция старого поля `unit_id`

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*