### PR TITLE
Add attachment type management and letter uploads

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -49,6 +49,20 @@
     "column_default": "false"
   },
   {
+    "table_name": "attachments",
+    "column_name": "letter_id",
+    "data_type": "bigint",
+    "is_nullable": "YES",
+    "column_default": null
+  },
+  {
+    "table_name": "attachments",
+    "column_name": "attachment_type_id",
+    "data_type": "bigint",
+    "is_nullable": "YES",
+    "column_default": null
+  },
+  {
     "table_name": "contractors",
     "column_name": "id",
     "data_type": "integer",
@@ -288,6 +302,20 @@
   },
   {
     "table_name": "letter_types",
+    "column_name": "name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": null
+  },
+  {
+    "table_name": "attachment_types",
+    "column_name": "id",
+    "data_type": "bigint",
+    "is_nullable": "NO",
+    "column_default": "nextval('attachment_types_id_seq'::regclass)"
+  },
+  {
+    "table_name": "attachment_types",
     "column_name": "name",
     "data_type": "text",
     "is_nullable": "NO",

--- a/src/entities/attachmentType.js
+++ b/src/entities/attachmentType.js
@@ -1,0 +1,65 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/shared/api/supabaseClient';
+
+const TABLE = 'attachment_types';
+const KEY = [TABLE];
+
+export const useAttachmentTypes = () =>
+    useQuery({
+        queryKey: KEY,
+        queryFn : async () => {
+            const { data, error } = await supabase
+                .from(TABLE)
+                .select('id, name')
+                .order('id');
+            if (error) throw error;
+            return data ?? [];
+        },
+        staleTime: 5 * 60_000,
+    });
+
+const invalidate = (qc) => qc.invalidateQueries({ queryKey: KEY });
+
+export const useAddAttachmentType = () => {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async (name) => {
+            const { data, error } = await supabase
+                .from(TABLE)
+                .insert({ name })
+                .select('id, name')
+                .single();
+            if (error) throw error;
+            return data;
+        },
+        onSuccess: () => invalidate(qc),
+    });
+};
+
+export const useUpdateAttachmentType = () => {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async ({ id, name }) => {
+            const { data, error } = await supabase
+                .from(TABLE)
+                .update({ name })
+                .eq('id', id)
+                .select('id, name')
+                .single();
+            if (error) throw error;
+            return data;
+        },
+        onSuccess: () => invalidate(qc),
+    });
+};
+
+export const useDeleteAttachmentType = () => {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async (id) => {
+            const { error } = await supabase.from(TABLE).delete().eq('id', id);
+            if (error) throw error;
+        },
+        onSuccess: () => invalidate(qc),
+    });
+};

--- a/src/pages/UnitsPage/AdminPage.tsx
+++ b/src/pages/UnitsPage/AdminPage.tsx
@@ -9,6 +9,7 @@ import UsersTable from "../../widgets/UsersTable";
 import LitigationStagesAdmin from "../../widgets/LitigationStagesAdmin";
 import PartyTypesAdmin from "../../widgets/PartyTypesAdmin";
 import LetterTypesAdmin from "../../widgets/LetterTypesAdmin";
+import AttachmentTypesAdmin from "../../widgets/AttachmentTypesAdmin";
 
 export default function AdminPage() {
   return (
@@ -36,6 +37,11 @@ export default function AdminPage() {
         <PartyTypesAdmin pageSize={25} rowsPerPageOptions={[10, 25, 50, 100]} />
 
         <LetterTypesAdmin
+          pageSize={25}
+          rowsPerPageOptions={[10, 25, 50, 100]}
+        />
+
+        <AttachmentTypesAdmin
           pageSize={25}
           rowsPerPageOptions={[10, 25, 50, 100]}
         />

--- a/src/shared/types/courtCase.ts
+++ b/src/shared/types/courtCase.ts
@@ -1,9 +1,18 @@
+export interface LetterAttachment {
+  id: number;
+  storage_path: string;
+  file_url: string;
+  file_type: string;
+  attachment_type_id: number | null;
+}
+
 export interface Letter {
   id: number;
   case_id: number;
   number: string;
   date: string;
   content: string;
+  attachments: LetterAttachment[];
 }
 
 export interface Defect {

--- a/src/widgets/AttachmentTypesAdmin.tsx
+++ b/src/widgets/AttachmentTypesAdmin.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { Dialog, DialogTitle, DialogContent, IconButton, Stack } from '@mui/material';
+import AdminDataGrid from '@/shared/ui/AdminDataGrid';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import {
+    useAttachmentTypes,
+    useAddAttachmentType,
+    useUpdateAttachmentType,
+    useDeleteAttachmentType,
+} from '@/entities/attachmentType';
+import LetterTypeForm from '@/features/letterType/LetterTypeForm';
+
+interface AttachmentTypesAdminProps {
+    pageSize?: number;
+    rowsPerPageOptions?: number[];
+}
+
+export default function AttachmentTypesAdmin({
+    pageSize = 25,
+    rowsPerPageOptions = [10, 25, 50, 100],
+}: AttachmentTypesAdminProps) {
+    const { data = [], isLoading } = useAttachmentTypes();
+    const add = useAddAttachmentType();
+    const update = useUpdateAttachmentType();
+    const remove = useDeleteAttachmentType();
+
+    const [open, setOpen] = React.useState(false);
+    const [editRow, setEditRow] = React.useState(null);
+
+    const handleAdd = () => { setEditRow(null); setOpen(true); };
+    const handleEdit = (row) => { setEditRow(row); setOpen(true); };
+    const handleDelete = (id) => { if (window.confirm('Удалить тип?')) remove.mutate(id); };
+    const handleSubmit = async (values) => {
+        if (editRow) {
+            await update.mutateAsync({ id: editRow.id, name: values.name });
+        } else {
+            await add.mutateAsync(values.name);
+        }
+        setOpen(false);
+    };
+
+    const columns = [
+        { field: 'id', headerName: 'ID', width: 80 },
+        { field: 'name', headerName: 'Название', flex: 1 },
+        {
+            field: 'actions',
+            headerName: '',
+            width: 100,
+            sortable: false,
+            renderCell: (params) => (
+                <Stack direction="row" spacing={0}>
+                    <IconButton size="small" onClick={() => handleEdit(params.row)} color="primary">
+                        <EditIcon fontSize="small" />
+                    </IconButton>
+                    <IconButton size="small" color="error" onClick={() => handleDelete(params.row.id)}>
+                        <DeleteIcon fontSize="small" />
+                    </IconButton>
+                </Stack>
+            ),
+        },
+    ];
+
+    return (
+        <>
+            <Dialog open={open} onClose={() => setOpen(false)} maxWidth="xs" fullWidth>
+                <DialogTitle>{editRow ? 'Редактировать тип' : 'Добавить тип'}</DialogTitle>
+                <DialogContent>
+                    <LetterTypeForm
+                        initialData={editRow}
+                        onSubmit={handleSubmit}
+                        onCancel={() => setOpen(false)}
+                    />
+                </DialogContent>
+            </Dialog>
+
+            <AdminDataGrid
+                title="Типы файлов"
+                rows={data}
+                columns={columns}
+                loading={isLoading}
+                onAdd={handleAdd}
+                pageSize={pageSize}
+                rowsPerPageOptions={rowsPerPageOptions}
+            />
+        </>
+    );
+}


### PR DESCRIPTION
## Summary
- add `attachment_types` table to schema
- link attachments to letters and attachment type
- manage attachment types in admin
- support uploading files for court case letters
- implement storage helper for letter attachments

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: Missing script 'test')*