### PR TITLE
Add case file uploads

### DIFF
--- a/src/entities/attachment.js
+++ b/src/entities/attachment.js
@@ -46,3 +46,7 @@ async function upload(file, pathPrefix) {
 export function uploadLetterAttachment(file, projectId) {
     return upload(file, `letters/${projectId}`);
 }
+
+export function uploadCaseAttachment(file, projectId, unitId) {
+    return upload(file, `Case/${projectId}/${unitId}`);
+}


### PR DESCRIPTION
## Summary
- allow uploading files when creating court cases
- save uploads to `Case/<projectId>/<unitId>` folder in storage

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing dependencies)*