### PR TITLE
Add attachments for correspondence letters

### DIFF
--- a/src/entities/attachment.js
+++ b/src/entities/attachment.js
@@ -1,6 +1,6 @@
 import { supabase } from '@/shared/api/supabaseClient';
 
-const ATTACH_BUCKET =
+export const ATTACH_BUCKET =
     (typeof import.meta !== 'undefined' && import.meta.env?.VITE_ATTACH_BUCKET) ||
     process.env.REACT_APP_ATTACH_BUCKET ||
     'attachments';
@@ -45,4 +45,9 @@ async function upload(file, pathPrefix) {
 
 export function uploadLetterAttachment(file, projectId) {
     return upload(file, `letters/${projectId}`);
+}
+
+export function uploadCorrespondenceAttachment(file, projectId) {
+    const prefix = `correspondence/${projectId ?? 'common'}`;
+    return upload(file, prefix);
 }

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -28,6 +28,7 @@ import { useUsers } from '@/entities/user';
 import { useLetterTypes } from '@/entities/letterType';
 import { useProjects } from '@/entities/project';
 import { useUnitsByProject, useUnitsByIds } from '@/entities/unit';
+import { useAttachmentTypes } from '@/entities/attachmentType';
 
 
 
@@ -64,6 +65,7 @@ export default function CorrespondencePage() {
   const { data: users = [] } = useUsers();
   const { data: letterTypes = [] } = useLetterTypes();
   const { data: projects = [] } = useProjects();
+  const { data: attachmentTypes = [] } = useAttachmentTypes();
   const { data: projectUnits = [] } = useUnitsByProject(
     view?.project_id ?? (filters.project ? Number(filters.project) : null),
   );
@@ -109,13 +111,11 @@ export default function CorrespondencePage() {
         correspondent: data.correspondent,
         subject: data.subject,
         content: data.content,
-
-
         responsible_user_id: data.responsible_user_id,
         letter_type_id: data.letter_type_id,
         project_id: data.project_id,
         unit_ids: data.unit_ids,
-
+        attachments: data.attachments,
       },
       {
         onSuccess: () => setSnackbar('Письмо добавлено'),
@@ -287,6 +287,28 @@ export default function CorrespondencePage() {
             <Typography gutterBottom>Корреспондент: {view.correspondent}</Typography>
             <Typography gutterBottom>Тема: {view.subject}</Typography>
             <Typography sx={{ whiteSpace: 'pre-wrap' }}>{view.content}</Typography>
+            {view.attachments.length > 0 && (
+              <Box sx={{ mt: 1 }}>
+                <Typography variant="subtitle2" gutterBottom>
+                  Вложения:
+                </Typography>
+                {view.attachments.map((a) => (
+                  <div key={a.id} style={{ marginBottom: 4 }}>
+                    <a href={a.file_url} download={a.name} style={{ marginRight: 8 }}>
+                      {a.name}
+                    </a>
+                    {a.attachment_type_id && (
+                      <Typography component="span" variant="body2" color="text.secondary">
+                        (
+                        {attachmentTypes.find((t) => t.id === a.attachment_type_id)?.name ||
+                          'Тип не указан'}
+                        )
+                      </Typography>
+                    )}
+                  </div>
+                ))}
+              </Box>
+            )}
           </DialogContent>
         )}
         <DialogActions>

--- a/src/shared/types/correspondence.ts
+++ b/src/shared/types/correspondence.ts
@@ -24,4 +24,22 @@ export interface CorrespondenceLetter {
   subject: string;
   /** Содержание письма */
   content: string;
+
+  /** Загруженные файлы */
+  attachments: CorrespondenceAttachment[];
+}
+
+export interface CorrespondenceAttachment {
+  /** Уникальный идентификатор вложения */
+  id: string;
+  /** Имя файла */
+  name: string;
+  /** MIME‑тип файла */
+  file_type: string;
+  /** Путь в хранилище */
+  storage_path: string;
+  /** Публичный URL */
+  file_url: string;
+  /** Тип вложения */
+  attachment_type_id: number | null;
 }


### PR DESCRIPTION
## Summary
- export attachment bucket constant and add helper for correspondence uploads
- upload correspondence attachments to Supabase storage
- remove stored files when deleting letters
- store attachment meta (storage path & URL) and show download links

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'react')*
- `npm run lint` *(fails: ESLint couldn't find configuration)*