### PR TITLE
Fix attachments bucket selection

### DIFF
--- a/src/entities/attachment.js
+++ b/src/entities/attachment.js
@@ -18,6 +18,13 @@ try {
     /* ignore invalid URL */
 }
 
+// Если из переменной окружения получилось название «s3», это скорее всего
+// базовый путь без указания корзины.  В таком случае переключаемся на
+// используемую в проекте корзину «attachments».
+if (ATTACH_BUCKET.toLowerCase() === 's3') {
+    ATTACH_BUCKET = 'attachments';
+}
+
 export const slugify = (str) =>
     str
         .normalize('NFKD')

--- a/src/entities/ticket.js
+++ b/src/entities/ticket.js
@@ -29,6 +29,12 @@ try {
     /* ignore invalid URL */
 }
 
+// Если по ошибке указали только базовый путь «s3», используем корзину
+// «attachments», которая настроена в Supabase.
+if (ATTACH_BUCKET.toLowerCase() === 's3') {
+    ATTACH_BUCKET = 'attachments';
+}
+
 // ──────────────────────────── helpers ──────────────────────────────
 export const slugify = (str) =>
     str


### PR DESCRIPTION
## Summary
- fallback to `attachments` bucket when env var resolves to `s3`

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*