### PR TITLE
Add related letters support in correspondence

### DIFF
--- a/src/entities/correspondence/index.ts
+++ b/src/entities/correspondence/index.ts
@@ -27,6 +27,7 @@ function loadLetters(): CorrespondenceLetter[] {
         ? [l.unit_id]
         : [],
       attachments: Array.isArray(l.attachments) ? l.attachments : [],
+      parent_id: l.parent_id ?? null,
     }));
   } catch {
     return [];
@@ -66,6 +67,7 @@ export function useAddLetter() {
         ...(payload as any),
         id: Date.now().toString(),
         attachments,
+        parent_id: (payload as any).parent_id ?? null,
       };
       letters.push(newLetter);
       saveLetters(letters);

--- a/src/features/correspondence/AddLetterForm.tsx
+++ b/src/features/correspondence/AddLetterForm.tsx
@@ -20,14 +20,16 @@ export interface AddLetterFormData {
   project_id: number | null;
   unit_ids: number[];
   attachments: { file: File; type_id: number | null }[];
+  parent_id: string | null;
 }
 
 interface AddLetterFormProps {
   onSubmit: (data: AddLetterFormData) => void;
+  parentId?: string | null;
 }
 
 /** Форма добавления нового письма на Ant Design */
-export default function AddLetterForm({ onSubmit }: AddLetterFormProps) {
+export default function AddLetterForm({ onSubmit, parentId = null }: AddLetterFormProps) {
   const [form] = Form.useForm<Omit<AddLetterFormData, 'attachments'>>();
   const projectId = Form.useWatch('project_id', form);
 
@@ -59,7 +61,12 @@ export default function AddLetterForm({ onSubmit }: AddLetterFormProps) {
     setFiles((p) => p.filter((_, i) => i !== idx));
 
   const submit = (values: Omit<AddLetterFormData, 'attachments'>) => {
-    onSubmit({ ...values, date: values.date ?? dayjs(), attachments: files });
+    onSubmit({
+      ...values,
+      date: values.date ?? dayjs(),
+      attachments: files,
+      parent_id: parentId,
+    });
     form.resetFields();
     setFiles([]);
   };

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -59,6 +59,7 @@ export default function CorrespondencePage() {
   const [form] = Form.useForm();
   const [view, setView] = useState<CorrespondenceLetter | null>(null);
   const [snackbar, setSnackbar] = useState<string | null>(null);
+  const [addFor, setAddFor] = useState<CorrespondenceLetter | null>(null);
 
 
 
@@ -116,9 +117,13 @@ export default function CorrespondencePage() {
         project_id: data.project_id,
         unit_ids: data.unit_ids,
         attachments: data.attachments,
+        parent_id: data.parent_id,
       },
       {
-        onSuccess: () => setSnackbar('Письмо добавлено'),
+        onSuccess: () => {
+          setSnackbar('Письмо добавлено');
+          setAddFor(null);
+        },
       },
     );
   };
@@ -183,6 +188,18 @@ export default function CorrespondencePage() {
         <AddLetterForm onSubmit={handleAdd} />
       </Paper>
 
+      <Dialog open={!!addFor} onClose={() => setAddFor(null)} maxWidth="md" fullWidth>
+        <DialogTitle>Добавить связанное письмо</DialogTitle>
+        {addFor && (
+          <DialogContent dividers>
+            <AddLetterForm onSubmit={handleAdd} parentId={addFor.id} />
+          </DialogContent>
+        )}
+        <DialogActions>
+          <MuiButton onClick={() => setAddFor(null)}>Отмена</MuiButton>
+        </DialogActions>
+      </Dialog>
+
       <Paper sx={{ p: 2 }}>
         <Form
           form={form}
@@ -236,6 +253,7 @@ export default function CorrespondencePage() {
           letters={filtered}
           onView={setView}
           onDelete={handleDelete}
+          onAddChild={setAddFor}
           users={users}
           letterTypes={letterTypes}
           projects={projects}

--- a/src/shared/types/correspondence.ts
+++ b/src/shared/types/correspondence.ts
@@ -4,6 +4,9 @@ export interface CorrespondenceLetter {
   /** Тип письма: входящее или исходящее */
   type: 'incoming' | 'outgoing';
 
+  /** Идентификатор родительского письма */
+  parent_id: string | null;
+
   /** Идентификатор ответственного пользователя */
   responsible_user_id: string | null;
   /** Идентификатор категории письма */


### PR DESCRIPTION
## Summary
- allow setting parent for correspondence letter
- support adding related letters from table
- show nested correspondence letters in table

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*