### PR TITLE
Fix attachments saving and link letters

### DIFF
--- a/src/entities/attachment.js
+++ b/src/entities/attachment.js
@@ -70,3 +70,5 @@ export function uploadLetterAttachment(file, projectId) {
 export function uploadCaseAttachment(file, projectId, unitId) {
     return upload(file, `Case/${projectId}/${unitId}`);
 }
+
+export { ATTACH_BUCKET };

--- a/src/features/correspondence/LinkLettersDialog.tsx
+++ b/src/features/correspondence/LinkLettersDialog.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button as MuiButton,
+} from '@mui/material';
+import { Select } from 'antd';
+import { CorrespondenceLetter } from '@/shared/types/correspondence';
+
+interface Props {
+  open: boolean;
+  parent: CorrespondenceLetter | null;
+  letters: CorrespondenceLetter[];
+  onClose: () => void;
+  onSubmit: (ids: string[]) => void;
+}
+
+export default function LinkLettersDialog({
+  open,
+  parent,
+  letters,
+  onClose,
+  onSubmit,
+}: Props) {
+  const [selected, setSelected] = useState<string[]>([]);
+
+  useEffect(() => setSelected([]), [parent]);
+
+  const options = letters
+    .filter((l) => l.id !== parent?.id)
+    .map((l) => ({ value: l.id, label: `${l.number} - ${l.subject}` }));
+
+  const handleSubmit = () => {
+    onSubmit(selected);
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Связать существующие письма</DialogTitle>
+      <DialogContent dividers>
+        <Select
+          mode="multiple"
+          style={{ width: '100%' }}
+          options={options}
+          value={selected}
+          onChange={(vals) => setSelected(vals as string[])}
+          placeholder="Выберите письма"
+        />
+      </DialogContent>
+      <DialogActions>
+        <MuiButton onClick={onClose}>Отмена</MuiButton>
+        <MuiButton
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={selected.length === 0}
+        >
+          Связать
+        </MuiButton>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/shared/types/correspondence.ts
+++ b/src/shared/types/correspondence.ts
@@ -39,8 +39,10 @@ export interface CorrespondenceAttachment {
   name: string;
   /** MIME‑тип файла */
   file_type: string;
-  /** Данные файла в Base64 */
-  data_url: string;
+  /** Путь к файлу в хранилище */
+  storage_path: string;
+  /** Публичная ссылка на файл */
+  file_url: string;
   /** Тип вложения */
   attachment_type_id: number | null;
 }


### PR DESCRIPTION
## Summary
- save uploaded correspondence files to Supabase storage
- keep bucket name exportable
- show attachments from `file_url`
- allow linking existing letters via new dialog

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: vite not found)*