### PR TITLE
Fix LinkLettersDialog dropdown position

### DIFF
--- a/src/features/correspondence/LinkLettersDialog.tsx
+++ b/src/features/correspondence/LinkLettersDialog.tsx
@@ -42,11 +42,13 @@ export default function LinkLettersDialog({
       <DialogContent dividers>
         <Select
           mode="multiple"
+          showSearch
           style={{ width: '100%' }}
           options={options}
           value={selected}
           onChange={(vals) => setSelected(vals as string[])}
           placeholder="Выберите письма"
+          getPopupContainer={(trigger) => trigger.parentElement!}
         />
       </DialogContent>
       <DialogActions>


### PR DESCRIPTION
## Summary
- fix issue where dropdown opened behind the dialog when linking letters
- enable search filter when selecting letters

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build` *(fails: vite not found)*