### PR TITLE
Fix dropdown filtering and popup container

### DIFF
--- a/src/features/correspondence/LinkLettersDialog.tsx
+++ b/src/features/correspondence/LinkLettersDialog.tsx
@@ -48,7 +48,7 @@ export default function LinkLettersDialog({
           value={selected}
           onChange={(vals) => setSelected(vals as string[])}
           placeholder="Выберите письма"
-          getPopupContainer={(trigger) => trigger.parentElement!}
+          optionFilterProp="label"
         />
       </DialogContent>
       <DialogActions>


### PR DESCRIPTION
## Summary
- adjust `Select` props in link letters dialog

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*