### PR TITLE
Fix unlink on correspondence page

### DIFF
--- a/src/entities/correspondence/index.ts
+++ b/src/entities/correspondence/index.ts
@@ -139,3 +139,23 @@ export function useLinkLetters() {
     },
   });
 }
+
+
+export function useUnlinkLetter() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const letters = loadLetters();
+      const map = new Map(letters.map((l) => [l.id, l]));
+      const letter = map.get(id);
+      if (letter) {
+        letter.parent_id = null;
+        map.set(id, letter);
+        saveLetters(Array.from(map.values()));
+      }
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: [LS_KEY] });
+    },
+  });
+}

--- a/src/features/correspondence/LinkLettersDialog.tsx
+++ b/src/features/correspondence/LinkLettersDialog.tsx
@@ -1,7 +1,7 @@
 // CHANGE: Полный список писем, отдельное окно, фильтрация по номеру/теме/корреспонденту
 
 import React, { useEffect, useMemo, useState } from 'react';
-import { Modal, Input, Table, Checkbox, Button } from 'antd';
+import { Modal, Input, Table, Button } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { CorrespondenceLetter } from '@/shared/types/correspondence';
 
@@ -34,12 +34,14 @@ export default function LinkLettersDialog({
   const filteredLetters = useMemo(() => {
     const term = search.trim().toLowerCase();
     return letters
-        .filter(l => l.id !== parent?.id)
-        .filter(l =>
-            !term
-            || l.number.toLowerCase().includes(term)
-            || (l.subject ?? '').toLowerCase().includes(term)
-            || (l.correspondent ?? '').toLowerCase().includes(term)
+        .filter((l) => l.id !== parent?.id)
+        .filter((l) => l.parent_id === null)
+        .filter(
+          (l) =>
+            !term ||
+            l.number.toLowerCase().includes(term) ||
+            (l.subject ?? '').toLowerCase().includes(term) ||
+            (l.correspondent ?? '').toLowerCase().includes(term),
         );
   }, [letters, parent, search]);
 
@@ -97,7 +99,7 @@ export default function LinkLettersDialog({
         />
         <Table<CorrespondenceLetter>
             rowKey="id"
-            columns={columns}Й
+            columns={columns}
             dataSource={filteredLetters}
             size="small"
             pagination={{ pageSize: 8, showSizeChanger: false }}

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -22,6 +22,7 @@ import {
   useAddLetter,
   useDeleteLetter,
   useLinkLetters,
+  useUnlinkLetter,
 } from '@/entities/correspondence';
 import { CorrespondenceLetter } from '@/shared/types/correspondence';
 
@@ -50,6 +51,7 @@ export default function CorrespondencePage() {
   const add = useAddLetter();
   const remove = useDeleteLetter();
   const linkLetters = useLinkLetters();
+  const unlinkLetter = useUnlinkLetter();
   const [filters, setFilters] = useState<Filters>({
     type: '',
     project: '',
@@ -134,6 +136,12 @@ export default function CorrespondencePage() {
     if (!window.confirm('Удалить письмо?')) return;
     remove.mutate(id, {
       onSuccess: () => setSnackbar('Письмо удалено'),
+    });
+  };
+
+  const handleUnlink = (id: string) => {
+    unlinkLetter.mutate(id, {
+      onSuccess: () => setSnackbar('Письмо исключено из связи'),
     });
   };
 
@@ -260,6 +268,7 @@ export default function CorrespondencePage() {
           onView={setView}
           onDelete={handleDelete}
           onAddChild={setLinkFor}
+          onUnlink={handleUnlink}
           users={users}
           letterTypes={letterTypes}
           projects={projects}


### PR DESCRIPTION
## Summary
- implement `useUnlinkLetter` hook
- handle unlink action in `CorrespondencePage`
- exclude linked letters from `LinkLettersDialog`

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: vite not found)*