### PR TITLE
Fix correspondence letter creation

### DIFF
--- a/src/entities/correspondence/index.ts
+++ b/src/entities/correspondence/index.ts
@@ -90,9 +90,11 @@ export function useAddLetter() {
     ) => {
       const { attachments = [], parent_id, ...data } = payload as any;
 
+      // В БД поле case_id обязательно, поэтому для
+      // писем общей корреспонденции проставляем 0
       const letterData = {
         project_id: data.project_id,
-        case_id: null,
+        case_id: 0,
         number: data.number,
         letter_type_id: data.letter_type_id,
         letter_date: data.date,


### PR DESCRIPTION
## Summary
- ensure `case_id` field is non-null when adding new correspondence letters

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*