### PR TITLE
Fix correspondence letter insertion

### DIFF
--- a/src/entities/correspondence/index.ts
+++ b/src/entities/correspondence/index.ts
@@ -90,6 +90,8 @@ export function useAddLetter() {
     ) => {
       const { attachments = [], parent_id, ...data } = payload as any;
 
+      // Письма в разделе «Корреспонденция» не привязаны к судебному делу,
+      // поэтому поле `case_id` сохраняем как `null`
       const letterData = {
         project_id: data.project_id,
         case_id: null,


### PR DESCRIPTION
## Summary
- allow `case_id` to be `null` when adding correspondence letters

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*