### PR TITLE
Fix correspondence letter creation

### DIFF
--- a/src/entities/correspondence/index.ts
+++ b/src/entities/correspondence/index.ts
@@ -96,7 +96,7 @@ export function useAddLetter() {
 
       const letterData = {
         project_id: data.project_id,
-        case_id: 0,
+        case_id: null,
         number: data.number,
         letter_type_id: data.letter_type_id,
         letter_date: data.date,


### PR DESCRIPTION
## Summary
- prevent invalid `case_id` when creating new correspondence letter

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*