### PR TITLE
Fix letters table queries and remove obsolete links

### DIFF
--- a/src/entities/correspondence/index.ts
+++ b/src/entities/correspondence/index.ts
@@ -41,9 +41,7 @@ export function useLetters() {
       const { data, error } = await supabase
         .from(LETTERS_TABLE)
         .select(
-
-          `id, project_id, case_id, number, letter_type_id, letter_date, subject, sender, receiver, created_at, attachments(id, storage_path, file_url, file_type, attachment_type_id)`
-
+          `id, project_id, number, letter_type_id, letter_date, subject, sender, receiver, created_at, attachments(id, storage_path, file_url, file_type, attachment_type_id)`
         )
         .order('id');
       if (error) throw error;
@@ -91,12 +89,8 @@ export function useAddLetter() {
       const { attachments = [], parent_id, ...data } = payload as any;
 
 
-      // Письма в разделе «Корреспонденция» не привязаны к судебному делу,
-      // поэтому поле `case_id` сохраняем как `null`
-
       const letterData = {
         project_id: data.project_id,
-        case_id: null,
         number: data.number,
         letter_type_id: data.letter_type_id,
         letter_date: data.date,

--- a/src/shared/types/courtCase.ts
+++ b/src/shared/types/courtCase.ts
@@ -1,19 +1,3 @@
-export interface LetterAttachment {
-  id: number;
-  storage_path: string;
-  file_url: string;
-  file_type: string;
-  attachment_type_id: number | null;
-}
-
-export interface Letter {
-  id: number;
-  case_id: number;
-  number: string;
-  date: string;
-  content: string;
-  attachments: LetterAttachment[];
-}
 
 export interface Defect {
   id: number;
@@ -40,6 +24,5 @@ export interface CourtCase {
   fix_end_date?: string | null;
   description: string;
   claim_amount?: number | null;
-  letters: Letter[];
   defects: Defect[];
 }


### PR DESCRIPTION
## Summary
- remove nonexistent `case_id` column from correspondence queries
- drop court case letter integration and related UI
- clean `CourtCase` types accordingly

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*