### PR TITLE
Add editable letter view

### DIFF
--- a/src/features/correspondence/EditLetterDialog.tsx
+++ b/src/features/correspondence/EditLetterDialog.tsx
@@ -1,0 +1,143 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button as MuiButton,
+} from '@mui/material';
+import { Form, Input, Select, DatePicker } from 'antd';
+import dayjs from 'dayjs';
+import FileDropZone from '@/shared/ui/FileDropZone';
+import AttachmentEditorList from '@/shared/ui/AttachmentEditorList';
+import { useUpdateLetter, signedLetterUrl } from '@/entities/correspondence';
+import { CorrespondenceLetter, CorrespondenceAttachment } from '@/shared/types/correspondence';
+
+interface Option { id: number | string; name: string; }
+
+interface Props {
+  open: boolean;
+  letter: CorrespondenceLetter | null;
+  onClose: () => void;
+  projects: Option[];
+  letterTypes: Option[];
+  attachmentTypes: Option[];
+}
+
+export default function EditLetterDialog({
+  open,
+  letter,
+  onClose,
+  projects,
+  letterTypes,
+  attachmentTypes,
+}: Props) {
+  const [form] = Form.useForm();
+  const update = useUpdateLetter();
+  const [remote, setRemote] = useState<CorrespondenceAttachment[]>([]);
+  const [newFiles, setNewFiles] = useState<{ file: File; type_id: number | null }[]>([]);
+  const [changedTypes, setChangedTypes] = useState<Record<string, number | null>>({});
+
+  useEffect(() => {
+    if (letter) {
+      form.setFieldsValue({
+        type: letter.type,
+        number: letter.number,
+        date: dayjs(letter.date),
+        correspondent: letter.correspondent,
+        subject: letter.subject,
+        project_id: letter.project_id ?? undefined,
+        letter_type_id: letter.letter_type_id ?? undefined,
+      });
+      setRemote(letter.attachments);
+      setNewFiles([]);
+      setChangedTypes({});
+    }
+  }, [letter, form]);
+
+  const addFiles = (files: File[]) => {
+    const arr = files.map((f) => ({ file: f, type_id: null }));
+    setNewFiles((p) => [...p, ...arr]);
+  };
+  const removeRemote = (id: string) => setRemote((p) => p.filter((f) => f.id !== id));
+  const removeNew = (idx: number) => setNewFiles((p) => p.filter((_, i) => i !== idx));
+  const changeRemoteType = (id: string, val: number | null) =>
+    setChangedTypes((p) => ({ ...p, [id]: val }));
+  const changeNewType = (idx: number, val: number | null) =>
+    setNewFiles((p) => p.map((f, i) => (i === idx ? { ...f, type_id: val } : f)));
+
+  const handleSave = async () => {
+    const vals = form.getFieldsValue();
+    const removedIds = letter!.attachments
+      .filter((a) => !remote.some((r) => r.id === a.id))
+      .map((a) => a.id);
+    const updated = Object.entries(changedTypes).map(([id, type_id]) => ({ id, type_id }));
+    await update.mutateAsync({
+      id: letter!.id,
+      updates: {
+        type: vals.type,
+        number: vals.number,
+        date: vals.date ? vals.date.toISOString() : dayjs().toISOString(),
+        correspondent: vals.correspondent,
+        subject: vals.subject,
+        project_id: vals.project_id ?? null,
+        letter_type_id: vals.letter_type_id ?? null,
+      },
+      newAttachments: newFiles,
+      removedAttachmentIds: removedIds,
+      updatedAttachments: updated,
+    });
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Детали письма</DialogTitle>
+      <DialogContent dividers>
+        <Form form={form} layout="vertical">
+          <Form.Item name="type" label="Тип письма">
+            <Select>
+              <Select.Option value="incoming">Входящее</Select.Option>
+              <Select.Option value="outgoing">Исходящее</Select.Option>
+            </Select>
+          </Form.Item>
+          <Form.Item name="number" label="Номер">
+            <Input />
+          </Form.Item>
+          <Form.Item name="date" label="Дата">
+            <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+          </Form.Item>
+          <Form.Item name="project_id" label="Проект">
+            <Select allowClear options={projects.map((p) => ({ value: p.id, label: p.name }))} />
+          </Form.Item>
+          <Form.Item name="letter_type_id" label="Категория">
+            <Select allowClear options={letterTypes.map((t) => ({ value: t.id, label: t.name }))} />
+          </Form.Item>
+          <Form.Item name="correspondent" label="Корреспондент">
+            <Input />
+          </Form.Item>
+          <Form.Item name="subject" label="Тема">
+            <Input />
+          </Form.Item>
+        </Form>
+        <FileDropZone onFiles={addFiles} />
+        <AttachmentEditorList
+          remoteFiles={remote.map((f) => ({ id: f.id, name: f.name, path: f.storage_path, typeId: changedTypes[f.id] ?? f.attachment_type_id }))}
+          newFiles={newFiles.map((f) => ({ file: f.file, typeId: f.type_id }))}
+          attachmentTypes={attachmentTypes}
+          onRemoveRemote={removeRemote}
+          onRemoveNew={removeNew}
+          onChangeRemoteType={changeRemoteType}
+          onChangeNewType={changeNewType}
+          getSignedUrl={(path, name) => signedLetterUrl(path, name)}
+        />
+      </DialogContent>
+      <DialogActions>
+        <MuiButton onClick={onClose}>Отмена</MuiButton>
+        <MuiButton variant="contained" onClick={handleSave} disabled={update.isPending}>
+          Сохранить
+        </MuiButton>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -4,10 +4,6 @@ import {
   Paper,
   Stack,
   Typography,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
   Snackbar,
   Button as MuiButton,
 } from '@mui/material';
@@ -16,6 +12,7 @@ import dayjs from 'dayjs';
 import { AddLetterFormData } from '@/features/correspondence/AddLetterForm';
 import AddLetterForm from '@/features/correspondence/AddLetterForm';
 import LinkLettersDialog from '@/features/correspondence/LinkLettersDialog';
+import EditLetterDialog from '@/features/correspondence/EditLetterDialog';
 import CorrespondenceTable from '@/widgets/CorrespondenceTable';
 import {
   useLetters,
@@ -268,73 +265,14 @@ export default function CorrespondencePage() {
           </Box>
         </Paper>
 
-        <Dialog open={!!view} onClose={() => setView(null)} maxWidth="sm" fullWidth>
-          <DialogTitle>Детали письма</DialogTitle>
-          {view && (
-              <DialogContent dividers>
-                <Typography variant="subtitle2" gutterBottom>
-                  {view.type === 'incoming' ? 'Входящее' : 'Исходящее'} письмо №{' '}
-                  {view.number}
-                </Typography>
-                <Typography gutterBottom>
-                  Дата: {dayjs(view.date).format('DD.MM.YYYY')}
-                </Typography>
-                {view.project_id && (
-                    <Typography gutterBottom>
-                      Проект: {projects.find((p) => p.id === view.project_id)?.name}
-                    </Typography>
-                )}
-                {view.unit_ids.length > 0 && (
-                    <Typography gutterBottom>
-                      Объекты:{' '}
-                      {view.unit_ids
-                          .map((id) => projectUnits.find((u) => u.id === id)?.name)
-                          .filter(Boolean)
-                          .join(', ')}
-                    </Typography>
-                )}
-                {view.letter_type_id && (
-                    <Typography gutterBottom>
-                      Категория: {letterTypes.find((t) => t.id === view.letter_type_id)?.name}
-                    </Typography>
-                )}
-                {view.responsible_user_id && (
-                    <Typography gutterBottom>
-                      Ответственный: {users.find((u) => u.id === view.responsible_user_id)?.name}
-                    </Typography>
-                )}
-
-                <Typography gutterBottom>Корреспондент: {view.correspondent}</Typography>
-                <Typography gutterBottom>Тема: {view.subject}</Typography>
-                <Typography sx={{ whiteSpace: 'pre-wrap' }}>{view.content}</Typography>
-                {view.attachments.length > 0 && (
-                    <Box sx={{ mt: 1 }}>
-                      <Typography variant="subtitle2" gutterBottom>
-                        Вложения:
-                      </Typography>
-                      {view.attachments.map((a) => (
-                          <div key={a.id} style={{ marginBottom: 4 }}>
-                            <a href={a.file_url} download={a.name} style={{ marginRight: 8 }}>
-                              {a.name}
-                            </a>
-                            {a.attachment_type_id && (
-                                <Typography component="span" variant="body2" color="text.secondary">
-                                  (
-                                  {attachmentTypes.find((t) => t.id === a.attachment_type_id)?.name ||
-                                      'Тип не указан'}
-                                  )
-                                </Typography>
-                            )}
-                          </div>
-                      ))}
-                    </Box>
-                )}
-              </DialogContent>
-          )}
-          <DialogActions>
-            <MuiButton onClick={() => setView(null)}>Закрыть</MuiButton>
-          </DialogActions>
-        </Dialog>
+        <EditLetterDialog
+            open={!!view}
+            letter={view}
+            onClose={() => setView(null)}
+            projects={projects}
+            letterTypes={letterTypes}
+            attachmentTypes={attachmentTypes}
+        />
 
         <Snackbar
             open={!!snackbar}

--- a/src/shared/ui/AttachmentEditorList.tsx
+++ b/src/shared/ui/AttachmentEditorList.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import {
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  IconButton,
+  Tooltip,
+  Select,
+  MenuItem,
+} from '@mui/material';
+import FileIcon from '@mui/icons-material/InsertDriveFileOutlined';
+import DeleteIcon from '@mui/icons-material/DeleteOutline';
+import DownloadIcon from '@mui/icons-material/DownloadOutlined';
+
+interface Option { id: number | string; name: string; }
+
+interface RemoteFile {
+  id: string;
+  name: string;
+  path: string;
+  typeId: number | null;
+}
+
+interface NewFile {
+  file: File;
+  typeId: number | null;
+}
+
+interface Props {
+  remoteFiles?: RemoteFile[];
+  newFiles?: NewFile[];
+  attachmentTypes: Option[];
+  onRemoveRemote?: (id: string) => void;
+  onRemoveNew?: (idx: number) => void;
+  onChangeRemoteType?: (id: string, type: number | null) => void;
+  onChangeNewType?: (idx: number, type: number | null) => void;
+  getSignedUrl?: (path: string, name: string) => Promise<string>;
+}
+
+export default function AttachmentEditorList({
+  remoteFiles = [],
+  newFiles = [],
+  attachmentTypes,
+  onRemoveRemote,
+  onRemoveNew,
+  onChangeRemoteType,
+  onChangeNewType,
+  getSignedUrl,
+}: Props) {
+  const [cache, setCache] = React.useState<Record<string, string>>({});
+
+  const signed = async (path: string, name: string, id: string) => {
+    if (cache[id]) return cache[id];
+    const url = await getSignedUrl?.(path, name);
+    if (url) setCache((p) => ({ ...p, [id]: url }));
+    return url;
+  };
+
+  const objUrls = React.useMemo(
+    () => newFiles.map((f) => URL.createObjectURL(f.file)),
+    [newFiles],
+  );
+  React.useEffect(() => () => objUrls.forEach(URL.revokeObjectURL), [objUrls]);
+
+  const forceDownload = async (f: RemoteFile) => {
+    const url = await signed(f.path, f.name, f.id);
+    if (!url) return;
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = f.name;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  };
+
+  if (!remoteFiles.length && !newFiles.length) return null;
+
+  return (
+    <List dense sx={{ mt: 1 }}>
+      {remoteFiles.map((f) => (
+        <ListItem key={`r-${f.id}`}>
+          <ListItemIcon>
+            <FileIcon />
+          </ListItemIcon>
+          <ListItemText primary={f.name} />
+          <Select
+            size="small"
+            value={f.typeId ?? ''}
+            onChange={(e) =>
+              onChangeRemoteType?.(
+                f.id,
+                e.target.value ? Number(e.target.value) : null,
+              )
+            }
+            displayEmpty
+            sx={{ mr: 1, minWidth: 120 }}
+          >
+            <MenuItem value="">
+              <em>Тип не указан</em>
+            </MenuItem>
+            {attachmentTypes.map((t) => (
+              <MenuItem key={t.id} value={t.id}>
+                {t.name}
+              </MenuItem>
+            ))}
+          </Select>
+          <Tooltip title="Скачать">
+            <IconButton onClick={() => forceDownload(f)}>
+              <DownloadIcon />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Удалить">
+            <IconButton onClick={() => onRemoveRemote?.(f.id)} sx={{ ml: 0.5 }}>
+              <DeleteIcon />
+            </IconButton>
+          </Tooltip>
+        </ListItem>
+      ))}
+      {newFiles.map((f, i) => (
+        <ListItem key={`n-${i}`}>
+          <ListItemIcon>
+            <FileIcon />
+          </ListItemIcon>
+          <ListItemText
+            primary={f.file.name}
+            secondary={`${(f.file.size / 1024).toFixed(1)} KB`}
+          />
+          <Select
+            size="small"
+            value={f.typeId ?? ''}
+            onChange={(e) =>
+              onChangeNewType?.(
+                i,
+                e.target.value ? Number(e.target.value) : null,
+              )
+            }
+            displayEmpty
+            sx={{ mr: 1, minWidth: 120 }}
+          >
+            <MenuItem value="">
+              <em>Тип не указан</em>
+            </MenuItem>
+            {attachmentTypes.map((t) => (
+              <MenuItem key={t.id} value={t.id}>
+                {t.name}
+              </MenuItem>
+            ))}
+          </Select>
+          <Tooltip title="Скачать">
+            <IconButton component="a" href={objUrls[i]} download={f.file.name}>
+              <DownloadIcon />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Удалить">
+            <IconButton onClick={() => onRemoveNew?.(i)} sx={{ ml: 0.5 }}>
+              <DeleteIcon />
+            </IconButton>
+          </Tooltip>
+        </ListItem>
+      ))}
+    </List>
+  );
+}


### PR DESCRIPTION
## Summary
- support attachment type and name parsing in correspondence entity
- add editor UI for attachments with download/remove/type select
- update letters via new hooks
- integrate EditLetterDialog into correspondence page

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*