### PR TITLE
Fix court cases handling

### DIFF
--- a/src/entities/attachment.js
+++ b/src/entities/attachment.js
@@ -67,8 +67,10 @@ export function uploadLetterAttachment(file, projectId) {
     return upload(file, `letters/${projectId}`);
 }
 
-export function uploadCaseAttachment(file, projectId, unitId) {
-    return upload(file, `Case/${projectId}/${unitId}`);
+// Загрузка вложений дела теперь привязана к идентификатору дела,
+// чтобы все файлы хранились в `attachments/case/<caseId>`
+export function uploadCaseAttachment(file, caseId) {
+    return upload(file, `case/${caseId}`);
 }
 
 export { ATTACH_BUCKET };

--- a/src/entities/courtCase/index.ts
+++ b/src/entities/courtCase/index.ts
@@ -41,6 +41,23 @@ export function useAddCourtCase() {
   });
 }
 
+export function useUpdateCourtCase() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, updates }: { id: number; updates: Partial<CourtCase> }) => {
+      const { data, error } = await supabase
+        .from(CASES_TABLE)
+        .update(updates)
+        .eq('id', id)
+        .select('*')
+        .single();
+      if (error) throw error;
+      return data as CourtCase;
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: [CASES_TABLE] }),
+  });
+}
+
 export function useDeleteCourtCase() {
   const qc = useQueryClient();
   return useMutation({


### PR DESCRIPTION
## Summary
- allow selecting multiple objects when creating a court case
- validate fix end date not earlier than start date
- store case attachments under `attachments/case/<id>`
- add hook for updating court cases and enable editing in the case dialog
- display object name instead of numeric id

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*