### PR TITLE
Fix date validation logic for court cases

### DIFF
--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import dayjs, { Dayjs } from 'dayjs';
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import 'dayjs/locale/ru';
 import { ConfigProvider } from 'antd';
 import ruRU from 'antd/locale/ru_RU';
 
 dayjs.locale('ru');
+dayjs.extend(isSameOrAfter);
 import {
   Row,
   Col,


### PR DESCRIPTION
## Summary
- add dayjs `isSameOrAfter` plugin
- extend dayjs before using validator

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*