### PR TITLE
Update correspondence form with sender and receiver

### DIFF
--- a/src/entities/correspondence/index.ts
+++ b/src/entities/correspondence/index.ts
@@ -55,7 +55,8 @@ export function useLetters() {
         const parent = map.get(row.id);
 
         const type = row.receiver ? 'outgoing' : 'incoming';
-        const correspondent = row.receiver || row.sender || '';
+        const sender = row.sender || '';
+        const receiver = row.receiver || '';
         const attachments = (row.attachments ?? []).map((a: any) => {
           let name = a.storage_path;
           try {
@@ -88,7 +89,8 @@ export function useLetters() {
           unit_ids: (row.unit_ids ?? []) as number[],
           number: row.number,
           date: row.letter_date,
-          correspondent,
+          sender,
+          receiver,
           subject: row.subject ?? '',
           content: '',
 
@@ -117,8 +119,8 @@ export function useAddLetter() {
         letter_type_id: data.letter_type_id,
         letter_date: data.date,
         subject: data.subject,
-        sender: data.type === 'incoming' ? data.correspondent : null,
-        receiver: data.type === 'outgoing' ? data.correspondent : null,
+        sender: data.sender,
+        receiver: data.receiver,
         responsible_user_id: data.responsible_user_id,
         unit_ids: data.unit_ids,
       };
@@ -172,7 +174,8 @@ export function useAddLetter() {
         unit_ids: data.unit_ids ?? [],
         number: data.number,
         date: data.date,
-        correspondent: data.correspondent,
+        sender: data.sender,
+        receiver: data.receiver,
         subject: data.subject,
         content: '',
 
@@ -290,8 +293,8 @@ export function useUpdateLetter() {
         letter_type_id: updates.letter_type_id,
         letter_date: updates.date,
         subject: updates.subject,
-        sender: updates.type === 'incoming' ? updates.correspondent : null,
-        receiver: updates.type === 'outgoing' ? updates.correspondent : null,
+        sender: updates.sender,
+        receiver: updates.receiver,
         responsible_user_id: updates.responsible_user_id,
         unit_ids: updates.unit_ids,
       };

--- a/src/features/correspondence/LinkLettersDialog.tsx
+++ b/src/features/correspondence/LinkLettersDialog.tsx
@@ -50,7 +50,8 @@ export default function LinkLettersDialog({
             !term ||
             l.number.toLowerCase().includes(term) ||
             (l.subject ?? '').toLowerCase().includes(term) ||
-            (l.correspondent ?? '').toLowerCase().includes(term),
+            (l.sender ?? '').toLowerCase().includes(term) ||
+            (l.receiver ?? '').toLowerCase().includes(term),
         );
   }, [letters, parent, search, parents]);
 
@@ -69,11 +70,18 @@ export default function LinkLettersDialog({
       ellipsis: true,
     },
     {
-      title: 'Корреспондент',
-      dataIndex: 'correspondent',
-      key: 'correspondent',
+      title: 'Отправитель',
+      dataIndex: 'sender',
+      key: 'sender',
       ellipsis: true,
-      width: 180,
+      width: 160,
+    },
+    {
+      title: 'Получатель',
+      dataIndex: 'receiver',
+      key: 'receiver',
+      ellipsis: true,
+      width: 160,
     },
   ];
 

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -34,7 +34,8 @@ interface Filters {
   type?: 'incoming' | 'outgoing' | '';
   project?: number | '';
   unit?: number | '';
-  correspondent?: string;
+  sender?: string;
+  receiver?: string;
   subject?: string;
   content?: string;
   search?: string;
@@ -51,7 +52,8 @@ export default function CorrespondencePage() {
     type: '',
     project: '',
     unit: '',
-    correspondent: '',
+    sender: '',
+    receiver: '',
     subject: '',
     content: '',
     search: '',
@@ -80,7 +82,8 @@ export default function CorrespondencePage() {
       type: values.type ?? '',
       project: values.project ?? '',
       unit: values.unit ?? '',
-      correspondent: values.correspondent ?? '',
+      sender: values.sender ?? '',
+      receiver: values.receiver ?? '',
       subject: values.subject ?? '',
       content: values.content ?? '',
       search: values.search ?? '',
@@ -93,7 +96,8 @@ export default function CorrespondencePage() {
       type: '',
       project: '',
       unit: '',
-      correspondent: '',
+      sender: '',
+      receiver: '',
       subject: '',
       content: '',
       search: '',
@@ -138,14 +142,14 @@ export default function CorrespondencePage() {
     if (filters.type && l.type !== filters.type) return false;
     if (filters.project && l.project_id !== Number(filters.project)) return false;
     if (filters.unit && !l.unit_ids.includes(Number(filters.unit))) return false;
-    const correspondent = (l.correspondent || '').toLowerCase();
+    const sender = (l.sender || '').toLowerCase();
+    const receiver = (l.receiver || '').toLowerCase();
     const subject = (l.subject || '').toLowerCase();
     const content = (l.content || '').toLowerCase();
 
-    if (
-        filters.correspondent &&
-        !correspondent.includes(filters.correspondent.toLowerCase())
-    )
+    if (filters.sender && !sender.includes(filters.sender.toLowerCase()))
+      return false;
+    if (filters.receiver && !receiver.includes(filters.receiver.toLowerCase()))
       return false;
     if (
         filters.subject &&
@@ -161,7 +165,8 @@ export default function CorrespondencePage() {
         filters.search &&
         !(
             l.number.includes(filters.search) ||
-            correspondent.includes(filters.search.toLowerCase()) ||
+            sender.includes(filters.search.toLowerCase()) ||
+            receiver.includes(filters.search.toLowerCase()) ||
             subject.includes(filters.search.toLowerCase())
         )
     )
@@ -231,7 +236,10 @@ export default function CorrespondencePage() {
                   disabled={!form.getFieldValue('project')}
               />
             </Form.Item>
-            <Form.Item name="correspondent" label="Корреспондент">
+            <Form.Item name="sender" label="Отправитель">
+              <Input allowClear autoComplete="off" />
+            </Form.Item>
+            <Form.Item name="receiver" label="Получатель">
               <Input allowClear autoComplete="off" />
             </Form.Item>
             <Form.Item name="subject" label="В теме">

--- a/src/shared/types/correspondence.ts
+++ b/src/shared/types/correspondence.ts
@@ -21,8 +21,10 @@ export interface CorrespondenceLetter {
   number: string;
   /** Дата письма ISO */
   date: string;
-  /** Корреспондент */
-  correspondent: string;
+  /** Отправитель письма */
+  sender: string;
+  /** Получатель письма */
+  receiver: string;
   /** Тема письма */
   subject: string;
   /** Содержание письма */

--- a/src/widgets/CorrespondenceTable.tsx
+++ b/src/widgets/CorrespondenceTable.tsx
@@ -132,11 +132,20 @@ export default function CorrespondenceTable({
       render: (v: string) => dayjs(v).format('DD.MM.YYYY'),
     },
     {
-      title: 'Корреспондент',
-      dataIndex: 'correspondent',
-      sorter: (a, b) => a.correspondent.localeCompare(b.correspondent),
-      render: (val: string, record: any) =>
-          <span style={record.parent_id ? { color: '#888' } : {}}>{val}</span>,
+      title: 'Отправитель',
+      dataIndex: 'sender',
+      sorter: (a, b) => (a.sender || '').localeCompare(b.sender || ''),
+      render: (val: string, record: any) => (
+        <span style={record.parent_id ? { color: '#888' } : {}}>{val}</span>
+      ),
+    },
+    {
+      title: 'Получатель',
+      dataIndex: 'receiver',
+      sorter: (a, b) => (a.receiver || '').localeCompare(b.receiver || ''),
+      render: (val: string, record: any) => (
+        <span style={record.parent_id ? { color: '#888' } : {}}>{val}</span>
+      ),
     },
     {
       title: 'Тема',


### PR DESCRIPTION
## Summary
- support sender/receiver fields in letters instead of single correspondent
- update add/edit forms and link dialog
- adjust correspondence table and filters
- revise types and API calls

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npx tsc --noEmit` *(fails: cannot find type declarations)*