### PR TITLE
Implement array unit IDs for court cases

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -204,8 +204,8 @@
   },
   {
     "table_name": "court_cases",
-    "column_name": "unit_id",
-    "data_type": "integer",
+    "column_name": "unit_ids",
+    "data_type": "integer[]",
     "is_nullable": "YES",
     "column_default": null
   },
@@ -234,13 +234,6 @@
     "table_name": "court_cases",
     "column_name": "fix_end_date",
     "data_type": "date",
-    "is_nullable": "YES",
-    "column_default": null
-  },
-  {
-    "table_name": "court_cases",
-    "column_name": "comments",
-    "data_type": "text",
     "is_nullable": "YES",
     "column_default": null
   },
@@ -288,15 +281,15 @@
   },
   {
     "table_name": "court_cases",
-    "column_name": "claim_amount",
-    "data_type": "numeric",
+    "column_name": "description",
+    "data_type": "text",
     "is_nullable": "YES",
     "column_default": null
   },
   {
     "table_name": "court_cases",
-    "column_name": "description",
-    "data_type": "text",
+    "column_name": "attachment_ids",
+    "data_type": "integer[]",
     "is_nullable": "YES",
     "column_default": null
   },

--- a/sql/20250530_update_court_cases.sql
+++ b/sql/20250530_update_court_cases.sql
@@ -1,0 +1,26 @@
+-- Обновление структуры таблицы court_cases
+-- Удаляем устаревшие колонки и добавляем массивы объектов и вложений
+
+-- Удаление полей comments и claim_amount
+ALTER TABLE court_cases
+    DROP COLUMN IF EXISTS comments,
+    DROP COLUMN IF EXISTS claim_amount;
+
+-- Поддержка нескольких объектов
+ALTER TABLE court_cases
+    ADD COLUMN IF NOT EXISTS unit_ids integer[] DEFAULT ARRAY[]::integer[];
+
+UPDATE court_cases
+    SET unit_ids = ARRAY[unit_id]
+    WHERE unit_id IS NOT NULL
+      AND (unit_ids IS NULL OR array_length(unit_ids, 1) IS NULL);
+
+ALTER TABLE court_cases DROP COLUMN IF EXISTS unit_id;
+CREATE INDEX IF NOT EXISTS court_cases_unit_ids_idx
+    ON court_cases USING GIN (unit_ids);
+
+-- Связь с таблицей attachments
+ALTER TABLE court_cases
+    ADD COLUMN IF NOT EXISTS attachment_ids integer[] DEFAULT ARRAY[]::integer[];
+CREATE INDEX IF NOT EXISTS court_cases_attachment_ids_idx
+    ON court_cases USING GIN (attachment_ids);

--- a/src/shared/types/courtCase.ts
+++ b/src/shared/types/courtCase.ts
@@ -13,7 +13,8 @@ export type CaseStatus = 'active' | 'won' | 'lost' | 'settled';
 export interface CourtCase {
   id: number;
   project_id: number;
-  unit_id: number | null;
+  /** Идентификаторы объектов проекта */
+  unit_ids: number[];
   date: string;
   number: string;
   plaintiff_id: number;
@@ -23,6 +24,7 @@ export interface CourtCase {
   fix_start_date?: string | null;
   fix_end_date?: string | null;
   description: string;
-  claim_amount?: number | null;
+  /** Ссылки на загруженные файлы */
+  attachment_ids?: number[];
   defects: Defect[];
 }


### PR DESCRIPTION
## Summary
- update DB structure to support `unit_ids` and attachment links
- add SQL migration to modify `court_cases`
- update court case types and page logic for new array field

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*