### PR TITLE
Fix responsible user save in correspondence

### DIFF
--- a/src/entities/correspondence/index.ts
+++ b/src/entities/correspondence/index.ts
@@ -102,6 +102,11 @@ export function useLetters() {
   });
 }
 
+/**
+ * Создать письмо вместе с вложениями и опциональной связью.
+ * Возвращает мутацию React Query, которая после успешного
+ * выполнения инвалидаирует кэш писем и связей.
+ */
 export function useAddLetter() {
   const qc = useQueryClient();
   return useMutation({
@@ -121,7 +126,8 @@ export function useAddLetter() {
         subject: data.subject,
         sender: data.sender,
         receiver: data.receiver,
-        responsible_user_id: data.responsible_user_id,
+        // null в случае отсутствия выбранного сотрудника
+        responsible_user_id: data.responsible_user_id ?? null,
         unit_ids: data.unit_ids,
       };
       const { data: inserted, error } = await supabase

--- a/src/features/correspondence/AddLetterForm.tsx
+++ b/src/features/correspondence/AddLetterForm.tsx
@@ -144,6 +144,7 @@ export default function AddLetterForm({ onSubmit, parentId = null }: AddLetterFo
           <Col span={8}>
             <Form.Item name="responsible_user_id" label="Ответственный">
               <Select
+                showSearch
                 loading={loadingUsers}
                 options={users.map((u) => ({ value: u.id, label: u.name }))}
                 allowClear

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -107,15 +107,13 @@ export default function CorrespondencePage() {
   const handleAdd = (data: AddLetterFormData) => {
     // 'case_id' удалён из всех списков FK!
     const safeData = fixForeignKeys(
-        {
-          ...data,
-          date: data.date ? data.date.toISOString() : dayjs().toISOString(),
-        },
-        [
-          'responsible_user_id',
-          'letter_type_id',
-          'project_id',
-        ]
+      {
+        ...data,
+        // явное приведение undefined/'' к null для корректного сохранения FK
+        responsible_user_id: data.responsible_user_id || null,
+        date: data.date ? data.date.toISOString() : dayjs().toISOString(),
+      },
+      ['responsible_user_id', 'letter_type_id', 'project_id'],
     );
 
     add.mutate(safeData, {

--- a/src/widgets/CorrespondenceTable.tsx
+++ b/src/widgets/CorrespondenceTable.tsx
@@ -175,6 +175,7 @@ export default function CorrespondenceTable({
       dataIndex: 'responsibleName',
       sorter: (a, b) =>
           (a.responsibleName || '').localeCompare(b.responsibleName || ''),
+      render: (name: string) => name || '—',
     },
     {
       title: 'Действия',


### PR DESCRIPTION
## Summary
- ensure responsible user id passed to insert and saved as null when empty
- show responsible user column placeholder
- improve responsible select UX with search
- document `useAddLetter` hook

## Testing
- `npm run lint` *(fails: ESLint config missing)*