### PR TITLE
Refactor attachments handling

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -22,13 +22,6 @@
   },
   {
     "table_name": "attachments",
-    "column_name": "ticket_id",
-    "data_type": "integer",
-    "is_nullable": "YES",
-    "column_default": null
-  },
-  {
-    "table_name": "attachments",
     "column_name": "file_url",
     "data_type": "text",
     "is_nullable": "NO",
@@ -53,20 +46,6 @@
     "column_name": "storage_path",
     "data_type": "text",
     "is_nullable": "NO",
-    "column_default": null
-  },
-  {
-    "table_name": "attachments",
-    "column_name": "is_fix_act",
-    "data_type": "boolean",
-    "is_nullable": "YES",
-    "column_default": "false"
-  },
-  {
-    "table_name": "attachments",
-    "column_name": "letter_id",
-    "data_type": "bigint",
-    "is_nullable": "YES",
     "column_default": null
   },
   {
@@ -438,6 +417,13 @@
     "column_name": "unit_ids",
     "data_type": "ARRAY",
     "is_nullable": "YES",
+  "column_default": "ARRAY[]::integer[]"
+  },
+  {
+    "table_name": "letters",
+    "column_name": "attachment_ids",
+    "data_type": "ARRAY",
+    "is_nullable": "YES",
     "column_default": "ARRAY[]::integer[]"
   },
   {
@@ -754,6 +740,13 @@
     "data_type": "uuid",
     "is_nullable": "YES",
     "column_default": null
+  },
+  {
+    "table_name": "tickets",
+    "column_name": "attachment_ids",
+    "data_type": "ARRAY",
+    "is_nullable": "YES",
+    "column_default": "ARRAY[]::integer[]"
   },
   {
     "table_name": "unit_persons",

--- a/src/entities/attachment.js
+++ b/src/entities/attachment.js
@@ -101,6 +101,61 @@ export async function addCaseAttachments(files, caseId) {
 }
 
 /**
+ * Загружает файлы письма и создаёт записи в таблице attachments
+ * с возвратом созданных строк.
+ * @param {{file: File, type_id: number | null}[]} files
+ * @param {number} projectId
+ */
+export async function addLetterAttachments(files, projectId) {
+    const uploaded = await Promise.all(
+        files.map(({ file }) => uploadLetterAttachment(file, projectId)),
+    );
+
+    const rows = uploaded.map((u, idx) => ({
+        file_url: u.url,
+        file_type: u.type,
+        storage_path: u.path,
+        attachment_type_id: files[idx].type_id ?? null,
+    }));
+
+    const { data, error } = await supabase
+        .from('attachments')
+        .insert(rows)
+        .select('id, storage_path, file_url, file_type, attachment_type_id');
+
+    if (error) throw error;
+    return data ?? [];
+}
+
+/**
+ * Загружает файлы замечания и создаёт записи в таблице attachments
+ * с возвратом созданных строк.
+ * @param {{file: File, type_id: number | null}[]} files
+ * @param {number} projectId
+ * @param {number} ticketId
+ */
+export async function addTicketAttachments(files, projectId, ticketId) {
+    const uploaded = await Promise.all(
+        files.map(({ file }) => uploadAttachment(file, projectId, ticketId)),
+    );
+
+    const rows = uploaded.map((u, idx) => ({
+        file_url: u.url,
+        file_type: u.type,
+        storage_path: u.path,
+        attachment_type_id: files[idx].type_id ?? null,
+    }));
+
+    const { data, error } = await supabase
+        .from('attachments')
+        .insert(rows)
+        .select('id, storage_path, file_url, file_type, attachment_type_id');
+
+    if (error) throw error;
+    return data ?? [];
+}
+
+/**
  * Возвращает вложения по указанным id
  * @param {number[]} ids
  */

--- a/src/shared/types/correspondence.ts
+++ b/src/shared/types/correspondence.ts
@@ -15,6 +15,8 @@ export interface CorrespondenceLetter {
   project_id: number | null;
   /** Объекты проекта */
   unit_ids: number[];
+  /** Идентификаторы вложений */
+  attachment_ids?: number[];
 
 
   /** Номер письма */


### PR DESCRIPTION
## Summary
- drop direct references to letters and tickets in attachments
- store letter attachment ids in `letters.attachment_ids`
- adjust correspondence and ticket logic to use attachment id arrays
- update attachment helpers with bulk upload helpers
- document schema changes

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*