### PR TITLE
Add project select and multi-unit tickets

### DIFF
--- a/sql/20250601_update_tickets.sql
+++ b/sql/20250601_update_tickets.sql
@@ -1,0 +1,13 @@
+-- Обновление структуры таблицы tickets для поддержки нескольких объектов
+ALTER TABLE tickets
+    ADD COLUMN IF NOT EXISTS unit_ids integer[] DEFAULT ARRAY[]::integer[];
+
+UPDATE tickets
+    SET unit_ids = ARRAY[unit_id]
+    WHERE unit_id IS NOT NULL
+      AND (unit_ids IS NULL OR array_length(unit_ids, 1) IS NULL);
+
+ALTER TABLE tickets DROP COLUMN IF EXISTS unit_id;
+
+CREATE INDEX IF NOT EXISTS tickets_unit_ids_idx
+    ON tickets USING GIN (unit_ids);

--- a/src/features/ticket/TicketListDialog.tsx
+++ b/src/features/ticket/TicketListDialog.tsx
@@ -54,7 +54,7 @@ export default function TicketListDialog({
       const { data: t } = await supabase
         .from("tickets")
         .select("id, title, status_id, created_at, project_id")
-        .eq("unit_id", unit.id)
+        .contains("unit_ids", [unit.id])
         .order("created_at", { ascending: false });
       setTickets(t || []);
 

--- a/src/shared/types/ticket.ts
+++ b/src/shared/types/ticket.ts
@@ -1,7 +1,8 @@
 export interface Ticket {
   id: number;
   project_id: number;
-  unit_id: number | null;
+  /** массив ID объектов, к которым относится замечание */
+  unit_ids: number[];
   type_id: number | null;
   status_id: number | null;
   title: string;

--- a/src/widgets/TicketsTable.tsx
+++ b/src/widgets/TicketsTable.tsx
@@ -57,7 +57,7 @@ const applyFilters = (rows, f) =>
     if (f.requestNo && r.customerRequestNo !== f.requestNo) return false;
     if (f.days && days !== Number(f.days)) return false;
     if (f.project && r.projectName !== f.project) return false;
-    if (f.unit && r.unitName !== f.unit) return false;
+    if (f.unit && !r.unitNames.includes(f.unit)) return false;
     if (f.warranty) {
       const want = f.warranty === "yes";
       if (r.isWarranty !== want) return false;
@@ -143,10 +143,10 @@ export default function TicketsTable({ tickets, filters, loading }) {
           (a.createdByName || "").localeCompare(b.createdByName || ""),
       },
       {
-        title: "Объект",
-        dataIndex: "unitName",
+        title: "Объекты",
+        dataIndex: "unitNames",
         width: 160,
-        sorter: (a, b) => a.unitName.localeCompare(b.unitName),
+        sorter: (a, b) => a.unitNames.localeCompare(b.unitNames),
       },
       {
         title: "Статус",


### PR DESCRIPTION
## Summary
- support multiple units in tickets schema
- add SQL migration for ticket unit_ids
- update ticket forms with project field and quick date pins
- adapt tickets table and page for unit names
- adjust ticket entity logic for new unit_ids array

## Testing
- `npx tsc -p tsconfig.json` *(fails: cannot find module typings)*
- `npm run lint` *(fails: ESLint config missing)*