### PR TITLE
Fix ticket attachment upload

### DIFF
--- a/src/entities/attachment.js
+++ b/src/entities/attachment.js
@@ -74,6 +74,16 @@ export function uploadCaseAttachment(file, caseId) {
 }
 
 /**
+ * Загружает файл замечания в хранилище Supabase.
+ * @param {File} file
+ * @param {number} projectId
+ * @param {number} ticketId
+ */
+export function uploadTicketAttachment(file, projectId, ticketId) {
+    return upload(file, `${projectId}/${ticketId}`);
+}
+
+/**
  * Загружает файлы дела и создаёт записи в таблице attachments
  * с возвратом созданных строк.
  * @param {{file: File, type_id: number | null}[]} files
@@ -136,7 +146,7 @@ export async function addLetterAttachments(files, projectId) {
  */
 export async function addTicketAttachments(files, projectId, ticketId) {
     const uploaded = await Promise.all(
-        files.map(({ file }) => uploadAttachment(file, projectId, ticketId)),
+        files.map(({ file }) => uploadTicketAttachment(file, projectId, ticketId)),
     );
 
     const rows = uploaded.map((u, idx) => ({


### PR DESCRIPTION
## Summary
- add missing `uploadTicketAttachment` helper
- use the helper inside `addTicketAttachments`

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_683a01722058832e9973549901e0a7cf