### PR TITLE
Fix undefined forEach in ticket pages

### DIFF
--- a/src/pages/StatsPage/StatsPage.tsx
+++ b/src/pages/StatsPage/StatsPage.tsx
@@ -15,8 +15,8 @@ export default function StatsPage() {
 
   const totalTickets = tickets.length;
   const byStatus = React.useMemo(() => {
-    const m = {};
-    tickets.forEach((t) => {
+    const m: Record<number, number> = {};
+    (tickets ?? []).forEach((t) => {
       m[t.status_id] = (m[t.status_id] || 0) + 1;
     });
     return m;

--- a/src/pages/TicketsPage/TicketsPage.tsx
+++ b/src/pages/TicketsPage/TicketsPage.tsx
@@ -32,8 +32,8 @@ export default function TicketsPage() {
   }, [error, enqueueSnackbar]);
 
   const userMap = useMemo(() => {
-    const map = {};
-    users.forEach((u) => {
+    const map = {} as Record<string, string>;
+    (users ?? []).forEach((u) => {
       map[u.id] = u.name;
     });
     return map;
@@ -41,7 +41,7 @@ export default function TicketsPage() {
 
   const unitMap = useMemo(() => {
     const map = {} as Record<number, string>;
-    units.forEach((u) => {
+    (units ?? []).forEach((u) => {
       map[u.id] = u.name;
     });
     return map;


### PR DESCRIPTION
## Summary
- guard against undefined `users`, `units` and `tickets` when building lookup objects
- prevent runtime errors on `/tickets` and stats pages

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a0691d14c832e9dba9db7d8269d69