### PR TITLE
Fix attachments fetch

### DIFF
--- a/src/entities/ticket.js
+++ b/src/entities/ticket.js
@@ -160,8 +160,7 @@ export function useTickets() {
             );
             let filesMap = {};
             if (allIds.length) {
-                const { data: files, error: fErr } = await getAttachmentsByIds(allIds);
-                if (fErr) throw fErr;
+                const files = await getAttachmentsByIds(allIds);
                 files.forEach((f) => {
                     filesMap[f.id] = {
                         id: f.id,


### PR DESCRIPTION
## Summary
- fix attachments fetch in useTickets to avoid undefined forEach

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npx tsc -p tsconfig.json` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_683a092098e4832eb66153b509403d67