### PR TITLE
Add ticket modal and update attachment path

### DIFF
--- a/src/entities/attachment.js
+++ b/src/entities/attachment.js
@@ -80,7 +80,8 @@ export function uploadCaseAttachment(file, caseId) {
  * @param {number} ticketId
  */
 export function uploadTicketAttachment(file, projectId, ticketId) {
-    return upload(file, `${projectId}/${ticketId}`);
+    // Файлы замечания храним в каталоге `tickets/<ticketId>` вне зависимости от проекта
+    return upload(file, `tickets/${ticketId}`);
 }
 
 /**

--- a/src/entities/ticket.js
+++ b/src/entities/ticket.js
@@ -57,7 +57,8 @@ export const slugify = (str) =>
 
 export async function uploadAttachment(file, projectId, ticketId) {
     const safe = slugify(file.name);
-    const path = `${projectId}/${ticketId}/${Date.now()}_${safe}`;
+    // При загрузке замечаний файлы помещаем в папку tickets/<id>
+    const path = `tickets/${ticketId}/${Date.now()}_${safe}`;
 
     const { error } = await supabase
         .storage.from(ATTACH_BUCKET)

--- a/src/features/ticket/TicketViewModal.tsx
+++ b/src/features/ticket/TicketViewModal.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Modal } from 'antd';
+import TicketForm from './TicketForm';
+
+interface Props {
+  open: boolean;
+  ticketId: string | number | null;
+  onClose: () => void;
+}
+
+export default function TicketViewModal({ open, ticketId, onClose }: Props) {
+  if (!ticketId) return null;
+  return (
+    <Modal open={open} onCancel={onClose} footer={null} width="80%">
+      <TicketForm embedded ticketId={String(ticketId)} onCancel={onClose} onCreated={onClose} />
+    </Modal>
+  );
+}
+

--- a/src/pages/TicketsPage/TicketsPage.tsx
+++ b/src/pages/TicketsPage/TicketsPage.tsx
@@ -13,6 +13,7 @@ import { useUnitsByIds } from "@/entities/unit";
 import TicketsTable from "@/widgets/TicketsTable";
 import TicketsFilters from "@/widgets/TicketsFilters";
 import TicketFormAntd from "@/features/ticket/TicketFormAntd";
+import TicketViewModal from "@/features/ticket/TicketViewModal";
 
 export default function TicketsPage() {
   const { enqueueSnackbar } = useSnackbar();
@@ -25,6 +26,7 @@ export default function TicketsPage() {
   const { data: units = [] } = useUnitsByIds(unitIds);
   const qc = useQueryClient();
   const [filters, setFilters] = useState({});
+  const [viewId, setViewId] = useState<number | null>(null);
 
   /* toast api-ошибки */
   React.useEffect(() => {
@@ -99,9 +101,15 @@ export default function TicketsPage() {
               tickets={ticketsWithNames}
               filters={filters}
               loading={isLoading}
+              onView={(id) => setViewId(id)}
             />
           )}
         </Card>
+        <TicketViewModal
+          open={viewId !== null}
+          ticketId={viewId}
+          onClose={() => setViewId(null)}
+        />
       </>
     </ConfigProvider>
   );

--- a/src/widgets/TicketsTable.tsx
+++ b/src/widgets/TicketsTable.tsx
@@ -14,12 +14,11 @@ import {
 } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import {
-  EditOutlined,
+  EyeOutlined,
   DeleteOutlined,
   CheckCircleTwoTone,
   CloseCircleTwoTone,
 } from "@ant-design/icons";
-import { useNavigate } from "react-router-dom";
 
 import { useDeleteTicket } from "@/entities/ticket";
 
@@ -76,8 +75,7 @@ const applyFilters = (rows, f) =>
  * @param {Object} filters - активные фильтры
  * @param {boolean} loading - индикатор загрузки
  */
-export default function TicketsTable({ tickets, filters, loading }) {
-  const navigate = useNavigate();
+export default function TicketsTable({ tickets, filters, loading, onView }) {
   const { mutateAsync: remove, isPending } = useDeleteTicket();
 
   const columns: ColumnsType<any> = useMemo(
@@ -200,12 +198,12 @@ export default function TicketsTable({ tickets, filters, loading }) {
         width: 100,
         render: (_, record) => (
           <Space size="middle">
-            <Tooltip title="Редактировать">
+            <Tooltip title="Просмотр">
               <Button
                 size="small"
                 type="text"
-                icon={<EditOutlined />}
-                onClick={() => navigate(`/tickets/${record.id}/edit`)}
+                icon={<EyeOutlined />}
+                onClick={() => onView && onView(record.id)}
               />
             </Tooltip>
             <Popconfirm
@@ -231,7 +229,7 @@ export default function TicketsTable({ tickets, filters, loading }) {
       },
     ],
 
-    [navigate, remove, isPending],
+    [onView, remove, isPending],
   );
 
   const dataSource = useMemo(


### PR DESCRIPTION
## Summary
- store ticket attachments in `tickets/<ticketId>` directory of the attachments bucket
- provide modal view for editing a ticket from the `/tickets` table
- show 'Просмотр' and 'Удалить' actions in tickets table

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_683a0c392f58832e9ec70b91f1c61212