### PR TITLE
Add editable TicketForm

### DIFF
--- a/src/features/ticket/TicketForm.tsx
+++ b/src/features/ticket/TicketForm.tsx
@@ -1,0 +1,418 @@
+import React, { useEffect, useState } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import {
+  Stack,
+  TextField,
+  Select,
+  MenuItem,
+  FormControlLabel,
+  Switch,
+  Button,
+  CircularProgress,
+  DialogActions,
+  Typography,
+  Box,
+  IconButton,
+} from '@mui/material';
+import DeleteIcon from '@mui/icons-material/DeleteOutline';
+import { DatePicker } from '@mui/x-date-pickers';
+import dayjs, { Dayjs } from 'dayjs';
+
+import { useTicketTypes } from '@/entities/ticketType';
+import { useTicketStatuses } from '@/entities/ticketStatus';
+import { useUnitsByProject } from '@/entities/unit';
+import { useUsers } from '@/entities/user';
+import { useProjects } from '@/entities/project';
+import { useCreateTicket, useTicket } from '@/entities/ticket';
+import { useProjectId } from '@/shared/hooks/useProjectId';
+import FileDropZone from '@/shared/ui/FileDropZone';
+import type { Ticket } from '@/shared/types/ticket';
+
+interface Attachment {
+  id: string;
+  name: string;
+  path: string;
+  url: string;
+  type: string;
+}
+
+interface TicketFormProps {
+  ticketId?: string;
+  onCreated?: () => void;
+  onCancel?: () => void;
+  embedded?: boolean;
+}
+
+interface TicketFormValues {
+  project_id: number | null;
+  unit_ids: number[];
+  responsible_engineer_id: string | null;
+  status_id: number | null;
+  type_id: number | null;
+  is_warranty: boolean;
+  customer_request_no: string;
+  customer_request_date: Dayjs | null;
+  received_at: Dayjs | null;
+  fixed_at: Dayjs | null;
+  title: string;
+  description: string;
+}
+
+/**
+ * Форма просмотра и редактирования замечания.
+ * При отсутствии ticketId создаёт новое замечание.
+ */
+export default function TicketForm({
+  ticketId,
+  onCreated,
+  onCancel,
+  embedded = false,
+}: TicketFormProps) {
+  const globalProjectId = useProjectId();
+  const {
+    control,
+    handleSubmit,
+    reset,
+    setValue,
+    watch,
+    formState: { isSubmitting },
+  } = useForm<TicketFormValues>({
+    defaultValues: {
+      project_id: globalProjectId ?? null,
+      unit_ids: [],
+      responsible_engineer_id: null,
+      status_id: null,
+      type_id: null,
+      is_warranty: false,
+      customer_request_no: '',
+      customer_request_date: null,
+      received_at: null,
+      fixed_at: null,
+      title: '',
+      description: '',
+    },
+  });
+
+  const { data: projects = [] } = useProjects();
+  const { data: types = [] } = useTicketTypes();
+  const { data: statuses = [] } = useTicketStatuses();
+  const { data: users = [] } = useUsers();
+  const projectIdWatch = watch('project_id') ?? globalProjectId;
+  const { data: units = [] } = useUnitsByProject(projectIdWatch);
+
+  const create = useCreateTicket();
+  const { data: ticket, updateAsync } = useTicket(ticketId);
+
+  const [remoteFiles, setRemoteFiles] = useState<Attachment[]>([]);
+  const [newFiles, setNewFiles] = useState<File[]>([]);
+  const [removedIds, setRemovedIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (ticket) {
+      reset({
+        project_id: ticket.projectId,
+        unit_ids: ticket.unitIds,
+        responsible_engineer_id: ticket.responsibleEngineerId,
+        status_id: ticket.statusId,
+        type_id: ticket.typeId,
+        is_warranty: ticket.isWarranty,
+        customer_request_no: ticket.customerRequestNo || '',
+        customer_request_date: ticket.customerRequestDate,
+        received_at: ticket.receivedAt,
+        fixed_at: ticket.fixedAt,
+        title: ticket.title,
+        description: ticket.description || '',
+      });
+      setRemoteFiles(ticket.attachments || []);
+    }
+  }, [ticket, reset]);
+
+  const addFiles = (files: File[]) =>
+    setNewFiles((p) => [...p, ...files]);
+  const removeNew = (idx: number) =>
+    setNewFiles((p) => p.filter((_, i) => i !== idx));
+  const removeRemote = (id: string) => {
+    setRemoteFiles((p) => p.filter((f) => String(f.id) !== String(id)));
+    setRemovedIds((p) => [...p, id]);
+  };
+
+  const submit = async (values: TicketFormValues) => {
+    const payload = {
+      project_id: values.project_id ?? globalProjectId,
+      unit_ids: values.unit_ids,
+      type_id: values.type_id,
+      status_id: values.status_id,
+      title: values.title,
+      description: values.description || null,
+      customer_request_no: values.customer_request_no || null,
+      customer_request_date: values.customer_request_date
+        ? values.customer_request_date.format('YYYY-MM-DD')
+        : null,
+      responsible_engineer_id: values.responsible_engineer_id ?? null,
+      is_warranty: values.is_warranty,
+      received_at: values.received_at
+        ? values.received_at.format('YYYY-MM-DD')
+        : dayjs().format('YYYY-MM-DD'),
+      fixed_at: values.fixed_at ? values.fixed_at.format('YYYY-MM-DD') : null,
+    };
+
+    if (ticketId) {
+      await updateAsync({
+        id: Number(ticketId),
+        updates: payload,
+        newAttachments: newFiles,
+        removedAttachmentIds: removedIds,
+      });
+      onCreated?.();
+    } else {
+      await create.mutateAsync({
+        ...(payload as Ticket),
+        attachments: newFiles.map((f) => ({ file: f, type_id: null })),
+      } as any);
+      onCreated?.();
+      reset();
+      setNewFiles([]);
+      setRemoteFiles([]);
+      setRemovedIds([]);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(submit)} noValidate>
+      <Stack spacing={2} sx={{ maxWidth: embedded ? 'none' : 640 }}>
+        <Controller
+          name="project_id"
+          control={control}
+          render={({ field }) => (
+            <Select {...field} fullWidth displayEmpty>
+              <MenuItem value="">
+                <em>Не выбрано</em>
+              </MenuItem>
+              {projects.map((p) => (
+                <MenuItem key={p.id} value={p.id}>
+                  {p.name}
+                </MenuItem>
+              ))}
+            </Select>
+          )}
+        />
+        <Controller
+          name="unit_ids"
+          control={control}
+          render={({ field }) => (
+            <Select
+              {...field}
+              multiple
+              fullWidth
+              value={field.value}
+              onChange={(e) =>
+                field.onChange(
+                  typeof e.target.value === 'string'
+                    ? e.target.value.split(',').map(Number)
+                    : e.target.value,
+                )
+              }
+            >
+              {units.map((u) => (
+                <MenuItem key={u.id} value={u.id}>
+                  {u.name}
+                </MenuItem>
+              ))}
+            </Select>
+          )}
+        />
+        <Controller
+          name="responsible_engineer_id"
+          control={control}
+          render={({ field }) => (
+            <Select {...field} fullWidth displayEmpty>
+              <MenuItem value="">
+                <em>Не указано</em>
+              </MenuItem>
+              {users.map((u) => (
+                <MenuItem key={u.id} value={u.id}>
+                  {u.name}
+                </MenuItem>
+              ))}
+            </Select>
+          )}
+        />
+        <Controller
+          name="status_id"
+          control={control}
+          rules={{ required: true }}
+          render={({ field, fieldState }) => (
+            <Select {...field} fullWidth error={!!fieldState.error} displayEmpty>
+              <MenuItem value="">
+                <em>Статус не выбран</em>
+              </MenuItem>
+              {statuses.map((s) => (
+                <MenuItem key={s.id} value={s.id}>
+                  {s.name}
+                </MenuItem>
+              ))}
+            </Select>
+          )}
+        />
+        <Controller
+          name="type_id"
+          control={control}
+          rules={{ required: true }}
+          render={({ field, fieldState }) => (
+            <Select {...field} fullWidth error={!!fieldState.error} displayEmpty>
+              <MenuItem value="">
+                <em>Тип не выбран</em>
+              </MenuItem>
+              {types.map((t) => (
+                <MenuItem key={t.id} value={t.id}>
+                  {t.name}
+                </MenuItem>
+              ))}
+            </Select>
+          )}
+        />
+        <Controller
+          name="is_warranty"
+          control={control}
+          render={({ field }) => (
+            <FormControlLabel
+              control={<Switch {...field} checked={field.value} />}
+              label="Гарантийный случай"
+            />
+          )}
+        />
+        <Controller
+          name="customer_request_no"
+          control={control}
+          render={({ field }) => (
+            <TextField {...field} label="№ заявки" fullWidth />
+          )}
+        />
+        <Controller
+          name="customer_request_date"
+          control={control}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              format="DD.MM.YYYY"
+              value={field.value}
+              onChange={(d) => field.onChange(d)}
+              slotProps={{ textField: { fullWidth: true, label: 'Дата заявки' } }}
+            />
+          )}
+        />
+        <Controller
+          name="received_at"
+          control={control}
+          rules={{ required: true }}
+          render={({ field, fieldState }) => (
+            <DatePicker
+              {...field}
+              format="DD.MM.YYYY"
+              value={field.value}
+              onChange={(d) => field.onChange(d)}
+              slotProps={{
+                textField: {
+                  fullWidth: true,
+                  label: 'Дата получения',
+                  required: true,
+                  error: !!fieldState.error,
+                },
+              }}
+            />
+          )}
+        />
+        <Controller
+          name="fixed_at"
+          control={control}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              format="DD.MM.YYYY"
+              value={field.value}
+              onChange={(d) => field.onChange(d)}
+              slotProps={{ textField: { fullWidth: true, label: 'Дата устранения' } }}
+            />
+          )}
+        />
+        <Box>
+          {[10, 45, 60].map((d) => (
+            <Button
+              key={d}
+              size="small"
+              sx={{ mr: 1, mb: 1 }}
+              onClick={() => {
+                const rec = control.getValues('received_at');
+                if (rec) setValue('fixed_at', dayjs(rec).add(d, 'day'));
+              }}
+            >
+              +{d} дней
+            </Button>
+          ))}
+        </Box>
+        <Controller
+          name="title"
+          control={control}
+          rules={{ required: true }}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              label="Краткое описание"
+              fullWidth
+              required
+              error={!!fieldState.error}
+            />
+          )}
+        />
+        <Controller
+          name="description"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              {...field}
+              label="Подробное описание"
+              fullWidth
+              multiline
+              rows={3}
+            />
+          )}
+        />
+        <Box>
+          <Typography variant="subtitle1" sx={{ mb: 1 }}>
+            Файлы
+          </Typography>
+          {remoteFiles.map((f) => (
+            <Box key={f.id} sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+              <Typography sx={{ flexGrow: 1 }}>{f.name}</Typography>
+              <IconButton onClick={() => removeRemote(String(f.id))}>
+                <DeleteIcon />
+              </IconButton>
+            </Box>
+          ))}
+          {newFiles.map((f, i) => (
+            <Box key={i} sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+              <Typography sx={{ flexGrow: 1 }}>{f.name}</Typography>
+              <IconButton onClick={() => removeNew(i)}>
+                <DeleteIcon />
+              </IconButton>
+            </Box>
+          ))}
+          <FileDropZone onFiles={addFiles} />
+        </Box>
+        <DialogActions sx={{ px: 0 }}>
+          <Button variant="text" onClick={onCancel} disabled={isSubmitting}>
+            Отмена
+          </Button>
+          <Button
+            type="submit"
+            variant="contained"
+            disabled={isSubmitting}
+            startIcon={isSubmitting && <CircularProgress size={18} />}
+          >
+            Сохранить
+          </Button>
+        </DialogActions>
+      </Stack>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add `TicketForm.tsx` to display and edit tickets
- show all ticket fields similar to `CourtCaseForm`

## Testing
- `npm run lint` *(fails: ESLint config not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_683a1d11ae38832e96244b0339938393