### PR TITLE
Fix MUI date pickers

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,14 +5,22 @@ import { BrowserRouter } from "react-router-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { queryClient } from "@/shared/config/queryClient";
+import { LocalizationProvider } from "@mui/x-date-pickers";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import dayjs from "dayjs";
+import "dayjs/locale/ru";
+
+dayjs.locale("ru");
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-      <ReactQueryDevtools initialIsOpen={false} />
-    </QueryClientProvider>
+    <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="ru">
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+        <ReactQueryDevtools initialIsOpen={false} />
+      </QueryClientProvider>
+    </LocalizationProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- add `LocalizationProvider` to root render for `@mui/x-date-pickers`
- configure dayjs with Russian locale

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_683a85694518832e8ed9348a43f382cb