### PR TITLE
Add original file name support

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -36,6 +36,13 @@
   },
   {
     "table_name": "attachments",
+    "column_name": "original_name",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": null
+  },
+  {
+    "table_name": "attachments",
     "column_name": "uploaded_at",
     "data_type": "timestamp with time zone",
     "is_nullable": "YES",

--- a/src/entities/attachment.js
+++ b/src/entities/attachment.js
@@ -98,6 +98,7 @@ export async function addCaseAttachments(files, caseId) {
     const rows = uploaded.map((u, idx) => ({
         file_url: u.url,
         file_type: u.type,
+        original_name: files[idx].file.name,
         storage_path: u.path,
         attachment_type_id: files[idx].type_id ?? null,
     }));
@@ -105,7 +106,7 @@ export async function addCaseAttachments(files, caseId) {
     const { data, error } = await supabase
         .from('attachments')
         .insert(rows)
-        .select('id, storage_path, file_url, file_type, attachment_type_id');
+        .select('id, storage_path, file_url, file_type, attachment_type_id, original_name');
 
     if (error) throw error;
     return data ?? [];
@@ -125,6 +126,7 @@ export async function addLetterAttachments(files, projectId) {
     const rows = uploaded.map((u, idx) => ({
         file_url: u.url,
         file_type: u.type,
+        original_name: files[idx].file.name,
         storage_path: u.path,
         attachment_type_id: files[idx].type_id ?? null,
     }));
@@ -132,7 +134,7 @@ export async function addLetterAttachments(files, projectId) {
     const { data, error } = await supabase
         .from('attachments')
         .insert(rows)
-        .select('id, storage_path, file_url, file_type, attachment_type_id');
+        .select('id, storage_path, file_url, file_type, attachment_type_id, original_name');
 
     if (error) throw error;
     return data ?? [];
@@ -153,6 +155,7 @@ export async function addTicketAttachments(files, projectId, ticketId) {
     const rows = uploaded.map((u, idx) => ({
         file_url: u.url,
         file_type: u.type,
+        original_name: files[idx].file.name,
         storage_path: u.path,
         attachment_type_id: files[idx].type_id ?? null,
     }));
@@ -160,7 +163,7 @@ export async function addTicketAttachments(files, projectId, ticketId) {
     const { data, error } = await supabase
         .from('attachments')
         .insert(rows)
-        .select('id, storage_path, file_url, file_type, attachment_type_id');
+        .select('id, storage_path, file_url, file_type, attachment_type_id, original_name');
 
     if (error) throw error;
     return data ?? [];
@@ -174,7 +177,7 @@ export async function getAttachmentsByIds(ids) {
     if (!ids.length) return [];
     const { data, error } = await supabase
         .from('attachments')
-        .select('id, storage_path, file_url, file_type, attachment_type_id')
+        .select('id, storage_path, file_url, file_type, attachment_type_id, original_name')
         .in('id', ids);
 
     if (error) throw error;

--- a/src/entities/ticket.js
+++ b/src/entities/ticket.js
@@ -120,13 +120,15 @@ function mapTicket(r) {
   const atts = Array.isArray(r.attachments) ? r.attachments : [];
 
   const attachments = atts.map((a) => {
-    let name = a.storage_path;
-    try {
-      name = decodeURIComponent(
-        a.storage_path.split("/").pop()?.replace(/^\d+_/, "") || a.storage_path,
-      );
-    } catch {
-      /* ignore */
+    let name = a.original_name;
+    if (!name) {
+      try {
+        name = decodeURIComponent(
+          a.storage_path.split("/").pop()?.replace(/^\d+_/, "") || a.storage_path,
+        );
+      } catch {
+        name = a.storage_path;
+      }
     }
     return {
       id: a.id,
@@ -200,7 +202,18 @@ export function useTickets() {
           filesMap[f.id] = {
             id: f.id,
             path: f.storage_path,
-            name: f.storage_path.split("/").pop() || f.storage_path,
+            name:
+              f.original_name ||
+              (() => {
+                try {
+                  return decodeURIComponent(
+                    f.storage_path.split("/").pop()?.replace(/^\d+_/, "") ||
+                      f.storage_path,
+                  );
+                } catch {
+                  return f.storage_path;
+                }
+              })(),
             url: f.file_url,
             type: f.file_type,
             attachment_type_id: f.attachment_type_id ?? null,
@@ -322,7 +335,18 @@ export function useTicket(ticketId) {
         atts = files.map((f) => ({
           id: f.id,
           path: f.storage_path,
-          name: f.storage_path.split("/").pop() || f.storage_path,
+          name:
+            f.original_name ||
+            (() => {
+              try {
+                return decodeURIComponent(
+                  f.storage_path.split("/").pop()?.replace(/^\d+_/, "") ||
+                    f.storage_path,
+                );
+              } catch {
+                return f.storage_path;
+              }
+            })(),
           url: f.file_url,
           type: f.file_type,
           attachment_type_id: f.attachment_type_id ?? null,

--- a/src/features/ticket/TicketListDialog.tsx
+++ b/src/features/ticket/TicketListDialog.tsx
@@ -139,11 +139,11 @@ export default function TicketListDialog({
   const handleDownload = async (a) => {
     try {
       setDownloadingId(a.id);
-      const filename = a.storage_path.split("/").pop() || "attachment";
+      const filename = a.original_name || a.storage_path.split("/").pop() || "attachment";
       const url = await signedUrl(a.storage_path, filename);
       const link = document.createElement("a");
       link.href = url;
-      link.download = filename;
+          link.download = filename;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
@@ -240,7 +240,7 @@ export default function TicketListDialog({
                                 downloadingId === a.id ? (
                                   <CircularProgress size={16} />
                                 ) : (
-                                  a.storage_path.split('/').pop() || 'file'
+                                  a.original_name || a.storage_path.split('/').pop() || 'file'
                                 )
                               }
                               size="small"

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -874,7 +874,18 @@ function CaseFilesTab({ caseData }: CaseFilesTabProps) {
       const data = await getAttachmentsByIds(caseData.attachment_ids || []);
       const arr = data.map((a) => ({
         id: a.id,
-        name: a.storage_path.split('/').pop() || a.storage_path,
+        name:
+          a.original_name ||
+          (() => {
+            try {
+              return decodeURIComponent(
+                a.storage_path.split('/').pop()?.replace(/^\d+_/, '') ||
+                  a.storage_path,
+              );
+            } catch {
+              return a.storage_path;
+            }
+          })(),
         path: a.storage_path,
         url: a.file_url,
         type_id: a.attachment_type_id,
@@ -908,7 +919,18 @@ function CaseFilesTab({ caseData }: CaseFilesTabProps) {
       });
       const newFiles = attachments.map((a) => ({
         id: a.id,
-        name: a.storage_path.split('/').pop() || a.storage_path,
+        name:
+          a.original_name ||
+          (() => {
+            try {
+              return decodeURIComponent(
+                a.storage_path.split('/').pop()?.replace(/^\d+_/, '') ||
+                  a.storage_path,
+              );
+            } catch {
+              return a.storage_path;
+            }
+          })(),
         path: a.storage_path,
         url: a.file_url,
         type_id: a.attachment_type_id,


### PR DESCRIPTION
## Summary
- store original file name in `attachments`
- show original names for ticket attachments
- show original names for court case attachments
- pass original name through correspondence features

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_683b3085f6f0832eb1442169313d0331