### PR TITLE
Fix attachment display in TicketForm

### DIFF
--- a/src/features/ticket/TicketForm.tsx
+++ b/src/features/ticket/TicketForm.tsx
@@ -483,8 +483,14 @@ export default function TicketForm({
               name: f.name,
               path: f.path,
               typeId: changedTypes[f.id] ?? f.attachment_type_id,
+              typeName: f.attachment_type_name,
+              mime: f.type,
             }))}
-            newFiles={newFiles.map((f) => ({ file: f.file, typeId: f.type_id }))}
+            newFiles={newFiles.map((f) => ({
+              file: f.file,
+              typeId: f.type_id,
+              mime: f.file.type,
+            }))}
             attachmentTypes={attachmentTypes}
             onRemoveRemote={(id) => removeRemote(String(id))}
             onRemoveNew={removeNew}

--- a/src/shared/ui/AttachmentEditorTable.tsx
+++ b/src/shared/ui/AttachmentEditorTable.tsx
@@ -21,11 +21,16 @@ interface RemoteFile {
   name: string;
   path: string;
   typeId: number | null;
+  /** Имя типа из attachments_types */
+  typeName?: string;
+  /** MIME-тип файла */
+  mime?: string;
 }
 
 interface NewFile {
   file: File;
   typeId: number | null;
+  mime?: string;
 }
 
 interface Props {
@@ -116,6 +121,12 @@ export default function AttachmentEditorTable({
                   </MenuItem>
                 ))}
               </Select>
+              {f.typeName && (
+                <span style={{ marginLeft: 8, fontSize: '0.8em' }}>{f.typeName}</span>
+              )}
+              {f.mime && !f.typeName && (
+                <span style={{ marginLeft: 8, fontSize: '0.8em' }}>{f.mime}</span>
+              )}
             </TableCell>
             <TableCell align="right">
               <Tooltip title="Скачать">
@@ -159,6 +170,9 @@ export default function AttachmentEditorTable({
                   </MenuItem>
                 ))}
               </Select>
+              {f.mime && (
+                <span style={{ marginLeft: 8, fontSize: '0.8em' }}>{f.mime}</span>
+              )}
             </TableCell>
             <TableCell align="right">
               <Tooltip title="Скачать">


### PR DESCRIPTION
## Summary
- improve AttachmentEditorTable to display type name and MIME
- pass attachment type info to AttachmentEditorTable

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_683b417681a0832e88a8184bf43e277a