### PR TITLE
Fix attachment type duplication in TicketForm

### DIFF
--- a/src/shared/ui/AttachmentEditorTable.tsx
+++ b/src/shared/ui/AttachmentEditorTable.tsx
@@ -121,11 +121,14 @@ export default function AttachmentEditorTable({
                   </MenuItem>
                 ))}
               </Select>
-              {f.typeName && (
-                <span style={{ marginLeft: 8, fontSize: '0.8em' }}>{f.typeName}</span>
-              )}
-              {f.mime && !f.typeName && (
-                <span style={{ marginLeft: 8, fontSize: '0.8em' }}>{f.mime}</span>
+              {!onChangeRemoteType && (
+                f.typeName ? (
+                  <span style={{ marginLeft: 8, fontSize: '0.8em' }}>{f.typeName}</span>
+                ) : (
+                  f.mime && (
+                    <span style={{ marginLeft: 8, fontSize: '0.8em' }}>{f.mime}</span>
+                  )
+                )
               )}
             </TableCell>
             <TableCell align="right">
@@ -170,9 +173,10 @@ export default function AttachmentEditorTable({
                   </MenuItem>
                 ))}
               </Select>
-              {f.mime && (
-                <span style={{ marginLeft: 8, fontSize: '0.8em' }}>{f.mime}</span>
-              )}
+              {!onChangeNewType &&
+                f.mime && (
+                  <span style={{ marginLeft: 8, fontSize: '0.8em' }}>{f.mime}</span>
+                )}
             </TableCell>
             <TableCell align="right">
               <Tooltip title="Скачать">


### PR DESCRIPTION
## Summary
- avoid showing file type label twice in `AttachmentEditorTable`

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_683b48e8b808832e88fa8a27d397dd20