### PR TITLE
Implement multi-object filter and remove clearing options

### DIFF
--- a/src/features/ticket/TicketForm.tsx
+++ b/src/features/ticket/TicketForm.tsx
@@ -112,6 +112,8 @@ export default function TicketForm({
 
   const create = useCreateTicket();
   const { data: ticket, updateAsync } = useTicket(ticketId);
+  /** Форма открыта для редактирования существующего замечания */
+  const isEdit = Boolean(ticketId);
 
   const [remoteFiles, setRemoteFiles] = useState<Attachment[]>([]);
   const [changedTypes, setChangedTypes] = useState<Record<string, number | null>>({});
@@ -232,9 +234,11 @@ export default function TicketForm({
                   )
                 }
               >
-                <MenuItem value="">
-                  <em>Не выбрано</em>
-                </MenuItem>
+                {!isEdit && (
+                  <MenuItem value="">
+                    <em>Не выбрано</em>
+                  </MenuItem>
+                )}
                 {projects.map((p) => (
                   <MenuItem key={p.id} value={p.id}>
                     {p.name}
@@ -289,9 +293,11 @@ export default function TicketForm({
                   field.onChange(e.target.value === "" ? null : e.target.value)
                 }
               >
-                <MenuItem value="">
-                  <em>Не указано</em>
-                </MenuItem>
+                {!isEdit && (
+                  <MenuItem value="">
+                    <em>Не указано</em>
+                  </MenuItem>
+                )}
                 {users.map((u) => (
                   <MenuItem key={u.id} value={u.id}>
                     {u.name}
@@ -320,9 +326,11 @@ export default function TicketForm({
                   )
                 }
               >
-                <MenuItem value="">
-                  <em>Статус не выбран</em>
-                </MenuItem>
+                {!isEdit && (
+                  <MenuItem value="">
+                    <em>Статус не выбран</em>
+                  </MenuItem>
+                )}
                 {statuses.map((s) => (
                   <MenuItem key={s.id} value={s.id}>
                     {s.name}
@@ -351,9 +359,11 @@ export default function TicketForm({
                   )
                 }
               >
-                <MenuItem value="">
-                  <em>Тип не выбран</em>
-                </MenuItem>
+                {!isEdit && (
+                  <MenuItem value="">
+                    <em>Тип не выбран</em>
+                  </MenuItem>
+                )}
                 {types.map((t) => (
                   <MenuItem key={t.id} value={t.id}>
                     {t.name}

--- a/src/widgets/TicketsFilters.tsx
+++ b/src/widgets/TicketsFilters.tsx
@@ -6,6 +6,12 @@ import { Form, DatePicker, Select, Input, Button } from "antd";
 const { RangePicker } = DatePicker;
 const { Option } = Select;
 
+/**
+ * Фильтры таблицы замечаний.
+ * @param options списки для Select
+ * @param onChange callback, возвращающий значения формы
+ */
+
 export default function TicketsFilters({ options, onChange }) {
   const [form] = Form.useForm();
 
@@ -42,8 +48,8 @@ export default function TicketsFilters({ options, onChange }) {
       <Form.Item name="project" label="Проект">
         <Select allowClear options={options.projects} />
       </Form.Item>
-      <Form.Item name="unit" label="Объект">
-        <Select allowClear options={options.units} />
+      <Form.Item name="units" label="Объекты">
+        <Select mode="multiple" allowClear options={options.units} />
       </Form.Item>
       <Form.Item name="warranty" label="Гарантия">
         <Select allowClear>

--- a/src/widgets/TicketsTable.tsx
+++ b/src/widgets/TicketsTable.tsx
@@ -54,7 +54,11 @@ const applyFilters = (rows, f) =>
     }
     if (f.requestNo && r.customerRequestNo !== f.requestNo) return false;
     if (f.project && r.projectName !== f.project) return false;
-    if (f.unit && !r.unitNames.includes(f.unit)) return false;
+    if (Array.isArray(f.units) && f.units.length > 0) {
+      const rowUnits = r.unitNames.split(',').map((u) => u.trim());
+      const hasMatch = f.units.some((u) => rowUnits.includes(u));
+      if (!hasMatch) return false;
+    }
     if (f.warranty) {
       const want = f.warranty === "yes";
       if (r.isWarranty !== want) return false;


### PR DESCRIPTION
## Summary
- allow selecting multiple units in ticket filters
- prevent clearing select fields when editing a ticket

## Testing
- `npm run lint` *(fails: ESLint configuration not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b4a0a0a28832e8f3c88330d4a5a60