### PR TITLE
Auto-save TicketForm

### DIFF
--- a/src/shared/hooks/useDebouncedEffect.ts
+++ b/src/shared/hooks/useDebouncedEffect.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+/**
+ * Вызывает эффект с задержкой, сбрасывая таймер при изменении зависимостей.
+ * @param effect Функция-эффект
+ * @param deps Массив зависимостей
+ * @param delay Задержка в мс
+ */
+export const useDebouncedEffect = (
+  effect: () => void,
+  deps: React.DependencyList,
+  delay: number,
+) => {
+  useEffect(() => {
+    const id = setTimeout(effect, delay);
+    return () => clearTimeout(id);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...deps, delay]);
+};


### PR DESCRIPTION
## Summary
- add debounced effect hook
- auto-save ticket fields on change
- hide save button when editing

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b4c7efea8832ea814d7cfd6011fae