### PR TITLE
Add ticket status change in table

### DIFF
--- a/src/features/ticket/TicketStatusSelect.tsx
+++ b/src/features/ticket/TicketStatusSelect.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Select } from "antd";
+import { useTicketStatuses } from "@/entities/ticketStatus";
+import { useUpdateTicketStatus } from "@/entities/ticket";
+
+interface TicketStatusSelectProps {
+  ticketId: number;
+  statusId: number | null;
+}
+
+/**
+ * Выпадающий список для смены статуса замечания напрямую из таблицы.
+ */
+export default function TicketStatusSelect({ ticketId, statusId }: TicketStatusSelectProps) {
+  const { data: statuses = [] } = useTicketStatuses();
+  const update = useUpdateTicketStatus();
+
+  const handleChange = (value: number) => {
+    update.mutate({ id: ticketId, statusId: value });
+  };
+
+  return (
+    <Select
+      size="small"
+      value={statusId ?? undefined}
+      onChange={handleChange}
+      loading={update.isPending}
+      options={statuses.map((s) => ({ label: s.name, value: s.id }))}
+      style={{ width: "100%" }}
+    />
+  );
+}

--- a/src/widgets/TicketsTable.tsx
+++ b/src/widgets/TicketsTable.tsx
@@ -21,6 +21,7 @@ import {
 } from "@ant-design/icons";
 
 import { useDeleteTicket } from "@/entities/ticket";
+import TicketStatusSelect from "@/features/ticket/TicketStatusSelect";
 
 /** Форматирование даты */
 const fmt = (d, withTime = false) =>
@@ -111,10 +112,12 @@ export default function TicketsTable({ tickets, filters, loading, onView }) {
       },
       {
         title: "Статус",
-        dataIndex: "statusName",
-        width: 140,
+        dataIndex: "statusId",
+        width: 160,
         sorter: (a, b) => a.statusName.localeCompare(b.statusName),
-        render: (_, row) => <Tag color={row.statusColor || "default"}>{row.statusName}</Tag>,
+        render: (_, row) => (
+          <TicketStatusSelect ticketId={row.id} statusId={row.statusId} />
+        ),
       },
       {
         title: "Тип замечания",


### PR DESCRIPTION
## Summary
- allow updating ticket status inline
- add dropdown component with mutation

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_683b511406c4832ea2b47d93deefa505