### PR TITLE
Add defect deadlines admin feature

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -818,4 +818,32 @@
     "is_nullable": "YES",
     "column_default": null
   }
+  {
+    "table_name": "defect_deadlines",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('defect_deadlines_id_seq'::regclass)"
+  },
+  {
+    "table_name": "defect_deadlines",
+    "column_name": "project_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": null
+  },
+  {
+    "table_name": "defect_deadlines",
+    "column_name": "ticket_type_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": null
+  },
+  {
+    "table_name": "defect_deadlines",
+    "column_name": "fix_days",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": null
+  }
 ]

--- a/src/entities/defectDeadline.js
+++ b/src/entities/defectDeadline.js
@@ -1,0 +1,68 @@
+import { supabase } from '@/shared/api/supabaseClient';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+const TABLE = 'defect_deadlines';
+const SELECT = `
+  id, project_id, ticket_type_id, fix_days,
+  project:projects ( id, name ),
+  ticket_type:ticket_types ( id, name )
+`;
+
+export const useDefectDeadlines = () =>
+  useQuery({
+    queryKey: [TABLE],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select(SELECT)
+        .order('id');
+      if (error) throw error;
+      return data ?? [];
+    },
+    staleTime: 5 * 60_000,
+  });
+
+export const useAddDefectDeadline = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload) => {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .insert(payload)
+        .select(SELECT)
+        .single();
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: [TABLE] }),
+  });
+};
+
+export const useUpdateDefectDeadline = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, updates }) => {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .update(updates)
+        .eq('id', id)
+        .select(SELECT)
+        .single();
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: [TABLE] }),
+  });
+};
+
+export const useDeleteDefectDeadline = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (id) => {
+      const { error } = await supabase.from(TABLE).delete().eq('id', id);
+      if (error) throw error;
+      return id;
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: [TABLE] }),
+  });
+};

--- a/src/features/defectDeadline/DefectDeadlineForm.tsx
+++ b/src/features/defectDeadline/DefectDeadlineForm.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import {
+  Stack,
+  TextField,
+  DialogActions,
+  Button,
+  CircularProgress,
+  MenuItem,
+} from '@mui/material';
+import { useProjects } from '@/entities/project';
+import { useTicketTypes } from '@/entities/ticketType';
+
+interface FormValues {
+  project_id: number | '';
+  ticket_type_id: number | '';
+  fix_days: number | '';
+}
+
+interface Props {
+  initialData?: { project_id?: number; ticket_type_id?: number; fix_days?: number };
+  onSubmit: (values: { project_id: number; ticket_type_id: number; fix_days: number }) => void;
+  onCancel: () => void;
+}
+
+export default function DefectDeadlineForm({ initialData, onSubmit, onCancel }: Props) {
+  const { control, handleSubmit, formState: { isSubmitting } } = useForm<FormValues>({
+    defaultValues: {
+      project_id: initialData?.project_id ?? '',
+      ticket_type_id: initialData?.ticket_type_id ?? '',
+      fix_days: initialData?.fix_days ?? '',
+    },
+  });
+
+  const { data: projects = [] } = useProjects();
+  const { data: types = [] } = useTicketTypes();
+
+  return (
+    <form onSubmit={handleSubmit((v) => onSubmit({
+      project_id: Number(v.project_id),
+      ticket_type_id: Number(v.ticket_type_id),
+      fix_days: Number(v.fix_days),
+    }))} noValidate>
+      <Stack spacing={2} sx={{ minWidth: 320 }}>
+        <Controller
+          name="project_id"
+          control={control}
+          rules={{ required: 'Проект обязателен' }}
+          render={({ field, fieldState }) => (
+            <TextField {...field} select label="Проект" fullWidth required error={!!fieldState.error} helperText={fieldState.error?.message}>
+              {projects.map((p) => (
+                <MenuItem key={p.id} value={p.id}>{p.name}</MenuItem>
+              ))}
+            </TextField>
+          )}
+        />
+        <Controller
+          name="ticket_type_id"
+          control={control}
+          rules={{ required: 'Тип дефекта обязателен' }}
+          render={({ field, fieldState }) => (
+            <TextField {...field} select label="Тип дефекта" fullWidth required error={!!fieldState.error} helperText={fieldState.error?.message}>
+              {types.map((t) => (
+                <MenuItem key={t.id} value={t.id}>{t.name}</MenuItem>
+              ))}
+            </TextField>
+          )}
+        />
+        <Controller
+          name="fix_days"
+          control={control}
+          rules={{ required: 'Срок обязателен', min: { value: 1, message: 'Минимум 1 день' } }}
+          render={({ field, fieldState }) => (
+            <TextField {...field} type="number" label="Срок устранения (дни)" fullWidth required error={!!fieldState.error} helperText={fieldState.error?.message} />
+          )}
+        />
+        <DialogActions sx={{ px: 0 }}>
+          <Button onClick={onCancel}>Отмена</Button>
+          <Button type="submit" variant="contained" disabled={isSubmitting} startIcon={isSubmitting && <CircularProgress size={18} color="inherit" />}>
+            Сохранить
+          </Button>
+        </DialogActions>
+      </Stack>
+    </form>
+  );
+}

--- a/src/pages/UnitsPage/AdminPage.tsx
+++ b/src/pages/UnitsPage/AdminPage.tsx
@@ -5,6 +5,7 @@ import ProjectsTable from "../../widgets/ProjectsTable";
 import ContractorAdmin from "../../widgets/ContractorAdmin";
 import TicketStatusesAdmin from "../../widgets/TicketStatusesAdmin";
 import TicketTypesAdmin from "../../widgets/TicketTypesAdmin";
+import DefectDeadlinesAdmin from "../../widgets/DefectDeadlinesAdmin";
 import UsersTable from "../../widgets/UsersTable";
 import LitigationStagesAdmin from "../../widgets/LitigationStagesAdmin";
 import PartyTypesAdmin from "../../widgets/PartyTypesAdmin";
@@ -25,6 +26,11 @@ export default function AdminPage() {
         />
 
         <TicketTypesAdmin
+          pageSize={25}
+          rowsPerPageOptions={[10, 25, 50, 100]}
+        />
+
+        <DefectDeadlinesAdmin
           pageSize={25}
           rowsPerPageOptions={[10, 25, 50, 100]}
         />

--- a/src/shared/types/defectDeadline.ts
+++ b/src/shared/types/defectDeadline.ts
@@ -1,0 +1,8 @@
+export interface DefectDeadline {
+  id: number;
+  project_id: number;
+  ticket_type_id: number;
+  fix_days: number;
+  project?: { id: number; name: string } | null;
+  ticket_type?: { id: number; name: string } | null;
+}

--- a/src/widgets/DefectDeadlinesAdmin.tsx
+++ b/src/widgets/DefectDeadlinesAdmin.tsx
@@ -1,0 +1,120 @@
+import React, { useState } from 'react';
+import { GridActionsCellItem } from '@mui/x-data-grid';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import {
+  useDefectDeadlines,
+  useAddDefectDeadline,
+  useUpdateDefectDeadline,
+  useDeleteDefectDeadline,
+} from '@/entities/defectDeadline';
+import DefectDeadlineForm from '@/features/defectDeadline/DefectDeadlineForm';
+import AdminDataGrid from '@/shared/ui/AdminDataGrid';
+import { Dialog, DialogTitle, DialogContent } from '@mui/material';
+import { useNotify } from '@/shared/hooks/useNotify';
+
+interface Props {
+  pageSize?: number;
+  rowsPerPageOptions?: number[];
+}
+
+export default function DefectDeadlinesAdmin({
+  pageSize = 25,
+  rowsPerPageOptions = [10, 25, 50, 100],
+}: Props) {
+  const notify = useNotify();
+  const { data = [], isPending } = useDefectDeadlines();
+  const add = useAddDefectDeadline();
+  const update = useUpdateDefectDeadline();
+  const remove = useDeleteDefectDeadline();
+  const [modal, setModal] = useState<null | { mode: 'add' | 'edit'; data?: any }>(null);
+
+  const columns = [
+    { field: 'id', headerName: 'ID', width: 70 },
+    {
+      field: 'project',
+      headerName: 'Проект',
+      valueGetter: ({ row }: any) => row.project?.name,
+      flex: 1,
+    },
+    {
+      field: 'ticket_type',
+      headerName: 'Тип дефекта',
+      valueGetter: ({ row }: any) => row.ticket_type?.name,
+      flex: 1,
+    },
+    { field: 'fix_days', headerName: 'Срок (дн.)', width: 120 },
+    {
+      field: 'actions',
+      type: 'actions',
+      width: 100,
+      getActions: ({ row }: any) => [
+        <GridActionsCellItem
+          key="edit"
+          icon={<EditIcon />}
+          label="Редактировать"
+          onClick={() => setModal({ mode: 'edit', data: row })}
+        />,
+        <GridActionsCellItem
+          key="del"
+          icon={<DeleteIcon color="error" />}
+          label="Удалить"
+          onClick={() => {
+            if (!window.confirm('Удалить запись?')) return;
+            remove.mutate(row.id, {
+              onSuccess: () => notify.success('Запись удалена'),
+              onError: (e) => notify.error(e.message),
+            });
+          }}
+        />,
+      ],
+    },
+  ];
+
+  const close = () => setModal(null);
+  const ok = (msg: string) => {
+    close();
+    notify.success(msg);
+  };
+
+  return (
+    <>
+      {modal && (
+        <Dialog open onClose={close} maxWidth="sm" fullWidth>
+          <DialogTitle>
+            {modal.mode === 'add' ? 'Новая запись' : 'Редактировать запись'}
+          </DialogTitle>
+          <DialogContent dividers>
+            <DefectDeadlineForm
+              initialData={modal.mode === 'edit' ? modal.data : undefined}
+              onSubmit={(d) =>
+                modal.mode === 'add'
+                  ? add.mutate(d, {
+                      onSuccess: () => ok('Запись создана'),
+                      onError: (e) => notify.error(e.message),
+                    })
+                  : update.mutate(
+                      { id: modal.data.id, updates: d },
+                      {
+                        onSuccess: () => ok('Запись обновлена'),
+                        onError: (e) => notify.error(e.message),
+                      },
+                    )
+              }
+              onCancel={close}
+            />
+          </DialogContent>
+        </Dialog>
+      )}
+      <AdminDataGrid
+        title="Сроки устранения дефектов"
+        rows={data}
+        columns={columns}
+        loading={isPending}
+        onAdd={() => setModal({ mode: 'add' })}
+        pageSize={pageSize}
+        rowsPerPageOptions={rowsPerPageOptions}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add CRUD hooks for `defect_deadlines`
- create form and admin table widgets
- link new widget on admin page
- document new table structure in `database_structure.json`

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_683b56a95e7c832e9da25f8e57220a8f