### PR TITLE
Fix value getters for DefectDeadlinesAdmin

### DIFF
--- a/src/widgets/DefectDeadlinesAdmin.tsx
+++ b/src/widgets/DefectDeadlinesAdmin.tsx
@@ -34,13 +34,13 @@ export default function DefectDeadlinesAdmin({
     {
       field: 'project',
       headerName: 'Проект',
-      valueGetter: ({ row }: any) => row.project?.name,
+      valueGetter: ({ row }: any) => row?.project?.name ?? '',
       flex: 1,
     },
     {
       field: 'ticket_type',
       headerName: 'Тип дефекта',
-      valueGetter: ({ row }: any) => row.ticket_type?.name,
+      valueGetter: ({ row }: any) => row?.ticket_type?.name ?? '',
       flex: 1,
     },
     { field: 'fix_days', headerName: 'Срок (дн.)', width: 120 },


### PR DESCRIPTION
## Summary
- avoid runtime errors when rows are undefined in DefectDeadlinesAdmin

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_683b5a248064832e8603593ae6c6dd1a