### PR TITLE
Fix duplicate check in defect deadlines admin

### DIFF
--- a/src/widgets/DefectDeadlinesAdmin.tsx
+++ b/src/widgets/DefectDeadlinesAdmin.tsx
@@ -110,20 +110,36 @@ export default function DefectDeadlinesAdmin({
           <DialogContent dividers>
             <DefectDeadlineForm
               initialData={modal.mode === 'edit' ? modal.data : undefined}
-              onSubmit={(d) =>
-                modal.mode === 'add'
-                  ? add.mutate(d, {
-                      onSuccess: () => ok('Запись создана'),
+              onSubmit={(d) => {
+                if (modal.mode === 'add') {
+                  // Проверяем наличие записи с такой комбинацией
+                  const exists = data.some(
+                    (r) =>
+                      r.project_id === d.project_id &&
+                      r.ticket_type_id === d.ticket_type_id,
+                  );
+
+                  if (exists) {
+                    notify.error(
+                      'Запись для выбранного проекта и типа дефекта уже существует',
+                    );
+                    return;
+                  }
+
+                  add.mutate(d, {
+                    onSuccess: () => ok('Запись создана'),
+                    onError: (e) => notify.error(e.message),
+                  });
+                } else {
+                  update.mutate(
+                    { id: modal.data.id, updates: d },
+                    {
+                      onSuccess: () => ok('Запись обновлена'),
                       onError: (e) => notify.error(e.message),
-                    })
-                  : update.mutate(
-                      { id: modal.data.id, updates: d },
-                      {
-                        onSuccess: () => ok('Запись обновлена'),
-                        onError: (e) => notify.error(e.message),
-                      },
-                    )
-              }
+                    },
+                  );
+                }
+              }}
               onCancel={close}
             />
           </DialogContent>


### PR DESCRIPTION
## Summary
- avoid duplicate entries for defect deadlines

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_683bdeb0b7bc832e9f62ef56b1e4ae6c