### PR TITLE
Fix attachment display after upload

### DIFF
--- a/src/entities/ticket.js
+++ b/src/entities/ticket.js
@@ -400,8 +400,9 @@ export function useTicket(ticketId) {
       }
 
       // новые вложения
+      let uploaded = [];
       if (newAttachments.length) {
-        const uploaded = await addTicketAttachments(
+        uploaded = await addTicketAttachments(
           newAttachments.map((f) =>
             "file" in f ? { file: f.file, type_id: f.type_id ?? null } : { file: f, type_id: null },
           ),
@@ -424,6 +425,7 @@ export function useTicket(ticketId) {
           .eq("project_id", projectId);
         if (error) throw error;
       }
+      return uploaded;
     },
     onSuccess: (_, vars) => {
       qc.invalidateQueries({ queryKey: ["tickets", projectId] });

--- a/src/features/ticket/TicketForm.tsx
+++ b/src/features/ticket/TicketForm.tsx
@@ -224,9 +224,33 @@ export default function TicketForm({
         id,
         type_id: type,
       })),
+    }).then((uploaded) => {
+      if (uploaded?.length) {
+        setRemoteFiles((p) => [
+          ...p,
+          ...uploaded.map((u) => ({
+            id: u.id,
+            name:
+              u.original_name ||
+              u.storage_path.split("/").pop() ||
+              "file",
+            path: u.storage_path,
+            url: u.file_url,
+            type: u.file_type,
+            attachment_type_id: u.attachment_type_id ?? null,
+          })),
+        ]);
+        setChangedTypes((prev) => {
+          const copy = { ...prev };
+          uploaded.forEach((u) => {
+            copy[u.id] = u.attachment_type_id ?? null;
+          });
+          return copy;
+        });
+      }
+      setNewFiles([]);
+      setRemovedIds([]);
     });
-    setNewFiles([]);
-    setRemovedIds([]);
   },
     [watchAll, newFiles, removedIds, changedTypes],
     1000,
@@ -253,7 +277,7 @@ export default function TicketForm({
     };
 
     if (ticketId) {
-      await updateAsync({
+      const uploaded = await updateAsync({
         id: Number(ticketId),
         ...payload,
         newAttachments: newFiles,
@@ -263,6 +287,31 @@ export default function TicketForm({
           type_id: type,
         })),
       });
+      if (uploaded?.length) {
+        setRemoteFiles((p) => [
+          ...p,
+          ...uploaded.map((u) => ({
+            id: u.id,
+            name:
+              u.original_name ||
+              u.storage_path.split("/").pop() ||
+              "file",
+            path: u.storage_path,
+            url: u.file_url,
+            type: u.file_type,
+            attachment_type_id: u.attachment_type_id ?? null,
+          })),
+        ]);
+        setChangedTypes((prev) => {
+          const copy = { ...prev };
+          uploaded.forEach((u) => {
+            copy[u.id] = u.attachment_type_id ?? null;
+          });
+          return copy;
+        });
+      }
+      setNewFiles([]);
+      setRemovedIds([]);
       onCreated?.();
     } else {
       await create.mutateAsync({


### PR DESCRIPTION
## Summary
- return uploaded attachments from `useTicket` update mutation
- append uploaded files to local state in `TicketForm`
- keep attachment type map updated for new files

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c416d8954832e91c7bd15d03a8fb8