### PR TITLE
Add manual save for ticket form

### DIFF
--- a/src/shared/hooks/useUnsavedChangesWarning.ts
+++ b/src/shared/hooks/useUnsavedChangesWarning.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+
+/**
+ * Показывает системное предупреждение о несохранённых изменениях
+ * при попытке закрыть или перезагрузить страницу.
+ * @param active Активировать предупреждение
+ */
+export function useUnsavedChangesWarning(active: boolean) {
+  useEffect(() => {
+    if (!active) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => {
+      window.removeEventListener('beforeunload', handler);
+    };
+  }, [active]);
+}


### PR DESCRIPTION
## Summary
- add `useUnsavedChangesWarning` hook
- rework ticket edit form to save only on button click and show a warning on unsaved changes

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_683c4558eb38832e8a2e6c1631f88a90