### PR TITLE
Add closed flag for tickets

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -784,6 +784,13 @@
     "column_default": "ARRAY[]::integer[]"
   },
   {
+    "table_name": "tickets",
+    "column_name": "is_closed",
+    "data_type": "boolean",
+    "is_nullable": "NO",
+    "column_default": "false"
+  },
+  {
     "table_name": "unit_persons",
     "column_name": "unit_id",
     "data_type": "integer",

--- a/sql/add_is_closed_column.sql
+++ b/sql/add_is_closed_column.sql
@@ -1,0 +1,3 @@
+-- Добавление колонки is_closed в таблицу tickets
+ALTER TABLE tickets
+    ADD COLUMN IF NOT EXISTS is_closed boolean NOT NULL DEFAULT false;

--- a/src/features/ticket/TicketClosedSelect.tsx
+++ b/src/features/ticket/TicketClosedSelect.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Select } from "antd";
+import { useUpdateTicketClosed } from "@/entities/ticket";
+
+interface Props {
+  ticketId: number;
+  isClosed: boolean;
+}
+
+/**
+ * Выпадающий список для отметки закрытия замечания.
+ */
+export default function TicketClosedSelect({ ticketId, isClosed }: Props) {
+  const update = useUpdateTicketClosed();
+  const handleChange = (value: string) => {
+    update.mutate({ id: ticketId, isClosed: value === "closed" });
+  };
+
+  return (
+    <Select
+      size="small"
+      value={isClosed ? "closed" : "open"}
+      style={{ width: "100%" }}
+      onChange={handleChange}
+      options={[
+        { label: "открыто", value: "open" },
+        { label: "закрыто", value: "closed" },
+      ]}
+      loading={update.isPending}
+    />
+  );
+}

--- a/src/shared/types/ticket.ts
+++ b/src/shared/types/ticket.ts
@@ -11,6 +11,8 @@ export interface Ticket {
   customer_request_date: string | null;
   responsible_engineer_id: string | null;
   is_warranty: boolean;
+  /** признак закрытого замечания */
+  is_closed: boolean;
   received_at: string;
   fixed_at: string | null;
   attachment_ids?: number[];

--- a/src/widgets/TicketsFilters.tsx
+++ b/src/widgets/TicketsFilters.tsx
@@ -1,10 +1,11 @@
 // src/widgets/TicketsFilters.js
 
 import React, { useEffect } from "react";
-import { Form, DatePicker, Select, Input, Button } from "antd";
+import { Form, DatePicker, Select, Input, Button, Switch } from "antd";
 
 const { RangePicker } = DatePicker;
 const { Option } = Select;
+const LS_KEY = "ticketsHideClosed";
 
 /**
  * Фильтры таблицы замечаний.
@@ -16,12 +17,34 @@ export default function TicketsFilters({ options, onChange }) {
   const [form] = Form.useForm();
 
   useEffect(() => {
+    try {
+      const saved = JSON.parse(localStorage.getItem(LS_KEY) || "false");
+      form.setFieldValue("hideClosed", saved);
+    } catch {}
     onChange(form.getFieldsValue());
     // eslint-disable-next-line
   }, []);
 
+  useEffect(() => {
+    const handler = (e) => {
+      if (e.key === LS_KEY) {
+        try {
+          form.setFieldValue("hideClosed", JSON.parse(e.newValue || "false"));
+          onChange(form.getFieldsValue());
+        } catch {}
+      }
+    };
+    window.addEventListener("storage", handler);
+    return () => window.removeEventListener("storage", handler);
+  }, [form, onChange]);
+
   const handleValuesChange = (_, values) => {
     onChange(values);
+    if (Object.prototype.hasOwnProperty.call(values, "hideClosed")) {
+      try {
+        localStorage.setItem(LS_KEY, JSON.stringify(values.hideClosed));
+      } catch {}
+    }
   };
 
   const reset = () => {
@@ -71,6 +94,9 @@ export default function TicketsFilters({ options, onChange }) {
       </Form.Item>
       <Form.Item name="responsible" label="Ответственный инженер">
         <Select allowClear options={options.responsibleEngineers} />
+      </Form.Item>
+      <Form.Item name="hideClosed" label="Скрыть закрытые" valuePropName="checked">
+        <Switch />
       </Form.Item>
       <Form.Item>
         <Button onClick={reset} block>

--- a/src/widgets/TicketsTable.tsx
+++ b/src/widgets/TicketsTable.tsx
@@ -22,6 +22,7 @@ import {
 
 import { useDeleteTicket } from "@/entities/ticket";
 import TicketStatusSelect from "@/features/ticket/TicketStatusSelect";
+import TicketClosedSelect from "@/features/ticket/TicketClosedSelect";
 
 /** Форматирование даты */
 const fmt = (d, withTime = false) =>
@@ -37,6 +38,7 @@ const daysPassed = (receivedAt) =>
 /** Фильтрация по фильтрам */
 const applyFilters = (rows, f) =>
   rows.filter((r) => {
+    if (f.hideClosed && r.isClosed) return false;
     const days = daysPassed(r.receivedAt);
     if (f.period && f.period.length === 2) {
       const [from, to] = f.period;
@@ -117,6 +119,15 @@ export default function TicketsTable({ tickets, filters, loading, onView }) {
         sorter: (a, b) => a.statusName.localeCompare(b.statusName),
         render: (_, row) => (
           <TicketStatusSelect ticketId={row.id} statusId={row.statusId} />
+        ),
+      },
+      {
+        title: "Замечание закрыто",
+        dataIndex: "isClosed",
+        width: 160,
+        sorter: (a, b) => Number(a.isClosed) - Number(b.isClosed),
+        render: (_, row) => (
+          <TicketClosedSelect ticketId={row.id} isClosed={row.isClosed} />
         ),
       },
       {


### PR DESCRIPTION
## Summary
- extend `tickets` database with `is_closed` column
- support is_closed field in ticket entities and types
- add dropdown for closing tickets in list
- filter component now allows hiding closed tickets
- provide SQL migration

## Testing
- `npm run lint` *(fails: couldn't find eslint config)*
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683c47765fa4832e803d22f5e2c84ee9