### PR TITLE
Implement person passport fields and modal editing

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -519,8 +519,15 @@
   },
   {
     "table_name": "persons",
-    "column_name": "project_id",
-    "data_type": "integer",
+    "column_name": "passport_series",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": null
+  },
+  {
+    "table_name": "persons",
+    "column_name": "passport_number",
+    "data_type": "text",
     "is_nullable": "YES",
     "column_default": null
   },

--- a/src/shared/types/person.ts
+++ b/src/shared/types/person.ts
@@ -1,0 +1,8 @@
+export interface Person {
+  id: number;
+  full_name: string;
+  phone?: string | null;
+  email?: string | null;
+  passport_series?: string | null;
+  passport_number?: string | null;
+}


### PR DESCRIPTION
## Summary
- add passport fields in `database_structure.json`
- refactor `person` entity to handle passport-based uniqueness and no project
- create `Person` type and extend UI to edit persons and contractors
- add phone masking and modals for editing/adding

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_683c4c0ef628832eb65dcb90e02c4a7a