### PR TITLE
Fix person deletion dropdown update

### DIFF
--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -388,6 +388,7 @@ export default function CourtCasesPage() {
                       onSuccess: () => {
                         message.success('Физлицо удалено');
                         form.setFieldValue('plaintiff_id', null);
+                        qc.invalidateQueries({ queryKey: ['projectPersons'] });
                       },
                       onError: (e: any) => message.error(e.message),
                     });


### PR DESCRIPTION
## Summary
- ensure person select refreshes after deletion by invalidating projectPersons query

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_683c64ae4878832ebf85b27369bf6599