### PR TITLE
Add description fields for persons and contractors

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -532,6 +532,13 @@
     "column_default": null
   },
   {
+    "table_name": "persons",
+    "column_name": "description",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": null
+  },
+  {
     "table_name": "profiles",
     "column_name": "id",
     "data_type": "uuid",

--- a/src/entities/contractor.js
+++ b/src/entities/contractor.js
@@ -10,18 +10,18 @@ import {
 
 const TABLE  = 'contractors';
 const FIELDS = `
-  id, name, inn, phone, email, comment:description, created_at
+  id, name, description, inn, phone, email, created_at
 `;
 
-/** trim + ''→null; comment→description */
+/** trim + ''→null */
 const sanitize = (o) =>
     Object.fromEntries(
         Object.entries(o)
             .filter(([k]) =>
-                ['name', 'inn', 'phone', 'email', 'comment'].includes(k),
+                ['name', 'inn', 'phone', 'email', 'description'].includes(k),
             )
             .map(([k, v]) => [
-                k === 'comment' ? 'description' : k,
+                k,
                 typeof v === 'string' ? v.trim() || null : v,
             ]),
     );

--- a/src/entities/person.js
+++ b/src/entities/person.js
@@ -7,7 +7,8 @@ import {
 
 const FIELDS = `
   id, full_name, phone, email,
-  passport_series, passport_number
+  passport_series, passport_number,
+  description
 `;
 
 const sanitize = (obj) =>

--- a/src/features/contractor/ContractorForm.tsx
+++ b/src/features/contractor/ContractorForm.tsx
@@ -20,7 +20,7 @@ const schema = z.object({
     .regex(/^(\d{10}|\d{12})$/, "ИНН должен содержать 10 или 12 цифр"),
   phone: z.string().trim().optional(),
   email: z.union([z.literal(""), z.string().email("Неверный e-mail")]),
-  comment: z.string().trim().optional(),
+  description: z.string().trim().optional(),
 });
 
 export default function ContractorForm({
@@ -46,7 +46,7 @@ export default function ContractorForm({
       inn: initialData?.inn ?? "",
       phone: initialData?.phone ?? "",
       email: initialData?.email ?? "",
-      comment: initialData?.comment ?? "",
+      description: initialData?.description ?? "",
     },
   });
 
@@ -72,7 +72,7 @@ export default function ContractorForm({
     }
   };
 
-  const fields = ["name", "inn", "phone", "email", "comment"] as const;
+  const fields = ["name", "inn", "phone", "email", "description"] as const;
 
   return (
     <form onSubmit={handleSubmit(submit)} noValidate data-oid="5.e52j6">
@@ -96,7 +96,7 @@ export default function ContractorForm({
                     inn: "ИНН *",
                     phone: "Телефон",
                     email: "E-mail",
-                    comment: "Комментарий",
+                    description: "Комментарий",
                   }[f]
                 }
                 required={["name", "inn"].includes(f)}

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -1368,6 +1368,9 @@ function AddPersonModal({ open, onClose, unitId, onSelect, initialData = null }:
         <Form.Item name="email" label="Email">
           <Input />
         </Form.Item>
+        <Form.Item name="description" label="Описание">
+          <Input.TextArea rows={2} />
+        </Form.Item>
       </Form>
     </Modal>
   );
@@ -1431,8 +1434,11 @@ function ContractorModal({ open, onClose, onSelect, initialData = null }: Contra
         >
           <Input placeholder="+7 (9xx) xxx-xx-xx" />
         </Form.Item>
-        <Form.Item name="email" label="Email"> 
+        <Form.Item name="email" label="Email">
           <Input />
+        </Form.Item>
+        <Form.Item name="description" label="Описание">
+          <Input.TextArea rows={2} />
         </Form.Item>
       </Form>
     </Modal>

--- a/src/shared/types/contractor.ts
+++ b/src/shared/types/contractor.ts
@@ -1,0 +1,9 @@
+export interface Contractor {
+  id: number;
+  name: string;
+  description?: string | null;
+  inn?: string | null;
+  phone?: string | null;
+  email?: string | null;
+  created_at?: string | null;
+}

--- a/src/shared/types/person.ts
+++ b/src/shared/types/person.ts
@@ -5,4 +5,5 @@ export interface Person {
   email?: string | null;
   passport_series?: string | null;
   passport_number?: string | null;
+  description?: string | null;
 }


### PR DESCRIPTION
## Summary
- add optional `description` fields for persons and contractors in DB structure
- update contractor entity and form to use `description`
- extend person entity and type with `description`
- expose description fields in court case modals
- add Contractor type definition

## Testing
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_683c9758e714832ea01b70196f7dc15c