### PR TITLE
Add project field and improved defects tab

### DIFF
--- a/src/shared/types/courtCase.ts
+++ b/src/shared/types/courtCase.ts
@@ -1,11 +1,10 @@
 
 export interface Defect {
   id: number;
-  name: string;
-  location: string;
+  /** Наименование недостатка */
   description: string;
+  /** Стоимость устранения */
   cost: number;
-  duration?: number | null;
 }
 
 export type CaseStatus = 'active' | 'won' | 'lost' | 'settled';


### PR DESCRIPTION
## Summary
- add project selector to court case dialog form
- display project in view mode
- map defect fix cost to cost
- allow editing defects and simplify defect form

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683ca9eaf818832eae10adcd39edd56c