### PR TITLE
Fix undefined projects in court cases page

### DIFF
--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -27,6 +27,7 @@ import {
 } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import type { CourtCase, Defect } from '@/shared/types/courtCase';
+import type { Project } from '@/shared/types/project';
 import { useProjects } from '@/entities/project';
 import { useUnitsByProject, useUnitsByIds } from '@/entities/unit';
 import {
@@ -665,6 +666,7 @@ export default function CourtCasesPage() {
         caseData={dialogCase}
         tab={tab}
         onTabChange={setTab}
+        projects={projects}
       />
       <Modal
         open={!!partySelect}
@@ -737,9 +739,10 @@ interface CaseDialogProps {
   caseData: CourtCase | null;
   tab: string;
   onTabChange: (k: string) => void;
+  projects: Project[];
 }
 
-function CaseDialog({ open, onClose, caseData, tab, onTabChange }: CaseDialogProps) {
+function CaseDialog({ open, onClose, caseData, tab, onTabChange, projects }: CaseDialogProps) {
   const { data: defects = [] } = useCaseDefects(caseData ? Number(caseData.id) : 0);
   const { data: stages = [] } = useLitigationStages();
   const { data: unitInfo = [] } = useUnitsByIds(

--- a/src/shared/types/project.ts
+++ b/src/shared/types/project.ts
@@ -1,0 +1,5 @@
+export interface Project {
+  id: number;
+  /** Название проекта */
+  name: string;
+}


### PR DESCRIPTION
## Summary
- define Project type
- pass projects to CourtCasesPage dialog
- reference Project type in dialog

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_683cac7228a4832e929066df7331a924