### PR TITLE
Fix case dialog null handling

### DIFF
--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -863,7 +863,8 @@ function CaseDialog({ open, onClose, caseData, tab, onTabChange, projects }: Cas
 
   const objectName =
     unitInfo.map((u) => u.name).join(', ') || (caseData as any)?.projectObject || '';
-  const projectName = projects.find((p) => p.id === caseData.project_id)?.name || '';
+  const projectName =
+    caseData ? projects.find((p) => p.id === caseData.project_id)?.name || '' : '';
 
   return (
     <Modal open={open} onCancel={onClose} width="80%" footer={null} title={caseData ? `Дело № ${caseData.number}` : ''}>


### PR DESCRIPTION
## Summary
- handle `null` `caseData` when computing project name

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_683cae2acd5c832ea076b4e3dbf5b709