### PR TITLE
Fix defect creation with project_id

### DIFF
--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -880,7 +880,7 @@ function CaseDialog({ open, onClose, caseData, tab, onTabChange, projects }: Cas
   const addDefect = (defect: Omit<Defect, 'id'>) => {
     if (!caseData) return;
     addDefectMutation.mutate(
-      { case_id: Number(caseData.id), ...defect },
+      { case_id: Number(caseData.id), project_id: caseData.project_id, ...defect },
       {
         onError: (e: any) => message.error(e.message),
       },


### PR DESCRIPTION
## Summary
- add project_id when inserting new defect
- forward project_id from CourtCase dialog when creating defects

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: vite not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683cb71a26a8832e92403a416640038d