### PR TITLE
Fix autocomplete for court defect field

### DIFF
--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -1214,8 +1214,8 @@ function DefectsTab({ defects, onAdd, onDelete, onUpdate }: DefectsProps) {
       <Form form={form} layout="vertical" onFinish={submit} style={{ marginBottom: 16 }}>
         <Row gutter={16}>
           <Col span={12}>
-            <Form.Item name="description" label="Наименование недостатка" rules={[{ required: true, message: 'Укажите название' }]}>
-              <Input />
+            <Form.Item name="description" label="Наименование недостатка" rules={[{ required: true, message: 'Укажите название' }]}> 
+              <Input autoComplete="off" />
             </Form.Item>
           </Col>
           <Col span={12}>


### PR DESCRIPTION
## Summary
- disable browser autocomplete for `Наименование недостатка` field on court cases page

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_683d20fcce98832eb66870067505c2e7