### PR TITLE
fix court case date validation

### DIFF
--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -196,16 +196,20 @@ export default function CourtCasesPage() {
   const removeCaseFile = (idx: number) =>
     setCaseFiles((p) => p.filter((_, i) => i !== idx));
 
+  /**
+   * Creates a new court case and uploads linked attachments.
+   * Date fields may be empty, so values are checked before formatting.
+   */
   const handleAddCase = async (values: any) => {
     try {
-      const newCase = await addCaseMutation.mutateAsync({
-        project_id: values.project_id,
-        unit_ids: values.unit_ids || [],
-        number: values.number,
-        date: values.date.format('YYYY-MM-DD'),
-        plaintiff_id: values.plaintiff_id,
-        defendant_id: values.defendant_id,
-        responsible_lawyer_id: values.responsible_lawyer_id,
+        const newCase = await addCaseMutation.mutateAsync({
+          project_id: values.project_id,
+          unit_ids: values.unit_ids || [],
+          number: values.number,
+          date: values.date ? values.date.format('YYYY-MM-DD') : null,
+          plaintiff_id: values.plaintiff_id,
+          defendant_id: values.defendant_id,
+          responsible_lawyer_id: values.responsible_lawyer_id,
         status: values.status,
         is_closed: false,
         fix_start_date: values.fix_start_date
@@ -397,7 +401,11 @@ export default function CourtCasesPage() {
             </Form.Item>
           </Col>
           <Col span={8}>
-            <Form.Item name="date" label="Дата" rules={[{ required: true, message: 'Укажите дату' }]}> 
+            <Form.Item
+              name="date"
+              label="Дата"
+              rules={[{ required: true, message: 'Укажите дату', type: 'object' }]}
+            >
               <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
             </Form.Item>
           </Col>
@@ -846,6 +854,10 @@ function CaseDialog({ open, onClose, caseData, tab, onTabChange, projects }: Cas
     }
   }, [caseData, form, projectPersons]);
 
+  /**
+   * Updates selected court case with new values.
+   * Optional dates are converted to strings only when provided.
+   */
   const saveChanges = async (values: any) => {
     if (!caseData) return;
     try {
@@ -854,7 +866,7 @@ function CaseDialog({ open, onClose, caseData, tab, onTabChange, projects }: Cas
         updates: {
           project_id: values.project_id,
           number: values.number,
-          date: values.date.format('YYYY-MM-DD'),
+          date: values.date ? values.date.format('YYYY-MM-DD') : null,
           unit_ids: values.unit_ids,
           plaintiff_id: values.plaintiff_id,
           defendant_id: values.defendant_id,
@@ -932,7 +944,11 @@ function CaseDialog({ open, onClose, caseData, tab, onTabChange, projects }: Cas
                   </Form.Item>
                 </Col>
                 <Col span={8}>
-                  <Form.Item name="date" label="Дата" rules={[{ required: true, message: 'Укажите дату' }]}> 
+                  <Form.Item
+                    name="date"
+                    label="Дата"
+                    rules={[{ required: true, message: 'Укажите дату', type: 'object' }]}
+                  >
                     <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
                   </Form.Item>
                 </Col>


### PR DESCRIPTION
## Summary
- fix date validation for new/edit case forms
- handle empty date values when saving court cases

## Testing
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_683d22716cb0832e961e35c0e8eb1c63