### PR TITLE
Fix correspondence page interactions

### DIFF
--- a/src/features/correspondence/AddLetterForm.tsx
+++ b/src/features/correspondence/AddLetterForm.tsx
@@ -49,6 +49,8 @@ interface AddLetterFormProps {
 export default function AddLetterForm({ onSubmit, parentId = null }: AddLetterFormProps) {
   const [form] = Form.useForm<Omit<AddLetterFormData, 'attachments'>>();
   const projectId = Form.useWatch('project_id', form);
+  const senderValue = Form.useWatch('sender', form);
+  const receiverValue = Form.useWatch('receiver', form);
 
   const [files, setFiles] = React.useState<{ file: File; type_id: number | null }[]>([]);
   const [senderType, setSenderType] = React.useState<'person' | 'contractor'>('person');
@@ -166,7 +168,7 @@ export default function AddLetterForm({ onSubmit, parentId = null }: AddLetterFo
                   <Button icon={<PlusOutlined />} onClick={() => setContractorModal({ target: 'sender' })} style={{ display: senderType === 'contractor' ? 'inline-block' : 'none' }} />
                   <Button
                     icon={<EditOutlined />}
-                    disabled={!form.getFieldValue('sender')}
+                    disabled={!senderValue}
                     onClick={() => {
                       const val = form.getFieldValue('sender');
                       const data = senderType === 'person'
@@ -199,7 +201,7 @@ export default function AddLetterForm({ onSubmit, parentId = null }: AddLetterFo
                       }
                     }}
                   >
-                    <Button danger icon={<DeleteOutlined />} disabled={!form.getFieldValue('sender')} />
+                    <Button danger icon={<DeleteOutlined />} disabled={!senderValue} />
                   </Popconfirm>
                 </Space.Compact>
               </Space>
@@ -227,7 +229,7 @@ export default function AddLetterForm({ onSubmit, parentId = null }: AddLetterFo
                   <Button icon={<PlusOutlined />} onClick={() => setContractorModal({ target: 'receiver' })} style={{ display: receiverType === 'contractor' ? 'inline-block' : 'none' }} />
                   <Button
                     icon={<EditOutlined />}
-                    disabled={!form.getFieldValue('receiver')}
+                    disabled={!receiverValue}
                     onClick={() => {
                       const val = form.getFieldValue('receiver');
                       const data = receiverType === 'person'
@@ -260,7 +262,7 @@ export default function AddLetterForm({ onSubmit, parentId = null }: AddLetterFo
                       }
                     }}
                   >
-                    <Button danger icon={<DeleteOutlined />} disabled={!form.getFieldValue('receiver')} />
+                    <Button danger icon={<DeleteOutlined />} disabled={!receiverValue} />
                   </Popconfirm>
                 </Space.Compact>
               </Space>

--- a/src/features/correspondence/EditLetterDialog.tsx
+++ b/src/features/correspondence/EditLetterDialog.tsx
@@ -53,8 +53,9 @@ export default function EditLetterDialog({
   // При смене проекта сбрасываем выбранные объекты,
   // чтобы пользователь не сохранял несоответствующие unit_ids
   useEffect(() => {
+    if (letter && projectId === letter.project_id) return;
     form.setFieldValue('unit_ids', []);
-  }, [projectId, form]);
+  }, [projectId, form, letter]);
 
   const contactOptions = React.useMemo(
     () => [

--- a/src/widgets/CorrespondenceTable.tsx
+++ b/src/widgets/CorrespondenceTable.tsx
@@ -155,14 +155,6 @@ export default function CorrespondenceTable({
           <span style={record.parent_id ? { color: '#888' } : {}}>{val}</span>,
     },
     {
-      title: 'Содержание',
-      dataIndex: 'content',
-      sorter: (a, b) => (a.content || '').localeCompare(b.content || ''),
-      render: (val: string, record: any) => (
-        <span style={record.parent_id ? { color: '#888' } : {}}>{val}</span>
-      ),
-    },
-    {
       title: 'Проект',
       dataIndex: 'projectName',
       sorter: (a, b) => (a.projectName || '').localeCompare(b.projectName || ''),


### PR DESCRIPTION
## Summary
- enable sender/receiver action buttons without manual re-render
- avoid clearing units when opening a letter for viewing
- hide content column in correspondence table

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npx tsc --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683d2d861118832eb3b54f796dac2594