### PR TITLE
Store letter attachments by ID

### DIFF
--- a/src/entities/attachment.js
+++ b/src/entities/attachment.js
@@ -63,8 +63,13 @@ async function upload(file, pathPrefix) {
     return { path, type: file.type, url: publicUrl };
 }
 
-export function uploadLetterAttachment(file, projectId) {
-    return upload(file, `letters/${projectId}`);
+/**
+ * Загружает файл письма в хранилище Supabase.
+ * @param {File} file
+ * @param {number} letterId
+ */
+export function uploadLetterAttachment(file, letterId) {
+    return upload(file, `letters/${letterId}`);
 }
 
 // Загрузка вложений дела теперь привязана к идентификатору дела,
@@ -113,14 +118,13 @@ export async function addCaseAttachments(files, caseId) {
 }
 
 /**
- * Загружает файлы письма и создаёт записи в таблице attachments
- * с возвратом созданных строк.
+ * Загружает файлы письма и создаёт записи в таблице attachments.
  * @param {{file: File, type_id: number | null}[]} files
- * @param {number} projectId
+ * @param {number} letterId
  */
-export async function addLetterAttachments(files, projectId) {
+export async function addLetterAttachments(files, letterId) {
     const uploaded = await Promise.all(
-        files.map(({ file }) => uploadLetterAttachment(file, projectId)),
+        files.map(({ file }) => uploadLetterAttachment(file, letterId)),
     );
 
     const rows = uploaded.map((u, idx) => ({

--- a/src/entities/correspondence/index.ts
+++ b/src/entities/correspondence/index.ts
@@ -147,11 +147,8 @@ export function useAddLetter() {
       const letterId = inserted.id as number;
       let files: CorrespondenceAttachment[] = [];
       let attachmentIds: number[] = [];
-      if (attachments.length && payload.project_id) {
-        const uploaded = await addLetterAttachments(
-          attachments,
-          payload.project_id!
-        );
+      if (attachments.length) {
+        const uploaded = await addLetterAttachments(attachments, letterId);
         files = uploaded.map((u) => ({
           id: String(u.id),
           name:
@@ -302,11 +299,10 @@ export function useUpdateLetter() {
       const letterId = Number(id);
       const { data: current } = await supabase
         .from(LETTERS_TABLE)
-        .select('attachment_ids, project_id')
+        .select('attachment_ids')
         .eq('id', letterId)
         .single();
       let ids = (current?.attachment_ids ?? []) as number[];
-      const projectId = updates.project_id ?? current?.project_id ?? null;
 
       if (removedAttachmentIds.length) {
         const { data: files } = await supabase
@@ -350,8 +346,8 @@ export function useUpdateLetter() {
         }
       }
 
-      if (newAttachments.length && projectId) {
-        const uploaded = await addLetterAttachments(newAttachments, projectId);
+      if (newAttachments.length) {
+        const uploaded = await addLetterAttachments(newAttachments, letterId);
         ids = ids.concat(uploaded.map((u) => u.id));
       }
 


### PR DESCRIPTION
## Summary
- store letter attachments in Supabase bucket `attachments` under `letters/<letter_id>`
- upload new attachments for new and edited letters using letter id

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_683d3067c8bc832e84d646c2fb257a48