### PR TITLE
Add court case and letter forms from structure page

### DIFF
--- a/src/features/correspondence/AddLetterForm.tsx
+++ b/src/features/correspondence/AddLetterForm.tsx
@@ -43,10 +43,12 @@ export interface AddLetterFormData {
 interface AddLetterFormProps {
   onSubmit: (data: AddLetterFormData) => void;
   parentId?: string | null;
+  /** Начальные значения формы */
+  initialValues?: Partial<AddLetterFormData>;
 }
 
 /** Форма добавления нового письма на Ant Design */
-export default function AddLetterForm({ onSubmit, parentId = null }: AddLetterFormProps) {
+export default function AddLetterForm({ onSubmit, parentId = null, initialValues: defaults = {} }: AddLetterFormProps) {
   const [form] = Form.useForm<Omit<AddLetterFormData, 'attachments'>>();
   const projectId = Form.useWatch('project_id', form);
   const senderValue = Form.useWatch('sender', form);
@@ -111,11 +113,11 @@ export default function AddLetterForm({ onSubmit, parentId = null }: AddLetterFo
   return (
     <>
       <Form
-          form={form}
-          layout="vertical"
-          onFinish={submit}
-          initialValues={{ type: 'incoming', date: dayjs(), unit_ids: [] }}
-          autoComplete="off"
+        form={form}
+        layout="vertical"
+        onFinish={submit}
+        initialValues={{ type: 'incoming', date: dayjs(), unit_ids: [], ...defaults }}
+        autoComplete="off"
       >
         <Row gutter={16}>
           <Col span={8}>

--- a/src/features/courtCase/AddCourtCaseForm.tsx
+++ b/src/features/courtCase/AddCourtCaseForm.tsx
@@ -1,0 +1,218 @@
+import React, { useEffect } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import {
+  Stack,
+  TextField,
+  Button,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  DialogActions,
+} from '@mui/material';
+import { DatePicker } from '@mui/x-date-pickers';
+import dayjs, { Dayjs } from 'dayjs';
+import { useProjects } from '@/entities/project';
+import { useUnitsByProject } from '@/entities/unit';
+import { useUsers } from '@/entities/user';
+import { useLitigationStages } from '@/entities/litigationStage';
+import { useAddCourtCase } from '@/entities/courtCase';
+import { useAuthStore } from '@/shared/store/authStore';
+
+export interface AddCourtCaseFormValues {
+  project_id: number | null;
+  unit_ids: number[];
+  number: string;
+  date: Dayjs | null;
+  responsible_lawyer_id: string | null;
+  status: number | null;
+  description: string;
+}
+
+interface Props {
+  initialProjectId?: number | null;
+  initialUnitId?: number | null;
+  onSuccess?: () => void;
+  onCancel?: () => void;
+}
+
+/**
+ * Форма добавления судебного дела. Использует минимальный набор полей.
+ */
+export default function AddCourtCaseForm({
+  initialProjectId = null,
+  initialUnitId = null,
+  onSuccess,
+  onCancel,
+}: Props) {
+  const profileId = useAuthStore((s) => s.profile?.id ?? null);
+  const { control, handleSubmit, watch, setValue } = useForm<AddCourtCaseFormValues>({
+    defaultValues: {
+      project_id: initialProjectId,
+      unit_ids: initialUnitId != null ? [initialUnitId] : [],
+      number: '',
+      date: dayjs(),
+      responsible_lawyer_id: profileId,
+      status: null,
+      description: '',
+    },
+  });
+
+  const projectId = watch('project_id');
+
+  const { data: projects = [] } = useProjects();
+  const { data: units = [] } = useUnitsByProject(projectId);
+  const { data: users = [] } = useUsers();
+  const { data: stages = [] } = useLitigationStages();
+
+  useEffect(() => {
+    setValue('unit_ids', initialUnitId != null ? [initialUnitId] : []);
+  }, [initialUnitId, setValue]);
+
+  const addCase = useAddCourtCase();
+
+  const submit = async (values: AddCourtCaseFormValues) => {
+    await addCase.mutateAsync({
+      project_id: values.project_id!,
+      unit_ids: values.unit_ids,
+      number: values.number,
+      date: values.date ? values.date.format('YYYY-MM-DD') : null,
+      plaintiff_id: null,
+      defendant_id: null,
+      responsible_lawyer_id: values.responsible_lawyer_id,
+      status: values.status ?? 1,
+      is_closed: false,
+      fix_start_date: null,
+      fix_end_date: null,
+      description: values.description || '',
+      attachment_ids: [],
+    } as any);
+    onSuccess?.();
+  };
+
+  return (
+    <form onSubmit={handleSubmit(submit)} noValidate>
+      <Stack spacing={2} sx={{ minWidth: 300 }}>
+        <Controller
+          name="project_id"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <FormControl fullWidth>
+              <InputLabel id="project-label">Проект</InputLabel>
+              <Select {...field} labelId="project-label" label="Проект">
+                {projects.map((p) => (
+                  <MenuItem key={p.id} value={p.id}>
+                    {p.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+        />
+        <Controller
+          name="unit_ids"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <FormControl fullWidth>
+              <InputLabel id="unit-label">Объект</InputLabel>
+              <Select
+                {...field}
+                multiple
+                labelId="unit-label"
+                label="Объект"
+                value={field.value}
+              >
+                {units.map((u) => (
+                  <MenuItem key={u.id} value={u.id}>
+                    {u.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+        />
+        <Controller
+          name="responsible_lawyer_id"
+          control={control}
+          render={({ field }) => (
+            <FormControl fullWidth>
+              <InputLabel id="lawyer-label">Ответственный юрист</InputLabel>
+              <Select
+                {...field}
+                labelId="lawyer-label"
+                label="Ответственный юрист"
+                value={field.value ?? ''}
+                onChange={(e) => field.onChange(e.target.value || null)}
+              >
+                <MenuItem value="">
+                  <em>Не указан</em>
+                </MenuItem>
+                {users.map((u) => (
+                  <MenuItem key={u.id} value={u.id}>
+                    {u.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+        />
+        <Controller
+          name="status"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <FormControl fullWidth>
+              <InputLabel id="status-label">Статус</InputLabel>
+              <Select {...field} labelId="status-label" label="Статус">
+                {stages.map((s) => (
+                  <MenuItem key={s.id} value={s.id}>
+                    {s.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+        />
+        <Controller
+          name="number"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <TextField {...field} label="Номер дела" fullWidth required />
+          )}
+        />
+        <Controller
+          name="date"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              format="DD.MM.YYYY"
+              value={field.value}
+              onChange={(d) => field.onChange(d)}
+              slotProps={{ textField: { fullWidth: true, required: true } }}
+            />
+          )}
+        />
+        <Controller
+          name="description"
+          control={control}
+          render={({ field }) => (
+            <TextField {...field} label="Описание" fullWidth multiline rows={3} />
+          )}
+        />
+        <DialogActions sx={{ px: 0 }}>
+          {onCancel && (
+            <Button onClick={onCancel}>Отмена</Button>
+          )}
+          <Button type="submit" variant="contained">
+            Добавить дело
+          </Button>
+        </DialogActions>
+      </Stack>
+    </form>
+  );
+}

--- a/src/widgets/UnitsMatrix/UnitsMatrix.tsx
+++ b/src/widgets/UnitsMatrix/UnitsMatrix.tsx
@@ -16,6 +16,9 @@ import useUnitsMatrix from "@/shared/hooks/useUnitsMatrix";
 import { supabase } from "@/shared/api/supabaseClient";
 import TicketForm from "@/features/ticket/TicketForm";
 import TicketListDialog from "@/features/ticket/TicketListDialog";
+import AddCourtCaseForm from "@/features/courtCase/AddCourtCaseForm";
+import AddLetterForm from "@/features/correspondence/AddLetterForm";
+import { ConfigProvider } from 'antd';
 
 /**
  * Шахматка квартир/этажей для заданного проекта/корпуса/секции.
@@ -327,8 +330,25 @@ export default function UnitsMatrix({
             >
               Добавить замечание
             </Button>
-            <Button variant="outlined" color="secondary" fullWidth disabled>
+            <Button
+              variant="outlined"
+              color="secondary"
+              fullWidth
+              onClick={() =>
+                setActionDialog((ad) => ({ ...ad, action: 'court' }))
+              }
+            >
               Добавить судебное дело
+            </Button>
+            <Button
+              variant="outlined"
+              color="inherit"
+              fullWidth
+              onClick={() =>
+                setActionDialog((ad) => ({ ...ad, action: 'letter' }))
+              }
+            >
+              Добавить письмо
             </Button>
             <Button
               variant="text"
@@ -363,6 +383,39 @@ export default function UnitsMatrix({
                 }
                 ticketId={undefined}
               />
+            </Box>
+          </DialogContent>
+        )}
+        {actionDialog.action === 'court' && (
+          <DialogContent sx={{ p: 0, pt: 2 }}>
+            <Typography sx={{ fontWeight: 500, textAlign: 'center', mb: 2 }}>
+              Добавление судебного дела для квартиры {actionDialog.unit?.name}
+            </Typography>
+            <Box sx={{ px: 2, pb: 2 }}>
+              <AddCourtCaseForm
+                initialProjectId={projectId}
+                initialUnitId={actionDialog.unit?.id}
+                onSuccess={() => setActionDialog({ open: false, unit: null, action: '' })}
+                onCancel={() => setActionDialog({ open: false, unit: null, action: '' })}
+              />
+            </Box>
+          </DialogContent>
+        )}
+        {actionDialog.action === 'letter' && (
+          <DialogContent sx={{ p: 0, pt: 2 }}>
+            <Typography sx={{ fontWeight: 500, textAlign: 'center', mb: 2 }}>
+              Добавление письма для квартиры {actionDialog.unit?.name}
+            </Typography>
+            <Box sx={{ px: 2, pb: 2 }}>
+              <ConfigProvider>
+                <AddLetterForm
+                  onSubmit={() => setActionDialog({ open: false, unit: null, action: '' })}
+                  initialValues={{
+                    project_id: projectId,
+                    unit_ids: actionDialog.unit ? [actionDialog.unit.id] : [],
+                  }}
+                />
+              </ConfigProvider>
             </Box>
           </DialogContent>
         )}


### PR DESCRIPTION
## Summary
- add `AddCourtCaseForm` to quickly register a court case
- support initial values in `AddLetterForm`
- extend `UnitsMatrix` menu with options to create court cases and letters

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_683e6f7a0554832e82fd8b17c71d845f