### PR TITLE
Add navigation with prefilled params

### DIFF
--- a/src/features/ticket/TicketFormAntd.tsx
+++ b/src/features/ticket/TicketFormAntd.tsx
@@ -18,7 +18,17 @@ import FileDropZone from '@/shared/ui/FileDropZone';
  * Форма создания замечания на основе Ant Design.
  * @param onCreated callback после успешного создания
  */
-export default function TicketFormAntd({ onCreated }: { onCreated?: () => void }) {
+export interface TicketFormAntdProps {
+  onCreated?: () => void;
+  /** Начальные значения формы */
+  initialValues?: Partial<{
+    project_id: number;
+    unit_ids: number[];
+    responsible_engineer_id: string;
+  }>;
+}
+
+export default function TicketFormAntd({ onCreated, initialValues = {} }: TicketFormAntdProps) {
   const [form] = Form.useForm();
   const globalProjectId = useProjectId();
   const projectId = Form.useWatch('project_id', form) ?? globalProjectId;
@@ -43,15 +53,25 @@ export default function TicketFormAntd({ onCreated }: { onCreated?: () => void }
   }, [projectId, typeId, deadlines]);
 
   useEffect(() => {
-    if (globalProjectId) {
+    if (initialValues.project_id != null) {
+      form.setFieldValue('project_id', initialValues.project_id);
+    } else if (globalProjectId) {
       form.setFieldValue('project_id', globalProjectId);
     }
+    if (initialValues.unit_ids) {
+      form.setFieldValue('unit_ids', initialValues.unit_ids);
+    }
+    if (initialValues.responsible_engineer_id) {
+      form.setFieldValue('responsible_engineer_id', initialValues.responsible_engineer_id);
+    }
     form.setFieldValue('received_at', dayjs());
-  }, [globalProjectId, form]);
+  }, [globalProjectId, form, initialValues]);
 
   useEffect(() => {
-    form.setFieldValue('unit_ids', []);
-  }, [projectId, form]);
+    if (!initialValues.unit_ids) {
+      form.setFieldValue('unit_ids', []);
+    }
+  }, [projectId, form, initialValues.unit_ids]);
 
   useEffect(() => {
     if (statuses.length) {

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import {
   ConfigProvider,
   Typography,
@@ -59,7 +60,17 @@ export default function CorrespondencePage() {
     content: '',
     search: '',
   });
+  const [searchParams] = useSearchParams();
   const [form] = Form.useForm();
+  const initialValues = {
+    project_id: searchParams.get('project_id')
+      ? Number(searchParams.get('project_id')!)
+      : undefined,
+    unit_ids: searchParams.get('unit_id')
+      ? [Number(searchParams.get('unit_id')!)]
+      : [],
+    responsible_user_id: searchParams.get('responsible_user_id') || undefined,
+  };
   const [view, setView] = useState<CorrespondenceLetter | null>(null);
   const [linkFor, setLinkFor] = useState<CorrespondenceLetter | null>(null);
 
@@ -178,7 +189,7 @@ export default function CorrespondencePage() {
     <ConfigProvider locale={ruRU}>
       <>
         <div style={{ marginTop: 16 }}>
-          <AddLetterForm onSubmit={handleAdd} />
+          <AddLetterForm onSubmit={handleAdd} initialValues={initialValues} />
         </div>
 
         <LinkLettersDialog

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import dayjs, { Dayjs } from 'dayjs';
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import 'dayjs/locale/ru';
@@ -109,10 +110,21 @@ export default function CourtCasesPage() {
   const [dialogCase, setDialogCase] = useState<CourtCase | null>(null);
   const [tab, setTab] = useState('defects');
 
+  const [searchParams] = useSearchParams();
+
   const [form] = Form.useForm();
   const projectId = Form.useWatch('project_id', form);
   const globalProjectId = useProjectId();
   const profileId = useAuthStore((s) => s.profile?.id);
+
+  useEffect(() => {
+    const p = searchParams.get('project_id');
+    const u = searchParams.get('unit_id');
+    const r = searchParams.get('responsible_lawyer_id');
+    if (p) form.setFieldValue('project_id', Number(p));
+    if (u) form.setFieldValue('unit_ids', [Number(u)]);
+    if (r) form.setFieldValue('responsible_lawyer_id', r);
+  }, [searchParams, form]);
 
   useEffect(() => {
     const handler = (e: StorageEvent) => {

--- a/src/pages/TicketsPage/TicketsPage.tsx
+++ b/src/pages/TicketsPage/TicketsPage.tsx
@@ -2,6 +2,7 @@
 // Страница «/tickets» – фильтры + таблица
 // -----------------------------------------------------------------------------
 import React, { useState, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
 import { ConfigProvider, Typography, Alert, Card } from "antd";
 import ruRU from "antd/locale/ru_RU";
 import { useSnackbar } from "notistack";
@@ -25,8 +26,18 @@ export default function TicketsPage() {
   );
   const { data: units = [] } = useUnitsByIds(unitIds);
   const qc = useQueryClient();
+  const [searchParams] = useSearchParams();
   const [filters, setFilters] = useState({});
   const [viewId, setViewId] = useState<number | null>(null);
+  const initialValues = {
+    project_id: searchParams.get('project_id')
+      ? Number(searchParams.get('project_id')!)
+      : undefined,
+    unit_ids: searchParams.get('unit_id')
+      ? [Number(searchParams.get('unit_id')!)]
+      : undefined,
+    responsible_engineer_id: searchParams.get('responsible_engineer_id') || undefined,
+  };
 
   /* toast api-ошибки */
   React.useEffect(() => {
@@ -85,7 +96,10 @@ export default function TicketsPage() {
         <Typography.Title level={4} style={{ marginBottom: 16 }}>Замечания</Typography.Title>
 
         <Card style={{ marginBottom: 24 }}>
-          <TicketFormAntd onCreated={() => qc.invalidateQueries({ queryKey: ['tickets'] })} />
+          <TicketFormAntd
+            onCreated={() => qc.invalidateQueries({ queryKey: ['tickets'] })}
+            initialValues={initialValues}
+          />
         </Card>
 
         <Card style={{ marginBottom: 24 }}>

--- a/src/widgets/UnitsMatrix/UnitsMatrix.tsx
+++ b/src/widgets/UnitsMatrix/UnitsMatrix.tsx
@@ -14,11 +14,9 @@ import AddIcon from "@mui/icons-material/Add";
 import FloorCell from "@/entities/floor/FloorCell";
 import useUnitsMatrix from "@/shared/hooks/useUnitsMatrix";
 import { supabase } from "@/shared/api/supabaseClient";
-import TicketForm from "@/features/ticket/TicketForm";
 import TicketListDialog from "@/features/ticket/TicketListDialog";
-import AddCourtCaseForm from "@/features/courtCase/AddCourtCaseForm";
-import AddLetterForm from "@/features/correspondence/AddLetterForm";
-import { ConfigProvider } from 'antd';
+import { useNavigate } from 'react-router-dom';
+import { useAuthStore } from '@/shared/store/authStore';
 
 /**
  * Шахматка квартир/этажей для заданного проекта/корпуса/секции.
@@ -38,6 +36,8 @@ export default function UnitsMatrix({
     ticketsByUnit,
     units,
   } = useUnitsMatrix(projectId, building, section);
+  const navigate = useNavigate();
+  const profileId = useAuthStore((s) => s.profile?.id);
 
   // Диалоги редактирования/удаления
   const [editDialog, setEditDialog] = useState({
@@ -324,9 +324,13 @@ export default function UnitsMatrix({
               variant="contained"
               color="primary"
               fullWidth
-              onClick={() =>
-                setActionDialog((ad) => ({ ...ad, action: "ticket" }))
-              }
+              onClick={() => {
+                const id = actionDialog.unit?.id;
+                navigate(
+                  `/tickets?project_id=${projectId}&unit_id=${id}&responsible_engineer_id=${profileId ?? ''}`,
+                );
+                setActionDialog({ open: false, unit: null, action: '' });
+              }}
             >
               Добавить замечание
             </Button>
@@ -334,9 +338,13 @@ export default function UnitsMatrix({
               variant="outlined"
               color="secondary"
               fullWidth
-              onClick={() =>
-                setActionDialog((ad) => ({ ...ad, action: 'court' }))
-              }
+              onClick={() => {
+                const id = actionDialog.unit?.id;
+                navigate(
+                  `/court-cases?project_id=${projectId}&unit_id=${id}&responsible_lawyer_id=${profileId ?? ''}`,
+                );
+                setActionDialog({ open: false, unit: null, action: '' });
+              }}
             >
               Добавить судебное дело
             </Button>
@@ -344,9 +352,13 @@ export default function UnitsMatrix({
               variant="outlined"
               color="inherit"
               fullWidth
-              onClick={() =>
-                setActionDialog((ad) => ({ ...ad, action: 'letter' }))
-              }
+              onClick={() => {
+                const id = actionDialog.unit?.id;
+                navigate(
+                  `/correspondence?project_id=${projectId}&unit_id=${id}&responsible_user_id=${profileId ?? ''}`,
+                );
+                setActionDialog({ open: false, unit: null, action: '' });
+              }}
             >
               Добавить письмо
             </Button>
@@ -363,60 +375,6 @@ export default function UnitsMatrix({
             <Button variant="text" color="info" fullWidth disabled>
               Показать историю
             </Button>
-          </DialogContent>
-        )}
-        {actionDialog.action === "ticket" && (
-          <DialogContent sx={{ p: 0, pt: 2 }}>
-            <Typography sx={{ fontWeight: 500, textAlign: "center", mb: 2 }}>
-              Добавление замечания для квартиры {actionDialog.unit?.name}
-            </Typography>
-            <Box sx={{ px: 2, pb: 2 }}>
-              <TicketForm
-                embedded
-                initialUnitId={actionDialog.unit?.id}
-                onCreated={() => {
-                  setActionDialog({ open: false, unit: null, action: "" });
-                  fetchUnits();
-                }}
-                onCancel={() =>
-                  setActionDialog({ open: false, unit: null, action: "" })
-                }
-                ticketId={undefined}
-              />
-            </Box>
-          </DialogContent>
-        )}
-        {actionDialog.action === 'court' && (
-          <DialogContent sx={{ p: 0, pt: 2 }}>
-            <Typography sx={{ fontWeight: 500, textAlign: 'center', mb: 2 }}>
-              Добавление судебного дела для квартиры {actionDialog.unit?.name}
-            </Typography>
-            <Box sx={{ px: 2, pb: 2 }}>
-              <AddCourtCaseForm
-                initialProjectId={projectId}
-                initialUnitId={actionDialog.unit?.id}
-                onSuccess={() => setActionDialog({ open: false, unit: null, action: '' })}
-                onCancel={() => setActionDialog({ open: false, unit: null, action: '' })}
-              />
-            </Box>
-          </DialogContent>
-        )}
-        {actionDialog.action === 'letter' && (
-          <DialogContent sx={{ p: 0, pt: 2 }}>
-            <Typography sx={{ fontWeight: 500, textAlign: 'center', mb: 2 }}>
-              Добавление письма для квартиры {actionDialog.unit?.name}
-            </Typography>
-            <Box sx={{ px: 2, pb: 2 }}>
-              <ConfigProvider>
-                <AddLetterForm
-                  onSubmit={() => setActionDialog({ open: false, unit: null, action: '' })}
-                  initialValues={{
-                    project_id: projectId,
-                    unit_ids: actionDialog.unit ? [actionDialog.unit.id] : [],
-                  }}
-                />
-              </ConfigProvider>
-            </Box>
           </DialogContent>
         )}
       </Dialog>


### PR DESCRIPTION
## Summary
- support initial values in `TicketFormAntd`
- open forms with preset data from query params on tickets, cases and letters pages
- navigate from structure page to those forms instead of showing modal

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npx tsc -p tsconfig.json` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_683e72f65cb8832eaaacdd39ce79b60b