### PR TITLE
Add primary unit link for tickets

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -792,6 +792,13 @@
   },
   {
     "table_name": "tickets",
+    "column_name": "unit_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": null
+  },
+  {
+    "table_name": "tickets",
     "column_name": "is_closed",
     "data_type": "boolean",
     "is_nullable": "NO",

--- a/migrations/20250613_add_unit_id_to_tickets.sql
+++ b/migrations/20250613_add_unit_id_to_tickets.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tickets
+  ADD COLUMN IF NOT EXISTS unit_id integer REFERENCES units(id);

--- a/src/entities/ticket.js
+++ b/src/entities/ticket.js
@@ -146,6 +146,7 @@ function mapTicket(r) {
     id: r.id,
     projectId: r.project_id,
     unitIds: r.unit_ids || [],
+    unitId: r.unit_id ?? null,
     typeId: r.type_id,
     statusId: r.status_id,
     projectName: r.projects?.name ?? "—",
@@ -180,7 +181,7 @@ export function useTickets() {
         .from("tickets")
         .select(
           `
-          id, project_id, unit_ids, type_id, status_id, title, description,
+          id, project_id, unit_ids, unit_id, type_id, status_id, title, description,
           customer_request_no, customer_request_date, responsible_engineer_id,
           created_by, is_warranty, is_closed, created_at, received_at, fixed_at,
           attachment_ids,
@@ -307,7 +308,7 @@ export function useTicket(ticketId) {
         .from("tickets")
         .select(
           `
-          id, project_id, unit_ids, type_id, status_id, title, description,
+          id, project_id, unit_ids, unit_id, type_id, status_id, title, description,
           customer_request_no, customer_request_date, responsible_engineer_id,
           created_by, is_warranty, is_closed, created_at, received_at, fixed_at,
           attachment_ids,

--- a/src/features/ticket/TicketForm.tsx
+++ b/src/features/ticket/TicketForm.tsx
@@ -58,6 +58,7 @@ interface TicketFormProps {
 interface TicketFormValues {
   project_id: number | null;
   unit_ids: number[];
+  unit_id: number | null;
   responsible_engineer_id: string | null;
   status_id: number | null;
   type_id: number | null;
@@ -94,6 +95,7 @@ export default function TicketForm({
     defaultValues: {
       project_id: globalProjectId ?? null,
       unit_ids: initialUnitId != null ? [initialUnitId] : [],
+      unit_id: initialUnitId ?? null,
       responsible_engineer_id: null,
       status_id: null,
       type_id: null,
@@ -142,6 +144,7 @@ export default function TicketForm({
       reset({
         project_id: ticket.projectId,
         unit_ids: ticket.unitIds,
+        unit_id: ticket.unitId,
         responsible_engineer_id: ticket.responsibleEngineerId,
         status_id: ticket.statusId,
         type_id: ticket.typeId,
@@ -205,6 +208,7 @@ export default function TicketForm({
     const payload = {
       project_id: values.project_id ?? globalProjectId,
       unit_ids: values.unit_ids,
+      unit_id: values.unit_id ?? values.unit_ids[0] ?? null,
       type_id: values.type_id,
       status_id: values.status_id,
       title: values.title,

--- a/src/features/ticket/TicketFormAntd.tsx
+++ b/src/features/ticket/TicketFormAntd.tsx
@@ -24,6 +24,7 @@ export interface TicketFormAntdProps {
   initialValues?: Partial<{
     project_id: number;
     unit_ids: number[];
+    unit_id: number;
     responsible_engineer_id: string;
   }>;
 }
@@ -61,6 +62,9 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
     if (initialValues.unit_ids) {
       form.setFieldValue('unit_ids', initialValues.unit_ids);
     }
+    if (initialValues.unit_id != null) {
+      form.setFieldValue('unit_id', initialValues.unit_id);
+    }
     if (initialValues.responsible_engineer_id) {
       form.setFieldValue('responsible_engineer_id', initialValues.responsible_engineer_id);
     }
@@ -70,6 +74,7 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
   useEffect(() => {
     if (!initialValues.unit_ids) {
       form.setFieldValue('unit_ids', []);
+      form.setFieldValue('unit_id', null);
     }
   }, [projectId, form, initialValues.unit_ids]);
 
@@ -100,6 +105,7 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
       await create.mutateAsync({
         ...rest,
         project_id: values.project_id ?? globalProjectId,
+        unit_id: values.unit_id ?? values.unit_ids?.[0] ?? null,
         attachments: files,
         received_at: values.received_at.format('YYYY-MM-DD'),
         fixed_at: values.fixed_at ? values.fixed_at.format('YYYY-MM-DD') : null,
@@ -118,6 +124,7 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
 
   return (
     <Form form={form} layout="vertical" onFinish={onFinish} autoComplete="off">
+      <Form.Item name="unit_id" hidden />
       <Row gutter={16}>
         <Col span={8}>
           <Form.Item name="project_id" label="Проект">
@@ -125,8 +132,16 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
           </Form.Item>
         </Col>
         <Col span={8}>
-          <Form.Item name="unit_ids" label="Объекты" rules={[{ required: true }]}>
-            <Select mode="multiple" options={units.map((u) => ({ value: u.id, label: u.name }))} disabled={!projectId} />
+          <Form.Item name="unit_ids" label="Объекты" rules={[{ required: true }]}> 
+            <Select
+              mode="multiple"
+              options={units.map((u) => ({ value: u.id, label: u.name }))}
+              disabled={!projectId}
+              onChange={(vals) => {
+                form.setFieldValue('unit_ids', vals);
+                form.setFieldValue('unit_id', vals?.[0] ?? null);
+              }}
+            />
           </Form.Item>
         </Col>
         <Col span={8}>

--- a/src/pages/TicketsPage/TicketsPage.tsx
+++ b/src/pages/TicketsPage/TicketsPage.tsx
@@ -36,6 +36,9 @@ export default function TicketsPage() {
     unit_ids: searchParams.get('unit_id')
       ? [Number(searchParams.get('unit_id')!)]
       : undefined,
+    unit_id: searchParams.get('unit_id')
+      ? Number(searchParams.get('unit_id')!)
+      : undefined,
     responsible_engineer_id: searchParams.get('responsible_engineer_id') || undefined,
   };
 

--- a/src/shared/types/ticket.ts
+++ b/src/shared/types/ticket.ts
@@ -3,6 +3,8 @@ export interface Ticket {
   project_id: number;
   /** массив ID объектов, к которым относится замечание */
   unit_ids: number[];
+  /** основной объект, выбранный при создании */
+  unit_id: number | null;
   type_id: number | null;
   status_id: number | null;
   title: string;


### PR DESCRIPTION
## Summary
- track the main object for each ticket
- update forms and queries to handle `unit_id`
- document DB change and add migration

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_683e83287a1c832eb32251b7acc55ff3