### PR TITLE
Implement colored ticket statuses

### DIFF
--- a/src/features/ticket/TicketStatusSelect.tsx
+++ b/src/features/ticket/TicketStatusSelect.tsx
@@ -1,17 +1,26 @@
 import React from "react";
-import { Select } from "antd";
+import { Select, Tag } from "antd";
 import { useTicketStatuses } from "@/entities/ticketStatus";
 import { useUpdateTicketStatus } from "@/entities/ticket";
 
 interface TicketStatusSelectProps {
   ticketId: number;
   statusId: number | null;
+  /** цвет статуса, используется до загрузки списка */
+  statusColor?: string | null;
+  /** имя статуса, используется до загрузки списка */
+  statusName?: string | null;
 }
 
 /**
  * Выпадающий список для смены статуса замечания напрямую из таблицы.
  */
-export default function TicketStatusSelect({ ticketId, statusId }: TicketStatusSelectProps) {
+export default function TicketStatusSelect({
+  ticketId,
+  statusId,
+  statusColor,
+  statusName,
+}: TicketStatusSelectProps) {
   const { data: statuses = [] } = useTicketStatuses();
   const update = useUpdateTicketStatus();
 
@@ -19,14 +28,27 @@ export default function TicketStatusSelect({ ticketId, statusId }: TicketStatusS
     update.mutate({ id: ticketId, statusId: value });
   };
 
+  const options = statuses.map((s) => ({
+    label: <Tag color={s.color ?? undefined}>{s.name}</Tag>,
+    value: s.id,
+  }));
+
+  const selected = options.find((o) => o.value === statusId);
+  const fallback = statusId ? (
+    <Tag color={statusColor ?? undefined}>{statusName ?? statusId}</Tag>
+  ) : undefined;
+
   return (
     <Select
       size="small"
       value={statusId ?? undefined}
       onChange={handleChange}
       loading={update.isPending}
-      options={statuses.map((s) => ({ label: s.name, value: s.id }))}
+      optionLabelProp="label"
+      options={options}
       style={{ width: "100%" }}
-    />
+    >
+      {selected ? null : fallback}
+    </Select>
   );
 }

--- a/src/widgets/TicketsTable.tsx
+++ b/src/widgets/TicketsTable.tsx
@@ -118,7 +118,12 @@ export default function TicketsTable({ tickets, filters, loading, onView }) {
         width: 160,
         sorter: (a, b) => a.statusName.localeCompare(b.statusName),
         render: (_, row) => (
-          <TicketStatusSelect ticketId={row.id} statusId={row.statusId} />
+          <TicketStatusSelect
+            ticketId={row.id}
+            statusId={row.statusId}
+            statusColor={row.statusColor}
+            statusName={row.statusName}
+          />
         ),
       },
       {


### PR DESCRIPTION
## Summary
- show ticket status colors in options
- pass color info to ticket status select

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4089c9c8832eabe7d23b34770b71