### PR TITLE
Fix tickets units relation

### DIFF
--- a/migrations/20250614_update_ticket_unit_id.sql
+++ b/migrations/20250614_update_ticket_unit_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tickets
+  DROP COLUMN IF EXISTS unit_id;

--- a/src/entities/ticket.js
+++ b/src/entities/ticket.js
@@ -146,7 +146,6 @@ function mapTicket(r) {
     id: r.id,
     projectId: r.project_id,
     unitIds: r.unit_ids || [],
-    unitId: r.unit_id ?? null,
     typeId: r.type_id,
     statusId: r.status_id,
     projectName: r.projects?.name ?? "—",
@@ -181,7 +180,7 @@ export function useTickets() {
         .from("tickets")
         .select(
           `
-          id, project_id, unit_ids, unit_id, type_id, status_id, title, description,
+          id, project_id, unit_ids, type_id, status_id, title, description,
           customer_request_no, customer_request_date, responsible_engineer_id,
           created_by, is_warranty, is_closed, created_at, received_at, fixed_at,
           attachment_ids,
@@ -308,7 +307,7 @@ export function useTicket(ticketId) {
         .from("tickets")
         .select(
           `
-          id, project_id, unit_ids, unit_id, type_id, status_id, title, description,
+          id, project_id, unit_ids, type_id, status_id, title, description,
           customer_request_no, customer_request_date, responsible_engineer_id,
           created_by, is_warranty, is_closed, created_at, received_at, fixed_at,
           attachment_ids,

--- a/src/features/ticket/TicketForm.tsx
+++ b/src/features/ticket/TicketForm.tsx
@@ -58,7 +58,6 @@ interface TicketFormProps {
 interface TicketFormValues {
   project_id: number | null;
   unit_ids: number[];
-  unit_id: number | null;
   responsible_engineer_id: string | null;
   status_id: number | null;
   type_id: number | null;
@@ -95,7 +94,6 @@ export default function TicketForm({
     defaultValues: {
       project_id: globalProjectId ?? null,
       unit_ids: initialUnitId != null ? [initialUnitId] : [],
-      unit_id: initialUnitId ?? null,
       responsible_engineer_id: null,
       status_id: null,
       type_id: null,
@@ -144,7 +142,6 @@ export default function TicketForm({
       reset({
         project_id: ticket.projectId,
         unit_ids: ticket.unitIds,
-        unit_id: ticket.unitId,
         responsible_engineer_id: ticket.responsibleEngineerId,
         status_id: ticket.statusId,
         type_id: ticket.typeId,
@@ -208,7 +205,6 @@ export default function TicketForm({
     const payload = {
       project_id: values.project_id ?? globalProjectId,
       unit_ids: values.unit_ids,
-      unit_id: values.unit_id ?? values.unit_ids[0] ?? null,
       type_id: values.type_id,
       status_id: values.status_id,
       title: values.title,

--- a/src/features/ticket/TicketFormAntd.tsx
+++ b/src/features/ticket/TicketFormAntd.tsx
@@ -24,7 +24,6 @@ export interface TicketFormAntdProps {
   initialValues?: Partial<{
     project_id: number;
     unit_ids: number[];
-    unit_id: number;
     responsible_engineer_id: string;
   }>;
 }
@@ -62,9 +61,6 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
     if (initialValues.unit_ids) {
       form.setFieldValue('unit_ids', initialValues.unit_ids);
     }
-    if (initialValues.unit_id != null) {
-      form.setFieldValue('unit_id', initialValues.unit_id);
-    }
     if (initialValues.responsible_engineer_id) {
       form.setFieldValue('responsible_engineer_id', initialValues.responsible_engineer_id);
     }
@@ -74,7 +70,6 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
   useEffect(() => {
     if (!initialValues.unit_ids) {
       form.setFieldValue('unit_ids', []);
-      form.setFieldValue('unit_id', null);
     }
   }, [projectId, form, initialValues.unit_ids]);
 
@@ -105,7 +100,6 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
       await create.mutateAsync({
         ...rest,
         project_id: values.project_id ?? globalProjectId,
-        unit_id: values.unit_id ?? values.unit_ids?.[0] ?? null,
         attachments: files,
         received_at: values.received_at.format('YYYY-MM-DD'),
         fixed_at: values.fixed_at ? values.fixed_at.format('YYYY-MM-DD') : null,
@@ -124,7 +118,6 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
 
   return (
     <Form form={form} layout="vertical" onFinish={onFinish} autoComplete="off">
-      <Form.Item name="unit_id" hidden />
       <Row gutter={16}>
         <Col span={8}>
           <Form.Item name="project_id" label="Проект">
@@ -139,7 +132,6 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
               disabled={!projectId}
               onChange={(vals) => {
                 form.setFieldValue('unit_ids', vals);
-                form.setFieldValue('unit_id', vals?.[0] ?? null);
               }}
             />
           </Form.Item>

--- a/src/pages/TicketsPage/TicketsPage.tsx
+++ b/src/pages/TicketsPage/TicketsPage.tsx
@@ -36,10 +36,8 @@ export default function TicketsPage() {
     unit_ids: searchParams.get('unit_id')
       ? [Number(searchParams.get('unit_id')!)]
       : undefined,
-    unit_id: searchParams.get('unit_id')
-      ? Number(searchParams.get('unit_id')!)
-      : undefined,
-    responsible_engineer_id: searchParams.get('responsible_engineer_id') || undefined,
+    responsible_engineer_id:
+      searchParams.get('responsible_engineer_id') || undefined,
   };
 
   /* toast api-ошибки */

--- a/src/shared/hooks/useUnitsMatrix.js
+++ b/src/shared/hooks/useUnitsMatrix.js
@@ -40,18 +40,20 @@ export default function useUnitsMatrix(projectId, building, section) {
                 .from('tickets')
                 .select(`
                     id,
-                    unit_id,
+                    unit_ids,
                     status_id,
                     ticket_statuses(color)
                 `)
-                .in('unit_id', unitIds);
+                .overlaps('unit_ids', unitIds);
             const byUnit = {};
             (ticketsData || []).forEach(t => {
-                if (!byUnit[t.unit_id]) byUnit[t.unit_id] = [];
-                byUnit[t.unit_id].push({
-                    id: t.id,
-                    status_id: t.status_id,
-                    color: t.ticket_statuses?.color || null,
+                (t.unit_ids || []).forEach(uid => {
+                    if (!byUnit[uid]) byUnit[uid] = [];
+                    byUnit[uid].push({
+                        id: t.id,
+                        status_id: t.status_id,
+                        color: t.ticket_statuses?.color || null,
+                    });
                 });
             });
             setTicketsByUnit(byUnit);

--- a/src/shared/types/ticket.ts
+++ b/src/shared/types/ticket.ts
@@ -3,8 +3,6 @@ export interface Ticket {
   project_id: number;
   /** массив ID объектов, к которым относится замечание */
   unit_ids: number[];
-  /** основной объект, выбранный при создании */
-  unit_id: number | null;
   type_id: number | null;
   status_id: number | null;
   title: string;


### PR DESCRIPTION
## Summary
- remove redundant `unit_id` column usage
- use `unit_ids` array for tickets
- adjust forms, hooks and entity mapping
- drop obsolete column via migration

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f424aedc0832e82548174005d53b7