### PR TITLE
Fix unit prefill in court case form

### DIFF
--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -144,8 +144,11 @@ export default function CourtCasesPage() {
   }, []);
 
   useEffect(() => {
+    // Сброс выбранных объектов при смене проекта.
+    // SearchParams могут проставить project_id и unit_id асинхронно,
+    // поэтому проверяем, что оба значения уже заданы.
     const prev = prevProjectIdRef.current;
-    if (prev !== null && prev !== projectId) {
+    if (prev != null && projectId != null && prev !== projectId) {
       form.setFieldValue('unit_ids', []);
     }
     prevProjectIdRef.current = projectId;


### PR DESCRIPTION
## Summary
- fix clearing unit on first load when project id comes from query params

## Testing
- `npm run lint` *(fails: cannot find package 'eslint-plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_683f47620b50832e9b0168eba38dc259