### PR TITLE
Highlight units with court cases

### DIFF
--- a/src/entities/floor/FloorCell.tsx
+++ b/src/entities/floor/FloorCell.tsx
@@ -8,10 +8,14 @@ import AddIcon from "@mui/icons-material/Add";
 const CELL_SIZE = 54;
 const FLOOR_COLOR = "#1976d2";
 
+/**
+ * Отображает один этаж в шахматке.
+ */
 export default function FloorCell({
   floor,
   units,
-  ticketsByUnit, // Новый проп!
+  ticketsByUnit,
+  casesByUnit,
   onAddUnit,
   onEditFloor,
   onDeleteFloor,
@@ -101,7 +105,8 @@ export default function FloorCell({
         <UnitCell
           key={unit.id}
           unit={unit}
-          tickets={ticketsByUnit ? ticketsByUnit[unit.id] : []} // <-- Вот тут!
+          tickets={ticketsByUnit ? ticketsByUnit[unit.id] : []}
+          cases={casesByUnit ? casesByUnit[unit.id] : []}
           onEditUnit={() => onEditUnit?.(unit)}
           onDeleteUnit={() => onDeleteUnit?.(unit)}
           onAction={() => onUnitClick?.(unit)}

--- a/src/entities/unit/UnitCell.tsx
+++ b/src/entities/unit/UnitCell.tsx
@@ -17,9 +17,14 @@ function getSemiTransparent(color, alpha = 0.3) {
   return color;
 }
 
+/**
+ * Ячейка объекта на шахматке.
+ * Подсвечивает наличие тикетов и судебных дел.
+ */
 export default function UnitCell({
   unit,
   tickets = [],
+  cases = [],
   onEditUnit,
   onDeleteUnit,
   onAction,
@@ -29,6 +34,7 @@ export default function UnitCell({
     Array.isArray(tickets) && tickets.length > 0 ? tickets[0] : null;
   const bgColor =
     ticket && ticket.color ? getSemiTransparent(ticket.color) : "#fff";
+  const hasCases = Array.isArray(cases) && cases.length > 0;
 
   return (
     <Paper
@@ -40,18 +46,20 @@ export default function UnitCell({
         flexDirection: "column",
         alignItems: "stretch",
         justifyContent: "flex-start",
-        border: "1.5px solid #dde2ee",
+        border: `1.5px solid ${hasCases ? "#e53935" : "#dde2ee"}`,
         background: bgColor,
         borderRadius: "12px",
-        boxShadow: "0 1px 6px 0 #E3ECFB",
+        boxShadow: hasCases ? "0 0 0 2px rgba(229,57,53,0.25)" : "0 1px 6px 0 #E3ECFB",
         px: 0,
         py: 0,
         overflow: "hidden",
         cursor: "pointer",
         transition: "box-shadow .15s, border-color .15s, background .15s",
         "&:hover": {
-          boxShadow: "0 4px 16px 0 #b5d2fa",
-          borderColor: "#1976d2",
+          boxShadow: hasCases
+            ? "0 0 0 2px rgba(211,47,47,0.4)"
+            : "0 4px 16px 0 #b5d2fa",
+          borderColor: hasCases ? "#d32f2f" : "#1976d2",
           background:
             ticket && ticket.color
               ? getSemiTransparent(ticket.color, 0.55)

--- a/src/widgets/UnitsMatrix/UnitsMatrix.tsx
+++ b/src/widgets/UnitsMatrix/UnitsMatrix.tsx
@@ -35,6 +35,7 @@ export default function UnitsMatrix({
     handleAddFloor,
     fetchUnits,
     ticketsByUnit,
+    casesByUnit,
     units,
   } = useUnitsMatrix(projectId, building, section);
   const navigate = useNavigate();
@@ -182,6 +183,7 @@ export default function UnitsMatrix({
             floor={floor}
             units={unitsByFloor[floor] || []}
             ticketsByUnit={ticketsByUnit}
+            casesByUnit={casesByUnit}
             onAddUnit={() => handleAddUnit(floor)}
             onEditFloor={handleEditFloor}
             onDeleteFloor={handleDeleteFloor}


### PR DESCRIPTION
## Summary
- mark units that have open court cases in `/structure`
- show red outline around apartments with court cases
- surface court case data in `useUnitsMatrix`

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_683fc7e71094832e97a1a9248c17e8b0