### PR TITLE
Fix unit prefill on correspondence page

### DIFF
--- a/src/features/correspondence/AddLetterForm.tsx
+++ b/src/features/correspondence/AddLetterForm.tsx
@@ -83,7 +83,13 @@ export default function AddLetterForm({ onSubmit, parentId = null, initialValues
     [contractorOptions, personOptions],
   );
 
+  const isFirstProject = React.useRef(true);
+
   useEffect(() => {
+    if (isFirstProject.current) {
+      isFirstProject.current = false;
+      return;
+    }
     form.setFieldValue('unit_ids', []);
   }, [projectId, form]);
 


### PR DESCRIPTION
## Summary
- avoid clearing prefilled `unit_ids` after navigation from Structure page

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_683fc9fbbda0832eb933f985c4cbe1c7