### PR TITLE
Add legend block to structure page

### DIFF
--- a/src/pages/ProjectStructurePage/ProjectStructurePage.tsx
+++ b/src/pages/ProjectStructurePage/ProjectStructurePage.tsx
@@ -17,6 +17,7 @@ import AddIcon from "@mui/icons-material/Add";
 import DeleteOutline from "@mui/icons-material/DeleteOutline";
 import AddBuildingOrSectionDialog from "@/features/addBuildingOrSection/AddBuildingOrSectionDialog";
 import UnitsMatrix from "@/widgets/UnitsMatrix/UnitsMatrix";
+import StatusLegend from "@/widgets/StatusLegend";
 import useProjectStructure from "@/shared/hooks/useProjectStructure";
 
 // Функция получения профиля пользователя
@@ -454,6 +455,7 @@ export default function ProjectStructurePage() {
           onUnitsChanged={setUnits}
         />
       )}
+      <StatusLegend />
     </Stack>
   );
 }

--- a/src/widgets/StatusLegend.tsx
+++ b/src/widgets/StatusLegend.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import { useTicketStatuses } from '@/entities/ticketStatus';
+
+/**
+ * Небольшой блок легенды статусов.
+ * Отображает цвета статусов замечаний и пояснение к красной обводке.
+ */
+export default function StatusLegend() {
+  const { data: statuses = [] } = useTicketStatuses();
+
+  return (
+    <Box sx={{ mt: 2, display: 'flex', flexDirection: 'column', gap: 1 }}>
+      <Typography variant="subtitle2">Легенда:</Typography>
+      <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 2 }}>
+        {statuses.map((s) => (
+          <Box key={s.id} sx={{ display: 'flex', alignItems: 'center', mr: 2 }}>
+            <Box
+              sx={{
+                width: 12,
+                height: 12,
+                bgcolor: s.color,
+                borderRadius: '50%',
+                mr: 0.5,
+              }}
+            />
+            <Typography variant="body2">{s.name}</Typography>
+          </Box>
+        ))}
+      </Box>
+      <Typography variant="body2" color="text.secondary">
+        Красная обводка — квартиры с судебными делами
+      </Typography>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- show color legend for ticket statuses
- display note about red border indicates court cases

## Testing
- `npm run lint` *(fails: cannot find module 'eslint-plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_683fcad3bcb0832e9b60e278d751d96c