### PR TITLE
Fix type errors in forms

### DIFF
--- a/src/features/correspondence/AddLetterForm.tsx
+++ b/src/features/correspondence/AddLetterForm.tsx
@@ -185,7 +185,9 @@ export default function AddLetterForm({ onSubmit, parentId = null, initialValues
                       allowClear
                       placeholder="Укажите отправителя"
                       filterOption={(input, option) =>
-                        (option?.value ?? '').toLowerCase().includes(input.toLowerCase())
+                        String(option?.value ?? '')
+                          .toLowerCase()
+                          .includes(input.toLowerCase())
                       }
                     />
                   </Form.Item>
@@ -246,7 +248,9 @@ export default function AddLetterForm({ onSubmit, parentId = null, initialValues
                       allowClear
                       placeholder="Укажите получателя"
                       filterOption={(input, option) =>
-                        (option?.value ?? '').toLowerCase().includes(input.toLowerCase())
+                        String(option?.value ?? '')
+                          .toLowerCase()
+                          .includes(input.toLowerCase())
                       }
                     />
                   </Form.Item>

--- a/src/features/ticket/TicketForm.tsx
+++ b/src/features/ticket/TicketForm.tsx
@@ -296,13 +296,10 @@ export default function TicketForm({
                 label="Проект"
                 displayEmpty
                 value={field.value ?? ""}
-                onChange={(e) =>
-                  field.onChange(
-                    (e.target.value as string) === ""
-                      ? null
-                      : Number(e.target.value as string),
-                  )
-                }
+                onChange={(e) => {
+                  const val = e.target.value;
+                  field.onChange(val === "" ? null : Number(val));
+                }}
               >
                 {!isEdit && (
                   <MenuItem value="">
@@ -359,11 +356,10 @@ export default function TicketForm({
                 label="Ответственный инженер"
                 displayEmpty
                 value={field.value ?? ""}
-                onChange={(e) =>
-                  field.onChange(
-                    (e.target.value as string) === "" ? null : (e.target.value as string)
-                  )
-                }
+                onChange={(e) => {
+                  const val = e.target.value;
+                  field.onChange(val === "" ? null : val);
+                }}
               >
                 {!isEdit && (
                   <MenuItem value="">
@@ -392,13 +388,10 @@ export default function TicketForm({
                 label="Статус"
                 displayEmpty
                 value={field.value ?? ""}
-                onChange={(e) =>
-                  field.onChange(
-                    (e.target.value as string) === ""
-                      ? null
-                      : Number(e.target.value as string),
-                  )
-                }
+                onChange={(e) => {
+                  const val = e.target.value;
+                  field.onChange(val === "" ? null : Number(val));
+                }}
               >
                 {!isEdit && (
                   <MenuItem value="">
@@ -429,13 +422,10 @@ export default function TicketForm({
                 label={`Тип${deadlineDays ? ` (${deadlineDays} дн.)` : ""}`}
                 displayEmpty
                 value={field.value ?? ""}
-                onChange={(e) =>
-                  field.onChange(
-                    (e.target.value as string) === ""
-                      ? null
-                      : Number(e.target.value as string),
-                  )
-                }
+                onChange={(e) => {
+                  const val = e.target.value;
+                  field.onChange(val === "" ? null : Number(val));
+                }}
               >
                 {!isEdit && (
                   <MenuItem value="">


### PR DESCRIPTION
## Summary
- sanitize filter option by casting to string
- handle select changes without invalid casts

## Testing
- `npm run lint` *(fails: Parsing errors)*
- `npx tsc --noEmit` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684223a4d104832e87cea532457bff46