### PR TITLE
Implement stats dashboards

### DIFF
--- a/src/entities/courtCase/index.ts
+++ b/src/entities/courtCase/index.ts
@@ -26,6 +26,20 @@ export function useCourtCases() {
   });
 }
 
+export function useAllCourtCases() {
+  return useQuery({
+    queryKey: [CASES_TABLE, 'all'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from(CASES_TABLE)
+        .select('id, project_id, status, defendant_id');
+      if (error) throw error;
+      return (data ?? []) as CourtCase[];
+    },
+    staleTime: 5 * 60_000,
+  });
+}
+
 export function useAddCourtCase() {
   const qc = useQueryClient();
   return useMutation({

--- a/src/entities/ticket.js
+++ b/src/entities/ticket.js
@@ -503,6 +503,23 @@ export function useAllTicketsSimple() {
 }
 
 // -----------------------------------------------------------------------------
+// Полный список замечаний для статистики
+// -----------------------------------------------------------------------------
+export function useTicketsStats() {
+  return useQuery({
+    queryKey: ["tickets-stats"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("tickets")
+        .select("id, project_id, type_id, is_warranty, fixed_at");
+      if (error) throw error;
+      return data ?? [];
+    },
+    staleTime: 5 * 60_000,
+  });
+}
+
+// -----------------------------------------------------------------------------
 // Обновить статус замечания
 // -----------------------------------------------------------------------------
 export function useUpdateTicketStatus() {

--- a/src/entities/unit.js
+++ b/src/entities/unit.js
@@ -75,6 +75,19 @@ export const useUnitsByProject = (projectId) =>
         staleTime: 5 * 60_000,
     });
 
+export const useAllUnits = () =>
+    useQuery({
+        queryKey: ['units-all'],
+        queryFn : async () => {
+            const { data, error } = await supabase
+                .from('units')
+                .select('id, project_id, building');
+            if (error) throw error;
+            return data ?? [];
+        },
+        staleTime: 5 * 60_000,
+    });
+
 export const useUnitsByIds = (ids) =>
     useQuery({
         queryKey: ['units-by-ids', ids?.join(',')],

--- a/src/pages/StatsPage/StatsPage.tsx
+++ b/src/pages/StatsPage/StatsPage.tsx
@@ -1,50 +1,143 @@
 import React from "react";
-import { Paper, Typography, CircularProgress, Box } from "@mui/material";
+import { Skeleton } from "@mui/material";
 import { useProjects } from "@/entities/project";
-import { useAllTicketsSimple } from "@/entities/ticket";
-import { useTicketStatuses } from "@/entities/ticketStatus";
+import { useAllUnits } from "@/entities/unit";
+import { useTicketsStats } from "@/entities/ticket";
+import { useTicketTypes } from "@/entities/ticketType";
+import { useAllCourtCases } from "@/entities/courtCase";
+import { useLitigationStages } from "@/entities/litigationStage";
+import { useContractors } from "@/entities/contractor";
+import AdminDataGrid from "@/shared/ui/AdminDataGrid";
 
+/**
+ * Статистика по проектам, замечаниям и судебным делам.
+ */
 export default function StatsPage() {
   const { data: projects = [], isPending: loadingProjects } = useProjects();
-  const {
-    data: tickets = [],
-    isPending: loadingTickets,
-    error,
-  } = useAllTicketsSimple();
-  const { data: statuses = [] } = useTicketStatuses();
+  const { data: units = [], isPending: loadingUnits } = useAllUnits();
+  const { data: tickets = [], isPending: loadingTickets } = useTicketsStats();
+  const { data: ticketTypes = [] } = useTicketTypes();
+  const { data: cases = [], isPending: loadingCases } = useAllCourtCases();
+  const { data: stages = [] } = useLitigationStages();
+  const { data: contractors = [] } = useContractors();
 
-  const totalTickets = tickets.length;
-  const byStatus = React.useMemo(() => {
-    const m: Record<number, number> = {};
-    (tickets ?? []).forEach((t) => {
-      m[t.status_id] = (m[t.status_id] || 0) + 1;
+  const loading =
+    loadingProjects || loadingUnits || loadingTickets || loadingCases;
+
+  const projectMap = React.useMemo(() => {
+    const map: Record<number, string> = {};
+    projects.forEach((p) => {
+      map[p.id] = p.name;
+    });
+    return map;
+  }, [projects]);
+
+  // ──────────── Dashboard 1: объекты по корпусам ────────────
+  const unitsRows = React.useMemo(() => {
+    const map: Record<string, { id: string; project: string; building: string; count: number }> = {};
+    units.forEach((u) => {
+      const project = projectMap[u.project_id] || "—";
+      const building = u.building || "—";
+      const key = `${project}-${building}`;
+      if (!map[key]) {
+        map[key] = { id: key, project, building, count: 0 };
+      }
+      map[key].count += 1;
+    });
+    return Object.values(map);
+  }, [units, projectMap]);
+
+  // ──────────── Dashboard 2: замечания по типам ────────────
+  const typeMap = React.useMemo(() => {
+    const m: Record<number, string> = {};
+    ticketTypes.forEach((t) => {
+      m[t.id] = t.name;
     });
     return m;
-  }, [tickets]);
+  }, [ticketTypes]);
 
-  if (loadingProjects || loadingTickets) {
-    return <CircularProgress />;
-  }
+  const ticketsRows = React.useMemo(() => {
+    const map: Record<string, { id: string; project: string; type: string; total: number; warranty: number; fixed: number }> = {};
+    tickets.forEach((t) => {
+      const project = projectMap[t.project_id] || "—";
+      const type = typeMap[t.type_id] || "—";
+      const key = `${project}-${type}`;
+      if (!map[key]) {
+        map[key] = { id: key, project, type, total: 0, warranty: 0, fixed: 0 };
+      }
+      map[key].total += 1;
+      if (t.is_warranty) map[key].warranty += 1;
+      if (t.fixed_at) map[key].fixed += 1;
+    });
+    return Object.values(map);
+  }, [tickets, projectMap, typeMap]);
+
+  // ──────────── Dashboard 3: судебные дела ────────────
+  const stageMap = React.useMemo(() => {
+    const m: Record<number, string> = {};
+    stages.forEach((s) => {
+      m[s.id] = s.name;
+    });
+    return m;
+  }, [stages]);
+
+  const contractorMap = React.useMemo(() => {
+    const m: Record<number, string> = {};
+    contractors.forEach((c) => {
+      m[c.id] = c.name;
+    });
+    return m;
+  }, [contractors]);
+
+  const casesRows = React.useMemo(() => {
+    const map: Record<string, { id: string; project: string; status: string; contractor: string; total: number }> = {};
+    cases.forEach((c) => {
+      const project = projectMap[c.project_id] || "—";
+      const status = stageMap[c.status] || "—";
+      const contractor = contractorMap[c.defendant_id] || "—";
+      const key = `${project}-${status}-${contractor}`;
+      if (!map[key]) {
+        map[key] = { id: key, project, status, contractor, total: 0 };
+      }
+      map[key].total += 1;
+    });
+    return Object.values(map);
+  }, [cases, projectMap, stageMap, contractorMap]);
+
+  if (loading) return <Skeleton variant="rectangular" height={160} />;
 
   return (
-    <Paper sx={{ p: 3 }}>
-      <Typography variant="h4" gutterBottom>
-        Статистика
-      </Typography>
-      <Typography>Количество проектов: {projects.length}</Typography>
-      <Typography sx={{ mt: 1 }}>Всего замечаний: {totalTickets}</Typography>
-      <Box sx={{ mt: 2 }}>
-        {statuses.map((st) => (
-          <Typography key={st.id}>
-            {st.name}: {byStatus[st.id] ?? 0}
-          </Typography>
-        ))}
-      </Box>
-      {error && (
-        <Typography color="error" sx={{ mt: 2 }}>
-          {error.message}
-        </Typography>
-      )}
-    </Paper>
+    <div>
+      <AdminDataGrid
+        title="Объекты по проектам"
+        rows={unitsRows}
+        columns={[
+          { field: "project", headerName: "Проект", flex: 1 },
+          { field: "building", headerName: "Корпус", flex: 1 },
+          { field: "count", headerName: "Кол-во объектов", width: 150 },
+        ]}
+      />
+      <AdminDataGrid
+        title="Замечания по типам"
+        rows={ticketsRows}
+        columns={[
+          { field: "project", headerName: "Проект", flex: 1 },
+          { field: "type", headerName: "Тип", flex: 1 },
+          { field: "total", headerName: "Всего", width: 100 },
+          { field: "warranty", headerName: "Гарантийных", width: 120 },
+          { field: "fixed", headerName: "Устранено", width: 110 },
+        ]}
+      />
+      <AdminDataGrid
+        title="Судебные дела"
+        rows={casesRows}
+        columns={[
+          { field: "project", headerName: "Проект", flex: 1 },
+          { field: "status", headerName: "Статус", flex: 1 },
+          { field: "contractor", headerName: "Заказчик", flex: 1 },
+          { field: "total", headerName: "Количество", width: 130 },
+        ]}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- show project and building unit counts
- aggregate ticket counts by type
- add court cases dashboard
- expose hooks for stats queries

## Testing
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_68422964ffa4832e985e7a91e09dfc9c