### PR TITLE
Optimize realtime subscriptions

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,6 +5,7 @@ import { useLocation } from "react-router-dom";
 
 import { supabase } from "@shared/api/supabaseClient";
 import { useAuthStore } from "@shared/store/authStore";
+import { useRealtimeUpdates } from "@/shared/hooks/useRealtimeUpdates";
 
 import NavBar from "@/widgets/NavBar";
 import AppRouter from "./Router";
@@ -14,6 +15,7 @@ const log = (...a) => console.log("%c[App]", "color:teal", ...a);
 export default function App() {
   const setProfile = useAuthStore((s) => s.setProfile);
   const location = useLocation();
+  useRealtimeUpdates();
 
   const loadProfile = useCallback(
     async (user, tag = "") => {

--- a/src/shared/hooks/useRealtimeUpdates.ts
+++ b/src/shared/hooks/useRealtimeUpdates.ts
@@ -1,0 +1,57 @@
+import { useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/shared/api/supabaseClient';
+import { useProjectId } from '@/shared/hooks/useProjectId';
+
+/**
+ * Подписка на создание записей в ключевых таблицах.
+ * Использует один канал Supabase для минимизации запросов
+ * к `realtime.list_changes` и инвалидирует кэш React Query
+ * при появлении новых данных.
+ */
+export function useRealtimeUpdates() {
+  const qc = useQueryClient();
+  const projectId = useProjectId();
+
+  useEffect(() => {
+    if (!projectId) return;
+
+    const channel = supabase
+      .channel('realtime-updates')
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'tickets',
+          filter: `project_id=eq.${projectId}`,
+        },
+        () => qc.invalidateQueries({ queryKey: ['tickets', projectId] }),
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'court_cases',
+          filter: `project_id=eq.${projectId}`,
+        },
+        () => qc.invalidateQueries({ queryKey: ['court_cases', projectId] }),
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'letters',
+          filter: `project_id=eq.${projectId}`,
+        },
+        () => qc.invalidateQueries({ queryKey: ['letters'] }),
+      )
+      .subscribe();
+
+    return () => {
+      channel.unsubscribe();
+    };
+  }, [projectId, qc]);
+}


### PR DESCRIPTION
## Summary
- add `useRealtimeUpdates` hook for realtime tables
- connect the hook in `App` to react-query caches
- filter realtime updates by `project_id`

## Testing
- `npm run lint` *(fails: parsing errors and missing eslint plugins)*

------
https://chatgpt.com/codex/tasks/task_e_684560daa8c0832e9f60e1d8bd1f5d6b