### PR TITLE
Enforce attachment types in tickets

### DIFF
--- a/src/features/ticket/TicketForm.tsx
+++ b/src/features/ticket/TicketForm.tsx
@@ -28,6 +28,7 @@ import { useAttachmentTypes } from "@/entities/attachmentType";
 import { useCreateTicket, useTicket, signedUrl } from "@/entities/ticket";
 import { useProjectId } from "@/shared/hooks/useProjectId";
 import { useUnsavedChangesWarning } from "@/shared/hooks/useUnsavedChangesWarning";
+import { useNotify } from "@/shared/hooks/useNotify";
 import AttachmentEditorTable from "@/shared/ui/AttachmentEditorTable";
 import type { Ticket } from "@/shared/types/ticket";
 
@@ -82,6 +83,7 @@ export default function TicketForm({
   initialUnitId,
 }: TicketFormProps) {
   const globalProjectId = useProjectId();
+  const notify = useNotify();
   const {
     control,
     handleSubmit,
@@ -202,6 +204,13 @@ export default function TicketForm({
 
 
   const submit = async (values: TicketFormValues) => {
+    if (
+      newFiles.some((f) => f.type_id == null) ||
+      remoteFiles.some((f) => (changedTypes[f.id] ?? null) == null)
+    ) {
+      notify.warn('Выберите тип файла для всех документов');
+      return;
+    }
     const payload = {
       project_id: values.project_id ?? globalProjectId,
       unit_ids: values.unit_ids,

--- a/src/features/ticket/TicketFormAntd.tsx
+++ b/src/features/ticket/TicketFormAntd.tsx
@@ -13,6 +13,7 @@ import type { Ticket } from '@/shared/types/ticket';
 import { useProjectId } from '@/shared/hooks/useProjectId';
 import { useAuthStore } from '@/shared/store/authStore';
 import FileDropZone from '@/shared/ui/FileDropZone';
+import { useNotify } from '@/shared/hooks/useNotify';
 
 /**
  * Форма создания замечания на основе Ant Design.
@@ -41,6 +42,7 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
   const { data: attachmentTypes = [] } = useAttachmentTypes();
   const { data: deadlines = [] } = useDefectDeadlines();
   const create = useCreateTicket();
+  const notify = useNotify();
   const [files, setFiles] = useState<{ file: File; type_id: number | null }[]>([]);
   const profileId = useAuthStore((s) => s.profile?.id);
   const typeId = Form.useWatch('type_id', form);
@@ -94,6 +96,10 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
   const removeFile = (idx: number) => setFiles((p) => p.filter((_, i) => i !== idx));
 
   const onFinish = async (values: any) => {
+    if (files.some((f) => f.type_id == null)) {
+      notify.warn('Выберите тип файла для всех документов');
+      return;
+    }
     try {
       const rest = { ...values } as any;
       delete rest.pins;


### PR DESCRIPTION
## Summary
- add global notification helper to ticket forms
- prevent saving tickets if any attachment lacks a type

## Testing
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_6845779fdce8832ea6a9e7fe203a6b0d