### PR TITLE
Implement global snackbar notifications

### DIFF
--- a/src/features/courtCase/AddCourtCaseForm.tsx
+++ b/src/features/courtCase/AddCourtCaseForm.tsx
@@ -18,6 +18,7 @@ import { useUsers } from '@/entities/user';
 import { useLitigationStages } from '@/entities/litigationStage';
 import { useAddCourtCase } from '@/entities/courtCase';
 import { useAuthStore } from '@/shared/store/authStore';
+import { useNotify } from '@/shared/hooks/useNotify';
 
 export interface AddCourtCaseFormValues {
   project_id: number | null;
@@ -70,24 +71,30 @@ export default function AddCourtCaseForm({
   }, [initialUnitId, setValue]);
 
   const addCase = useAddCourtCase();
+  const notify = useNotify();
 
   const submit = async (values: AddCourtCaseFormValues) => {
-    await addCase.mutateAsync({
-      project_id: values.project_id!,
-      unit_ids: values.unit_ids,
-      number: values.number,
-      date: values.date ? values.date.format('YYYY-MM-DD') : null,
-      plaintiff_id: null,
-      defendant_id: null,
-      responsible_lawyer_id: values.responsible_lawyer_id,
-      status: values.status ?? 1,
-      is_closed: false,
-      fix_start_date: null,
-      fix_end_date: null,
-      description: values.description || '',
-      attachment_ids: [],
-    } as any);
-    onSuccess?.();
+    try {
+      await addCase.mutateAsync({
+        project_id: values.project_id!,
+        unit_ids: values.unit_ids,
+        number: values.number,
+        date: values.date ? values.date.format('YYYY-MM-DD') : null,
+        plaintiff_id: null,
+        defendant_id: null,
+        responsible_lawyer_id: values.responsible_lawyer_id,
+        status: values.status ?? 1,
+        is_closed: false,
+        fix_start_date: null,
+        fix_end_date: null,
+        description: values.description || '',
+        attachment_ids: [],
+      } as any);
+      notify.success('Дело успешно добавлено!');
+      onSuccess?.();
+    } catch (e: any) {
+      notify.error(e.message);
+    }
   };
 
   return (

--- a/src/features/ticket/TicketForm.tsx
+++ b/src/features/ticket/TicketForm.tsx
@@ -208,7 +208,7 @@ export default function TicketForm({
       newFiles.some((f) => f.type_id == null) ||
       remoteFiles.some((f) => (changedTypes[f.id] ?? null) == null)
     ) {
-      notify.warn('Выберите тип файла для всех документов');
+      notify.error('Выберите тип файла для всех документов');
       return;
     }
     const payload = {

--- a/src/features/ticket/TicketFormAntd.tsx
+++ b/src/features/ticket/TicketFormAntd.tsx
@@ -97,7 +97,7 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
 
   const onFinish = async (values: any) => {
     if (files.some((f) => f.type_id == null)) {
-      notify.warn('Выберите тип файла для всех документов');
+      notify.error('Выберите тип файла для всех документов');
       return;
     }
     try {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./app/App";
 import { BrowserRouter } from "react-router-dom";
+import { SnackbarProvider } from "notistack";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { queryClient } from "@/shared/config/queryClient";
@@ -16,9 +17,14 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="ru">
       <QueryClientProvider client={queryClient}>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
+        <SnackbarProvider
+          maxSnack={3}
+          anchorOrigin={{ vertical: "top", horizontal: "right" }}
+        >
+          <BrowserRouter>
+            <App />
+          </BrowserRouter>
+        </SnackbarProvider>
         <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>
     </LocalizationProvider>

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -7,7 +7,6 @@ import {
   Select,
   Input,
   Button,
-  message,
 } from 'antd';
 import ruRU from 'antd/locale/ru_RU';
 import dayjs from 'dayjs';
@@ -31,6 +30,7 @@ import { useLetterTypes } from '@/entities/letterType';
 import { useProjects } from '@/entities/project';
 import { useUnitsByProject, useUnitsByIds } from '@/entities/unit';
 import { useAttachmentTypes } from '@/entities/attachmentType';
+import { useNotify } from '@/shared/hooks/useNotify';
 
 interface Filters {
   type?: 'incoming' | 'outgoing' | '';
@@ -50,6 +50,7 @@ export default function CorrespondencePage() {
   const remove = useDeleteLetter();
   const linkLetters = useLinkLetters();
   const unlinkLetter = useUnlinkLetter();
+  const notify = useNotify();
   const [filters, setFilters] = useState<Filters>({
     type: '',
     project: '',
@@ -129,7 +130,7 @@ export default function CorrespondencePage() {
 
     add.mutate(safeData, {
       onSuccess: () => {
-        message.success('Письмо добавлено');
+        notify.success('Письмо добавлено');
       },
     });
   };
@@ -137,13 +138,13 @@ export default function CorrespondencePage() {
   const handleDelete = (id: string) => {
     if (!window.confirm('Удалить письмо?')) return;
     remove.mutate(id, {
-      onSuccess: () => message.success('Письмо удалено'),
+      onSuccess: () => notify.success('Письмо удалено'),
     });
   };
 
   const handleUnlink = (id: string) => {
     unlinkLetter.mutate(id, {
-      onSuccess: () => message.success('Письмо исключено из связи'),
+      onSuccess: () => notify.success('Письмо исключено из связи'),
     });
   };
 
@@ -201,7 +202,7 @@ export default function CorrespondencePage() {
             if (!linkFor) return;
             linkLetters.mutate({ parentId: linkFor.id, childIds: ids }, {
               onSuccess: () => {
-                message.success('Письма связаны');
+                notify.success('Письма связаны');
                 setLinkFor(null);
               },
             });

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -21,7 +21,6 @@ import {
   Space,
   Modal,
   Tabs,
-  message,
   Popconfirm,
   Tooltip,
   Radio,
@@ -68,6 +67,7 @@ import { supabase } from '@/shared/api/supabaseClient';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useProjectId } from '@/shared/hooks/useProjectId';
 import { useAuthStore } from '@/shared/store/authStore';
+import { useNotify } from '@/shared/hooks/useNotify';
 import FileDropZone from '@/shared/ui/FileDropZone';
 import CourtCaseStatusSelect from '@/features/courtCase/CourtCaseStatusSelect';
 import CourtCaseClosedSelect from '@/features/courtCase/CourtCaseClosedSelect';
@@ -98,6 +98,7 @@ export default function CourtCasesPage() {
   const deleteCaseMutation = useDeleteCourtCase();
   const qc = useQueryClient();
   const updateCaseMutation = useUpdateCourtCase();
+  const notify = useNotify();
 
   const [filters, setFilters] = useState<Filters>(() => {
     try {
@@ -256,16 +257,16 @@ export default function CourtCasesPage() {
 
       form.resetFields();
       setCaseFiles([]);
-      message.success('Дело успешно добавлено!');
+      notify.success('Дело успешно добавлено!');
     } catch (e: any) {
-      message.error(e.message);
+      notify.error(e.message);
     }
   };
 
   const deleteCase = (id: number) => {
     deleteCaseMutation.mutate(id, {
-      onSuccess: () => message.success('Дело удалено!'),
-      onError: (e: any) => message.error(e.message),
+      onSuccess: () => notify.success('Дело удалено!'),
+      onError: (e: any) => notify.error(e.message),
     });
   };
 
@@ -507,19 +508,19 @@ export default function CourtCasesPage() {
                       if (plaintiffType === 'person') {
                         deletePersonMutation.mutate(id, {
                           onSuccess: () => {
-                            message.success('Физлицо удалено');
+                            notify.success('Физлицо удалено');
                             form.setFieldValue('plaintiff_id', null);
                             qc.invalidateQueries({ queryKey: ['projectPersons'] });
                           },
-                          onError: (e: any) => message.error(e.message),
+                          onError: (e: any) => notify.error(e.message),
                         });
                       } else {
                         deleteContractorMutation.mutate(id, {
                           onSuccess: () => {
-                            message.success('Контрагент удалён');
+                            notify.success('Контрагент удалён');
                             form.setFieldValue('plaintiff_id', null);
                           },
-                          onError: (e: any) => message.error(e.message),
+                          onError: (e: any) => notify.error(e.message),
                         });
                       }
                     }}
@@ -590,19 +591,19 @@ export default function CourtCasesPage() {
                       if (defendantType === 'person') {
                         deletePersonMutation.mutate(id, {
                           onSuccess: () => {
-                            message.success('Физлицо удалено');
+                            notify.success('Физлицо удалено');
                             form.setFieldValue('defendant_id', null);
                             qc.invalidateQueries({ queryKey: ['projectPersons'] });
                           },
-                          onError: (e: any) => message.error(e.message),
+                          onError: (e: any) => notify.error(e.message),
                         });
                       } else {
                         deleteContractorMutation.mutate(id, {
                           onSuccess: () => {
-                            message.success('Контрагент удалён');
+                            notify.success('Контрагент удалён');
                             form.setFieldValue('defendant_id', null);
                           },
-                          onError: (e: any) => message.error(e.message),
+                          onError: (e: any) => notify.error(e.message),
                         });
                       }
                     }}
@@ -928,10 +929,10 @@ function CaseDialog({ open, onClose, caseData, tab, onTabChange, projects }: Cas
           description: values.description || '',
         },
       });
-      message.success('Дело обновлено');
+      notify.success('Дело обновлено');
       setEditing(false);
     } catch (e: any) {
-      message.error(e.message);
+      notify.error(e.message);
     }
   };
 
@@ -941,7 +942,7 @@ function CaseDialog({ open, onClose, caseData, tab, onTabChange, projects }: Cas
     addDefectMutation.mutate(
       { case_id: Number(caseData.id), project_id: caseData.project_id, ...defect },
       {
-        onError: (e: any) => message.error(e.message),
+        onError: (e: any) => notify.error(e.message),
       },
     );
   };
@@ -951,7 +952,7 @@ function CaseDialog({ open, onClose, caseData, tab, onTabChange, projects }: Cas
     deleteDefectMutation.mutate(
       { id, case_id: Number(caseData.id) },
       {
-        onError: (e: any) => message.error(e.message),
+        onError: (e: any) => notify.error(e.message),
       },
     );
   };
@@ -961,7 +962,7 @@ function CaseDialog({ open, onClose, caseData, tab, onTabChange, projects }: Cas
     updateDefectMutation.mutate(
       { id: defect.id, case_id: Number(caseData.id), updates: defect },
       {
-        onError: (e: any) => message.error(e.message),
+        onError: (e: any) => notify.error(e.message),
       },
     );
   };
@@ -1341,7 +1342,7 @@ function CaseFilesTab({ caseData }: CaseFilesTabProps) {
       }));
       setFiles(arr);
     } catch (err: any) {
-      message.error(err.message);
+      notify.error(err.message);
     }
   };
 
@@ -1385,9 +1386,9 @@ function CaseFilesTab({ caseData }: CaseFilesTabProps) {
         type_id: a.attachment_type_id,
       }));
       setFiles((p) => [...p, ...newFiles]);
-      message.success('Файлы загружены');
+      notify.success('Файлы загружены');
     } catch (err: any) {
-      message.error(err.message);
+      notify.error(err.message);
     }
   };
 
@@ -1401,9 +1402,9 @@ function CaseFilesTab({ caseData }: CaseFilesTabProps) {
         updates: { attachment_ids: updatedIds },
       });
       setFiles((p) => p.filter((f) => f.id !== id));
-      message.success('Файл удалён');
+      notify.success('Файл удалён');
     } catch (err: any) {
-      message.error(err.message);
+      notify.error(err.message);
     }
   };
 
@@ -1430,7 +1431,7 @@ function CaseFilesTab({ caseData }: CaseFilesTabProps) {
         .update({ attachment_type_id: val })
         .eq('id', file.id);
     } catch (err: any) {
-      message.error(err.message);
+      notify.error(err.message);
     }
   };
 
@@ -1512,13 +1513,13 @@ function AddPersonModal({ open, onClose, unitId, onSelect, initialData = null }:
         if (unitId && !isEdit) {
           await supabase.from('unit_persons').insert({ unit_id: unitId, person_id: person.id });
         }
-        message.success(isEdit ? 'Физлицо обновлено' : 'Физлицо добавлено');
+        notify.success(isEdit ? 'Физлицо обновлено' : 'Физлицо добавлено');
         qc.invalidateQueries({ queryKey: ['projectPersons'] });
         onSelect(person.id);
         form.resetFields();
         onClose();
       })
-      .catch((e: any) => message.error(e.message));
+      .catch((e: any) => notify.error(e.message));
   };
 
   return (
@@ -1579,11 +1580,11 @@ function ContractorModal({ open, onClose, onSelect, initialData = null }: Contra
       : addMutation.mutateAsync(values);
     action
       .then((res: any) => {
-        message.success(isEdit ? 'Контрагент обновлён' : 'Контрагент создан');
+        notify.success(isEdit ? 'Контрагент обновлён' : 'Контрагент создан');
         onSelect(res.id);
         onClose();
       })
-      .catch((e: any) => message.error(e.message));
+      .catch((e: any) => notify.error(e.message));
   };
 
   return (


### PR DESCRIPTION
## Summary
- wrap app with SnackbarProvider for consistent notifications
- notify about court case creation and updates
- notify about correspondence actions
- validate file types in ticket forms as errors

## Testing
- `npm run lint` *(fails: Parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_6845a29414e8832ea57fb4dc09e261b5