### PR TITLE
Handle realtime updates for tickets and others

### DIFF
--- a/src/shared/hooks/useRealtimeUpdates.ts
+++ b/src/shared/hooks/useRealtimeUpdates.ts
@@ -31,6 +31,26 @@ export function useRealtimeUpdates() {
       .on(
         'postgres_changes',
         {
+          event: 'UPDATE',
+          schema: 'public',
+          table: 'tickets',
+          filter: `project_id=eq.${projectId}`,
+        },
+        () => qc.invalidateQueries({ queryKey: ['tickets', projectId] }),
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: 'DELETE',
+          schema: 'public',
+          table: 'tickets',
+          filter: `project_id=eq.${projectId}`,
+        },
+        () => qc.invalidateQueries({ queryKey: ['tickets', projectId] }),
+      )
+      .on(
+        'postgres_changes',
+        {
           event: 'INSERT',
           schema: 'public',
           table: 'court_cases',
@@ -41,7 +61,47 @@ export function useRealtimeUpdates() {
       .on(
         'postgres_changes',
         {
+          event: 'UPDATE',
+          schema: 'public',
+          table: 'court_cases',
+          filter: `project_id=eq.${projectId}`,
+        },
+        () => qc.invalidateQueries({ queryKey: ['court_cases', projectId] }),
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: 'DELETE',
+          schema: 'public',
+          table: 'court_cases',
+          filter: `project_id=eq.${projectId}`,
+        },
+        () => qc.invalidateQueries({ queryKey: ['court_cases', projectId] }),
+      )
+      .on(
+        'postgres_changes',
+        {
           event: 'INSERT',
+          schema: 'public',
+          table: 'letters',
+          filter: `project_id=eq.${projectId}`,
+        },
+        () => qc.invalidateQueries({ queryKey: ['letters'] }),
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: 'UPDATE',
+          schema: 'public',
+          table: 'letters',
+          filter: `project_id=eq.${projectId}`,
+        },
+        () => qc.invalidateQueries({ queryKey: ['letters'] }),
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: 'DELETE',
           schema: 'public',
           table: 'letters',
           filter: `project_id=eq.${projectId}`,


### PR DESCRIPTION
## Summary
- add UPDATE/DELETE events to realtime hook
- invalidate React Query caches when tickets, court cases or letters change

## Testing
- `npm run lint` *(fails: Parsing errors)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ab007fe4832e8f2c7bb4e0aa0c80