### PR TITLE
Add JSDoc and attachment type

### DIFF
--- a/src/entities/project.ts
+++ b/src/entities/project.ts
@@ -14,7 +14,10 @@ import type { Project } from '@/shared/types/project';
 const normalize = (s: string) => s.trim();
 const sanitize = (obj: Partial<Project>) => ({ name: normalize(obj.name ?? '') });
 
-/* ===================== READ ===================== */
+/**
+ * Загружает список проектов из Supabase.
+ * Возвращает React Query хук с кэшированными данными.
+ */
 export const useProjects = () =>
     useQuery({
         queryKey: ['projects'],
@@ -29,7 +32,10 @@ export const useProjects = () =>
         staleTime: 5 * 60_000,
     });
 
-/* === generic invalidate helper === */
+/**
+ * Фабрика мутаций с автоматическим инвалидированием
+ * кэша проектов после выполнения.
+ */
 const withInvalidate =
     <TArgs extends any[], TResult>(fn: (...args: TArgs) => Promise<TResult>) =>
         () => {
@@ -41,6 +47,10 @@ const withInvalidate =
         };
 
 /* ==================== CREATE ==================== */
+/**
+ * Создаёт новый проект с указанным названием.
+ * @param name Название проекта
+ */
 const createProject = async ({ name }: { name: string }): Promise<Project> => {
     const n = normalize(name);
     if (!n) throw new Error('Название проекта обязательно');
@@ -64,6 +74,11 @@ const createProject = async ({ name }: { name: string }): Promise<Project> => {
 export const useAddProject = withInvalidate(createProject);
 
 /* ==================== UPDATE ==================== */
+/**
+ * Обновляет данные проекта.
+ * @param id       Идентификатор проекта
+ * @param updates  Поля для обновления
+ */
 const updateProject = async ({ id, updates }: { id: number; updates: Partial<Project> }): Promise<Project> => {
     const fields = sanitize(updates);
     if (fields.name) {
@@ -89,6 +104,10 @@ const updateProject = async ({ id, updates }: { id: number; updates: Partial<Pro
 export const useUpdateProject = withInvalidate(updateProject);
 
 /* ==================== DELETE ==================== */
+/**
+ * Удаляет проект по его идентификатору.
+ * @param id ID проекта
+ */
 const deleteProject = async (id: number): Promise<void> => {
     const { error } = await supabase.from('projects').delete().eq('id', id);
     if (error) throw error;

--- a/src/shared/hooks/useProjectId.ts
+++ b/src/shared/hooks/useProjectId.ts
@@ -1,3 +1,7 @@
 // src/shared/hooks/useProjectId.ts
+/**
+ * Возвращает выбранный в приложении идентификатор проекта
+ * из zustand‑хранилища authStore.
+ */
 export { useProjectId } from '@/shared/store/authStore';
 

--- a/src/shared/hooks/useProjectStructure.ts
+++ b/src/shared/hooks/useProjectStructure.ts
@@ -4,6 +4,10 @@ import type { Project } from '@/shared/types/project';
 
 const LS_KEY = 'structurePageSelection';
 
+/**
+ * Хук для выбора проекта, корпуса и секции.
+ * Сохраняет состояние в localStorage и синхронизирует его между вкладками.
+ */
 export default function useProjectStructure() {
     const [projects, setProjects] = useState<Project[]>([]);
     const [projectId, setProjectIdState] = useState<string>('');

--- a/src/shared/hooks/useUnitsMatrix.js
+++ b/src/shared/hooks/useUnitsMatrix.js
@@ -5,6 +5,10 @@ import { useAuthStore } from '@/shared/store/authStore';
 /**
  * Универсальный хук для шахматки квартир.
  * Загружает объекты проекта, связанные тикеты и активные судебные дела.
+ *
+ * @param {number} projectId ID проекта
+ * @param {string} building  Корпус
+ * @param {string} section   Секция
  */
 export default function useUnitsMatrix(projectId, building, section) {
     const [units, setUnits] = useState([]); // <-- ВСЕ объекты проекта

--- a/src/shared/types/attachment.ts
+++ b/src/shared/types/attachment.ts
@@ -1,0 +1,13 @@
+export interface Attachment {
+  id: number;
+  /** Путь к файлу в Storage */
+  storage_path: string;
+  /** Публичная ссылка на файл */
+  file_url: string;
+  /** MIME‑тип файла */
+  file_type: string;
+  /** Тип вложения */
+  attachment_type_id: number | null;
+  /** Исходное имя файла */
+  original_name: string | null;
+}


### PR DESCRIPTION
## Summary
- describe project hooks via JSDoc
- document several shared hooks
- add common `Attachment` type

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npx tsc --noEmit` *(fails: Cannot find name 'notify')*

------
https://chatgpt.com/codex/tasks/task_e_6845ae16da2c832e877458d1700f83f8