### PR TITLE
Add unit history feature

### DIFF
--- a/migrations/20250615_add_unit_history.sql
+++ b/migrations/20250615_add_unit_history.sql
@@ -1,0 +1,85 @@
+-- Таблица хронологии изменений по объектам
+create table if not exists unit_history (
+  id bigserial primary key,
+  project_id integer not null references projects(id) on delete cascade,
+  unit_id integer not null references units(id) on delete cascade,
+  entity_type text not null check (entity_type in ('ticket','letter','court_case')),
+  entity_id bigint not null,
+  action text not null check (action in ('created','updated','deleted')),
+  changed_by uuid,
+  changed_at timestamp with time zone default now()
+);
+
+-- Функция логирования изменений
+create or replace function log_ticket_history() returns trigger as $$
+declare
+  u integer;
+  act text := lower(tg_op);
+begin
+  if act = 'delete' then
+    foreach u in array old.unit_ids loop
+      insert into unit_history(project_id, unit_id, entity_type, entity_id, action, changed_by, changed_at)
+      values(old.project_id, u, 'ticket', old.id, act, old.created_by, now());
+    end loop;
+    return old;
+  else
+    foreach u in array new.unit_ids loop
+      insert into unit_history(project_id, unit_id, entity_type, entity_id, action, changed_by, changed_at)
+      values(new.project_id, u, 'ticket', new.id, act, new.created_by, now());
+    end loop;
+    return new;
+  end if;
+end;
+$$ language plpgsql;
+
+create or replace function log_case_history() returns trigger as $$
+declare
+  u integer;
+  act text := lower(tg_op);
+begin
+  if act = 'delete' then
+    foreach u in array old.unit_ids loop
+      insert into unit_history(project_id, unit_id, entity_type, entity_id, action, changed_by, changed_at)
+      values(old.project_id, u, 'court_case', old.id, act, old.responsible_lawyer_id, now());
+    end loop;
+    return old;
+  else
+    foreach u in array new.unit_ids loop
+      insert into unit_history(project_id, unit_id, entity_type, entity_id, action, changed_by, changed_at)
+      values(new.project_id, u, 'court_case', new.id, act, new.responsible_lawyer_id, now());
+    end loop;
+    return new;
+  end if;
+end;
+$$ language plpgsql;
+
+create or replace function log_letter_history() returns trigger as $$
+declare
+  u integer;
+  act text := lower(tg_op);
+begin
+  if act = 'delete' then
+    foreach u in array old.unit_ids loop
+      insert into unit_history(project_id, unit_id, entity_type, entity_id, action, changed_by, changed_at)
+      values(old.project_id, u, 'letter', old.id, act, old.responsible_user_id, now());
+    end loop;
+    return old;
+  else
+    foreach u in array new.unit_ids loop
+      insert into unit_history(project_id, unit_id, entity_type, entity_id, action, changed_by, changed_at)
+      values(new.project_id, u, 'letter', new.id, act, new.responsible_user_id, now());
+    end loop;
+    return new;
+  end if;
+end;
+$$ language plpgsql;
+
+create trigger ticket_history_trg
+  after insert or update or delete on tickets
+  for each row execute procedure log_ticket_history();
+create trigger case_history_trg
+  after insert or update or delete on court_cases
+  for each row execute procedure log_case_history();
+create trigger letter_history_trg
+  after insert or update or delete on letters
+  for each row execute procedure log_letter_history();

--- a/src/entities/history/index.ts
+++ b/src/entities/history/index.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/shared/api/supabaseClient';
+import type { HistoryEvent } from '@/shared/types/history';
+
+const TABLE = 'unit_history';
+
+/** Получить историю изменений по объекту */
+export function useUnitHistory(unitId?: number) {
+  return useQuery({
+    queryKey: [TABLE, unitId],
+    enabled: !!unitId,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select('*')
+        .eq('unit_id', unitId)
+        .order('changed_at', { ascending: false });
+      if (error) throw error;
+      return (data ?? []) as HistoryEvent[];
+    },
+    staleTime: 60_000,
+  });
+}

--- a/src/features/history/HistoryDialog.tsx
+++ b/src/features/history/HistoryDialog.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import { Modal, Table, Tag, ConfigProvider } from 'antd';
+import ruRU from 'antd/locale/ru_RU';
+import type { ColumnsType } from 'antd/es/table';
+import { useUnitHistory } from '@/entities/history';
+import type { HistoryEvent } from '@/shared/types/history';
+
+interface HistoryDialogProps {
+  open: boolean;
+  unit: { id: number; name: string } | null;
+  onClose: () => void;
+}
+
+/** Диалог отображения истории объекта */
+export default function HistoryDialog({ open, unit, onClose }: HistoryDialogProps) {
+  const { data = [], isLoading } = useUnitHistory(unit?.id);
+
+  const columns: ColumnsType<HistoryEvent> = [
+    {
+      title: 'Дата',
+      dataIndex: 'changed_at',
+      render: (d: string) => dayjs(d).format('DD.MM.YYYY HH:mm'),
+    },
+    {
+      title: 'Действие',
+      dataIndex: 'action',
+      render: (a: string) => <Tag>{a}</Tag>,
+    },
+    {
+      title: 'Тип',
+      dataIndex: 'entity_type',
+    },
+    {
+      title: 'ID',
+      dataIndex: 'entity_id',
+    },
+    {
+      title: 'Пользователь',
+      dataIndex: 'changed_by',
+    },
+  ];
+
+  return (
+    <ConfigProvider locale={ruRU}>
+      <Modal
+        open={open}
+        onCancel={onClose}
+        footer={null}
+        title={unit ? `История объекта ${unit.name}` : 'История'}
+        width={700}
+      >
+        <Table
+          rowKey="id"
+          columns={columns}
+          dataSource={data}
+          loading={isLoading}
+          pagination={{ pageSize: 10 }}
+          size="small"
+        />
+      </Modal>
+    </ConfigProvider>
+  );
+}

--- a/src/shared/hooks/useRealtimeUpdates.ts
+++ b/src/shared/hooks/useRealtimeUpdates.ts
@@ -108,6 +108,16 @@ export function useRealtimeUpdates() {
         },
         () => qc.invalidateQueries({ queryKey: ['letters'] }),
       )
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'unit_history',
+          filter: `project_id=eq.${projectId}`,
+        },
+        () => qc.invalidateQueries({ queryKey: ['unit_history'] }),
+      )
       .subscribe();
 
     return () => {

--- a/src/shared/types/history.ts
+++ b/src/shared/types/history.ts
@@ -1,0 +1,18 @@
+export interface HistoryEvent {
+  /** Уникальный идентификатор записи */
+  id: number;
+  /** Проект, к которому относится объект */
+  project_id: number;
+  /** Идентификатор объекта */
+  unit_id: number;
+  /** Тип сущности: ticket, letter или court_case */
+  entity_type: 'ticket' | 'letter' | 'court_case';
+  /** Идентификатор сущности */
+  entity_id: number;
+  /** Тип изменения */
+  action: 'created' | 'updated' | 'deleted';
+  /** Пользователь, внесший изменение */
+  changed_by: string | null;
+  /** Дата изменения ISO */
+  changed_at: string;
+}

--- a/src/widgets/UnitsMatrix/UnitsMatrix.tsx
+++ b/src/widgets/UnitsMatrix/UnitsMatrix.tsx
@@ -16,6 +16,7 @@ import FloorCell from "@/entities/floor/FloorCell";
 import useUnitsMatrix from "@/shared/hooks/useUnitsMatrix";
 import { supabase } from "@/shared/api/supabaseClient";
 import TicketListDialog from "@/features/ticket/TicketListDialog";
+import HistoryDialog from "@/features/history/HistoryDialog";
 import { useNavigate, createSearchParams } from 'react-router-dom';
 import { useAuthStore } from '@/shared/store/authStore';
 
@@ -375,12 +376,9 @@ export default function UnitsMatrix({
               color="info"
               fullWidth
               onClick={() =>
-                setActionDialog((ad) => ({ ...ad, action: "tickets" }))
+                setActionDialog((ad) => ({ ...ad, action: "history" }))
               }
             >
-              Посмотреть все замечания
-            </Button>
-            <Button variant="text" color="info" fullWidth disabled>
               Показать историю
             </Button>
           </DialogContent>
@@ -392,6 +390,11 @@ export default function UnitsMatrix({
         unit={actionDialog.unit}
         onClose={() => setActionDialog({ open: false, unit: null, action: "" })}
         onTicketsChanged={fetchUnits}
+      />
+      <HistoryDialog
+        open={actionDialog.action === "history"}
+        unit={actionDialog.unit}
+        onClose={() => setActionDialog({ open: false, unit: null, action: "" })}
       />
     </>
   );


### PR DESCRIPTION
## Summary
- track changes of tickets, letters and court cases per unit
- add `unit_history` table migration with triggers
- expose `useUnitHistory` hook
- implement `HistoryDialog` UI using Ant Design
- link history dialog in `UnitsMatrix`
- subscribe to history updates in realtime hook

## Testing
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_6845b0dbd648832ead616342341d7bb2