### PR TITLE
Add links from history to entity forms

### DIFF
--- a/src/features/history/HistoryDialog.tsx
+++ b/src/features/history/HistoryDialog.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import dayjs from 'dayjs';
-import { Modal, Table, Tag, ConfigProvider } from 'antd';
+import { Modal, Table, Tag, ConfigProvider, Button } from 'antd';
+import { useNavigate } from 'react-router-dom';
 import ruRU from 'antd/locale/ru_RU';
 import type { ColumnsType } from 'antd/es/table';
 import { useUnitHistory } from '@/entities/history';
@@ -15,6 +16,7 @@ interface HistoryDialogProps {
 /** Диалог отображения истории объекта */
 export default function HistoryDialog({ open, unit, onClose }: HistoryDialogProps) {
   const { data = [], isLoading } = useUnitHistory(unit?.id);
+  const navigate = useNavigate();
 
   const actionLabels: Record<string, string> = {
     created: 'Создан',
@@ -52,6 +54,27 @@ export default function HistoryDialog({ open, unit, onClose }: HistoryDialogProp
       title: 'Пользователь',
       dataIndex: 'user_name',
       render: (n: string | null) => n || '—',
+    },
+    {
+      title: 'Действие',
+      key: 'open',
+      render: (_: any, record) => (
+        <Button
+          type="link"
+          onClick={() => {
+            if (record.entity_type === 'ticket') {
+              navigate(`/tickets?ticket_id=${record.entity_id}`);
+            } else if (record.entity_type === 'letter') {
+              navigate(`/correspondence?letter_id=${record.entity_id}`);
+            } else if (record.entity_type === 'court_case') {
+              navigate(`/court-cases?case_id=${record.entity_id}`);
+            }
+            onClose();
+          }}
+        >
+          Открыть
+        </Button>
+      ),
     },
   ];
 

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -75,6 +75,14 @@ export default function CorrespondencePage() {
   const [view, setView] = useState<CorrespondenceLetter | null>(null);
   const [linkFor, setLinkFor] = useState<CorrespondenceLetter | null>(null);
 
+  React.useEffect(() => {
+    const id = searchParams.get('letter_id');
+    if (id && letters.length) {
+      const letter = letters.find((l) => String(l.id) === id);
+      if (letter) setView(letter);
+    }
+  }, [searchParams, letters]);
+
   const { data: users = [] } = useUsers();
   const { data: letterTypes = [] } = useLetterTypes();
   const { data: projects = [] } = useProjects();

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -291,6 +291,17 @@ export default function CourtCasesPage() {
       : null,
   }));
 
+  useEffect(() => {
+    const id = searchParams.get('case_id');
+    if (id && casesData.length) {
+      const c = casesData.find((cs: any) => String(cs.id) === id);
+      if (c) {
+        setDialogCase(c);
+        setTab('defects');
+      }
+    }
+  }, [searchParams, casesData]);
+
   const columns: ColumnsType<CourtCase & any> = [
     {
       title: 'Проект',

--- a/src/pages/TicketsPage/TicketsPage.tsx
+++ b/src/pages/TicketsPage/TicketsPage.tsx
@@ -29,6 +29,13 @@ export default function TicketsPage() {
   const [searchParams] = useSearchParams();
   const [filters, setFilters] = useState({});
   const [viewId, setViewId] = useState<number | null>(null);
+
+  React.useEffect(() => {
+    const id = searchParams.get('ticket_id');
+    if (id) {
+      setViewId(Number(id));
+    }
+  }, [searchParams]);
   const initialValues = {
     project_id: searchParams.get('project_id')
       ? Number(searchParams.get('project_id')!)


### PR DESCRIPTION
## Summary
- add navigation links in history dialog to tickets, letters and court cases
- open view dialogs from URL params on entity pages

## Testing
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_6845c0208eb8832ea62ecf071a74e30a