### PR TITLE
fix: notify undefined in CourtCase dialog

### DIFF
--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -867,6 +867,7 @@ interface CaseDialogProps {
 }
 
 function CaseDialog({ open, onClose, caseData, tab, onTabChange, projects }: CaseDialogProps) {
+  const notify = useNotify();
   const { data: defects = [] } = useCaseDefects(caseData ? Number(caseData.id) : 0);
   const { data: stages = [] } = useLitigationStages();
   const { data: unitInfo = [] } = useUnitsByIds(


### PR DESCRIPTION
## Summary
- fix notify undefined by adding hook inside CaseDialog

## Testing
- `npm run lint` *(fails: eslint not configured)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ca162a38832e9ab7e384f9b5faca