### PR TITLE
Fix mutations typing and missing notifier

### DIFF
--- a/src/entities/project.ts
+++ b/src/entities/project.ts
@@ -37,12 +37,12 @@ export const useProjects = () =>
  * кэша проектов после выполнения.
  */
 const withInvalidate =
-    <TArgs extends any[], TResult>(fn: (...args: TArgs) => Promise<TResult>) =>
+    <TVariables, TResult>(fn: (vars: TVariables) => Promise<TResult>) =>
         () => {
             const qc = useQueryClient();
-            return useMutation({
+            return useMutation<TResult, Error, TVariables>({
                 mutationFn: fn,
-                onSuccess : () => qc.invalidateQueries({ queryKey: ['projects'] }),
+                onSuccess: () => qc.invalidateQueries({ queryKey: ['projects'] }),
             });
         };
 

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -1341,6 +1341,7 @@ interface CaseFilesTabProps {
 function CaseFilesTab({ caseData }: CaseFilesTabProps) {
   const { data: attachmentTypes = [] } = useAttachmentTypes();
   const updateCaseMutation = useUpdateCourtCase();
+  const notify = useNotify();
   const [files, setFiles] = useState<{
     id: number;
     name: string;
@@ -1525,6 +1526,7 @@ function AddPersonModal({ open, onClose, unitId, onSelect, initialData = null }:
   const addPersonMutation = useAddPerson();
   const updatePersonMutation = useUpdatePerson();
   const qc = useQueryClient();
+  const notify = useNotify();
   const isEdit = !!initialData?.id;
 
   useEffect(() => {
@@ -1595,6 +1597,7 @@ function ContractorModal({ open, onClose, onSelect, initialData = null }: Contra
   const [form] = Form.useForm();
   const addMutation = useAddContractor();
   const updateMutation = useUpdateContractor();
+  const notify = useNotify();
   const isEdit = !!initialData?.id;
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- fix generics for mutation helpers to accept variables
- add `useNotify` usage to missing court case dialogs

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Property 'id' does not exist etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6845cdfe3d28832eba2a60cc4ea3dfb0