### PR TITLE
Fix edit dialog form initialization

### DIFF
--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -927,7 +927,9 @@ function CaseDialog({ open, onClose, caseData, tab, onTabChange, projects }: Cas
 
   useEffect(() => {
     setEditing(false);
-    form.resetFields();
+    if (!caseData) {
+      form.resetFields();
+    }
   }, [caseData, form]);
 
   const saveChanges = async (values: any) => {


### PR DESCRIPTION
## Summary
- prevent clearing form fields when opening the court case dialog in edit mode

## Testing
- `npm run lint` *(fails: Parsing error: The keyword 'interface' is reserved)*

------
https://chatgpt.com/codex/tasks/task_e_6845ec8b0bb4832ea7f9380b6bed48b0