### PR TITLE
Fix court case dialog closing

### DIFF
--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -789,18 +789,17 @@ export default function CourtCasesPage() {
           open
           onClose={() => {
             const back = searchParams.get('from');
+            setSearchParams(
+              (prev) => {
+                const params = new URLSearchParams(prev);
+                params.delete('case_id');
+                params.delete('from');
+                return params;
+              },
+              { replace: true },
+            );
             if (back === 'structure') {
               navigate('/structure');
-            } else {
-              setSearchParams(
-                (prev) => {
-                  const params = new URLSearchParams(prev);
-                  params.delete('case_id');
-                  params.delete('from');
-                  return params;
-                },
-                { replace: true },
-              );
             }
             setDialogCase(null);
           }}
@@ -1041,7 +1040,7 @@ function CaseDialog({ open, onClose, caseData, tab, onTabChange, projects }: Cas
         onCancel={onClose}
         width="80%"
         footer={null}
-        destroyOnHidden
+        destroyOnClose
         title={caseData ? `Дело № ${caseData.number}` : ''}
     >
       {caseData && (


### PR DESCRIPTION
## Summary
- remove case_id search params before leaving the court case dialog
- use correct `destroyOnClose` prop for Ant Design modal

## Testing
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_684726a72e54832eb9f8626e278a362b