### PR TITLE
Fix court case navigation

### DIFF
--- a/src/features/history/HistoryDialog.tsx
+++ b/src/features/history/HistoryDialog.tsx
@@ -84,7 +84,7 @@ export default function HistoryDialog({ open, unit, onClose, onOpenCourtCase }: 
                   if (onOpenCourtCase) {
                     onOpenCourtCase(record.entity_id);
                   } else {
-                    navigate(`/court-cases?case_id=${record.entity_id}&from=structure`);
+                    navigate(`/court-cases?case_id=${record.entity_id}`);
                   }
                 }
                 onClose();

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -788,7 +788,6 @@ export default function CourtCasesPage() {
         <CaseDialog
           open
           onClose={() => {
-            const back = searchParams.get('from');
             setSearchParams(
               (prev) => {
                 const params = new URLSearchParams(prev);
@@ -798,9 +797,6 @@ export default function CourtCasesPage() {
               },
               { replace: true },
             );
-            if (back === 'structure') {
-              navigate('/structure');
-            }
             setDialogCase(null);
           }}
           caseData={dialogCase}

--- a/src/pages/ProjectStructurePage/ProjectStructurePage.tsx
+++ b/src/pages/ProjectStructurePage/ProjectStructurePage.tsx
@@ -424,7 +424,7 @@ export default function ProjectStructurePage() {
                 onClose={() => setHistoryDialogOpen(false)}
                 onOpenCourtCase={(caseId) => {
                     setHistoryDialogOpen(false);
-                    navigate(`/court-cases?case_id=${caseId}&from=structure`);
+                    navigate(`/court-cases?case_id=${caseId}`);
                 }}
             />
 


### PR DESCRIPTION
## Summary
- update HistoryDialog: open court cases without `from=structure`
- keep user on court cases page when closing case

## Testing
- `npm run lint` *(fails: Parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_684732f5cb94832e85b3e06292b8c342