### PR TITLE
Fix case page open from history

### DIFF
--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -124,17 +124,14 @@ export default function CourtCasesPage() {
   useEffect(() => {
     const state = location.state as { openCaseId?: number } | null;
     if (state?.openCaseId) {
-      setSearchParams(
-        (prev) => {
-          const params = new URLSearchParams(prev);
-          params.set('case_id', String(state.openCaseId));
-          return params;
-        },
-        { replace: true },
-      );
-      navigate('.', { replace: true, state: null });
+      const params = new URLSearchParams(location.search);
+      params.set('case_id', String(state.openCaseId));
+      navigate({ pathname: '.', search: params.toString() }, {
+        replace: true,
+        state: null,
+      });
     }
-  }, [location.state, navigate, setSearchParams]);
+  }, [location.state, location.search, navigate]);
 
   useEffect(() => {
     const p = searchParams.get('project_id');


### PR DESCRIPTION
## Summary
- keep query params while removing state when navigating from history

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68473860bbd8832e8a5713facff162d9