### PR TITLE
Add ID filters and navigation from history

### DIFF
--- a/src/features/history/HistoryDialog.tsx
+++ b/src/features/history/HistoryDialog.tsx
@@ -20,6 +20,38 @@ export default function HistoryDialog({ open, unit, onClose, onOpenCourtCase }: 
   const navigate = useNavigate();
   const [primaryOnly, setPrimaryOnly] = React.useState(false);
 
+  const ticketIds = React.useMemo(
+    () =>
+      Array.from(
+        new Set(
+          data
+            .filter((e) => e.entity_type === 'ticket')
+            .map((e) => e.entity_id),
+        ),
+      ),
+    [data],
+  );
+  const caseIds = React.useMemo(
+    () =>
+      Array.from(
+        new Set(
+          data
+            .filter((e) => e.entity_type === 'court_case')
+            .map((e) => e.entity_id),
+        ),
+      ),
+    [data],
+  );
+  const letterIds = React.useMemo(
+    () =>
+      Array.from(
+        new Set(
+          data.filter((e) => e.entity_type === 'letter').map((e) => e.entity_id),
+        ),
+      ),
+    [data],
+  );
+
   const displayedData = React.useMemo(() => {
     if (!primaryOnly) return data;
     const latest = new Map<string, HistoryEventWithUser>();
@@ -110,6 +142,35 @@ export default function HistoryDialog({ open, unit, onClose, onOpenCourtCase }: 
           <Space style={{ marginBottom: 12 }}>
             <Switch checked={primaryOnly} onChange={setPrimaryOnly} />
             Показать основные документы
+          </Space>
+          <Space style={{ marginBottom: 12 }}>
+            <Button
+              disabled={!ticketIds.length}
+              onClick={() => {
+                navigate(`/tickets?ids=${ticketIds.join(',')}`);
+                onClose();
+              }}
+            >
+              Показать замечания
+            </Button>
+            <Button
+              disabled={!caseIds.length}
+              onClick={() => {
+                navigate(`/court-cases?ids=${caseIds.join(',')}`);
+                onClose();
+              }}
+            >
+              Судебные дела
+            </Button>
+            <Button
+              disabled={!letterIds.length}
+              onClick={() => {
+                navigate(`/correspondence?ids=${letterIds.join(',')}`);
+                onClose();
+              }}
+            >
+              Письма
+            </Button>
           </Space>
           <Table
               rowKey="id"

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -41,6 +41,7 @@ interface Filters {
   subject?: string;
   content?: string;
   search?: string;
+  id?: string;
 }
 
 /** Страница учёта корреспонденции */
@@ -60,6 +61,7 @@ export default function CorrespondencePage() {
     subject: '',
     content: '',
     search: '',
+    id: '',
   });
   const [searchParams] = useSearchParams();
   const [form] = Form.useForm();
@@ -80,6 +82,11 @@ export default function CorrespondencePage() {
     if (id && letters.length) {
       const letter = letters.find((l) => String(l.id) === id);
       if (letter) setView(letter);
+    }
+    const ids = searchParams.get('ids');
+    if (ids) {
+      setFilters((f) => ({ ...f, id: ids }));
+      form.setFieldValue('id', ids);
     }
   }, [searchParams, letters]);
 
@@ -102,6 +109,7 @@ export default function CorrespondencePage() {
       type: values.type ?? '',
       project: values.project ?? '',
       unit: values.unit ?? '',
+      id: values.id ?? '',
       sender: values.sender ?? '',
       receiver: values.receiver ?? '',
       subject: values.subject ?? '',
@@ -116,6 +124,7 @@ export default function CorrespondencePage() {
       type: '',
       project: '',
       unit: '',
+      id: '',
       sender: '',
       receiver: '',
       subject: '',
@@ -160,6 +169,10 @@ export default function CorrespondencePage() {
     if (filters.type && l.type !== filters.type) return false;
     if (filters.project && l.project_id !== Number(filters.project)) return false;
     if (filters.unit && !l.unit_ids.includes(Number(filters.unit))) return false;
+    if (filters.id) {
+      const ids = filters.id.split(',').map((s) => s.trim()).filter(Boolean);
+      if (ids.length && !ids.includes(String(l.id))) return false;
+    }
     const sender = (l.sender || '').toLowerCase();
     const receiver = (l.receiver || '').toLowerCase();
     const subject = (l.subject || '').toLowerCase();
@@ -247,6 +260,9 @@ export default function CorrespondencePage() {
                   options={projectUnits.map((u) => ({ value: u.id, label: u.name }))}
                   disabled={!form.getFieldValue('project')}
               />
+            </Form.Item>
+            <Form.Item name="id" label="ID">
+              <Input allowClear autoComplete="off" />
             </Form.Item>
             <Form.Item name="sender" label="Отправитель">
               <Input allowClear autoComplete="off" />

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -90,6 +90,7 @@ type Filters = {
   lawyer?: string;
   search?: string;
   hideClosed?: boolean;
+  ids?: string;
 };
 
 export default function CourtCasesPage() {
@@ -317,6 +318,13 @@ export default function CourtCasesPage() {
   }, [searchParams, casesData]);
 
   useEffect(() => {
+    const ids = searchParams.get('ids');
+    if (ids) {
+      setFilters((f) => ({ ...f, ids }));
+    }
+  }, [searchParams]);
+
+  useEffect(() => {
     if (!searchParams.get('case_id')) {
       setDialogCase(null);
     }
@@ -402,6 +410,9 @@ export default function CourtCasesPage() {
 
   const filteredCases = casesData.filter((c: any) => {
     const search = filters.search?.toLowerCase() ?? '';
+    const idFilter = filters.ids
+      ? filters.ids.split(',').map((s) => s.trim()).filter(Boolean)
+      : null;
     const matchesSearch =
       c.number.toLowerCase().includes(search) ||
       c.plaintiff.toLowerCase().includes(search) ||
@@ -419,7 +430,9 @@ export default function CourtCasesPage() {
     const matchesLawyer =
       !filters.lawyer || c.responsibleLawyer.toLowerCase().includes(filters.lawyer.toLowerCase());
     const matchesClosed = !filters.hideClosed || !c.is_closed;
+    const matchesIds = !idFilter || idFilter.includes(String(c.id));
     return (
+      matchesIds &&
       matchesSearch &&
       matchesStatus &&
       matchesProject &&
@@ -742,6 +755,12 @@ export default function CourtCasesPage() {
           <Input
             placeholder="Проект"
             onChange={(e) => setFilters((f) => ({ ...f, project: e.target.value }))}
+          />
+        </Col>
+        <Col>
+          <Input
+            placeholder="ID"
+            onChange={(e) => setFilters((f) => ({ ...f, ids: e.target.value }))}
           />
         </Col>
         <Col>

--- a/src/pages/TicketsPage/TicketsPage.tsx
+++ b/src/pages/TicketsPage/TicketsPage.tsx
@@ -28,12 +28,22 @@ export default function TicketsPage() {
   const qc = useQueryClient();
   const [searchParams] = useSearchParams();
   const [filters, setFilters] = useState({});
+  const [initialFilters, setInitialFilters] = useState({});
   const [viewId, setViewId] = useState<number | null>(null);
 
   React.useEffect(() => {
     const id = searchParams.get('ticket_id');
     if (id) {
       setViewId(Number(id));
+    }
+    const ids = searchParams.get('ids');
+    if (ids) {
+      const arr = ids
+        .split(',')
+        .map((v) => Number(v))
+        .filter(Boolean);
+      setInitialFilters({ id: arr });
+      setFilters((f) => ({ ...f, id: arr }));
     }
   }, [searchParams]);
   const initialValues = {
@@ -95,6 +105,7 @@ export default function TicketsPage() {
       statuses: uniq(ticketsWithNames, "statusName"),
       types: uniq(ticketsWithNames, "typeName"),
       responsibleEngineers: uniq(ticketsWithNames, "responsibleEngineerName"),
+      ids: uniq(ticketsWithNames, "id"),
     };
   }, [ticketsWithNames]);
 
@@ -111,7 +122,11 @@ export default function TicketsPage() {
         </Card>
 
         <Card style={{ marginBottom: 24 }}>
-          <TicketsFilters options={options} onChange={setFilters} />
+          <TicketsFilters
+            options={options}
+            onChange={setFilters}
+            initialValues={initialFilters}
+          />
         </Card>
 
         <Card>

--- a/src/widgets/TicketsFilters.tsx
+++ b/src/widgets/TicketsFilters.tsx
@@ -16,8 +16,11 @@ const LS_PROJECT_KEY = "ticketsProject";
  * @param onChange callback, возвращающий значения формы
  */
 
-export default function TicketsFilters({ options, onChange }) {
+export default function TicketsFilters({ options, onChange, initialValues = {} }) {
   const [form] = Form.useForm();
+  useEffect(() => {
+    form.setFieldsValue(initialValues);
+  }, [initialValues, form]);
 
   useEffect(() => {
     try {
@@ -97,6 +100,9 @@ export default function TicketsFilters({ options, onChange }) {
       </Form.Item>
       <Form.Item name="units" label="Объекты">
         <Select mode="multiple" allowClear options={options.units} />
+      </Form.Item>
+      <Form.Item name="id" label="ID">
+        <Select mode="multiple" allowClear options={options.ids} />
       </Form.Item>
       <Form.Item name="warranty" label="Гарантия">
         <Select allowClear>

--- a/src/widgets/TicketsTable.tsx
+++ b/src/widgets/TicketsTable.tsx
@@ -38,6 +38,7 @@ const daysPassed = (receivedAt) =>
 /** Фильтрация по фильтрам */
 const applyFilters = (rows, f) =>
   rows.filter((r) => {
+    if (Array.isArray(f.id) && f.id.length > 0 && !f.id.includes(r.id)) return false;
     if (f.hideClosed && r.isClosed) return false;
     const days = daysPassed(r.receivedAt);
     if (f.period && f.period.length === 2) {


### PR DESCRIPTION
## Summary
- add navigation buttons in `HistoryDialog` for tickets, court cases and letters
- extend `TicketsFilters` with ID filter and initial values
- support `ids` query param on Tickets page
- filter tickets by ID in `TicketsTable`
- add ID filter and logic on CourtCases page
- add ID filter and logic on Correspondence page

## Testing
- `npm run lint` *(fails: eslint dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6847adda54a4832e87f6da32d3ea361c