### PR TITLE
Fix filter IDs after history navigation

### DIFF
--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -89,8 +89,9 @@ export default function CorrespondencePage() {
         .split(',')
         .map((v) => Number(v))
         .filter(Boolean);
-      setFilters((f) => ({ ...f, id: arr }));
-      form.setFieldValue('id', arr);
+      const valid = arr.filter((lid) => letters.some((l) => Number(l.id) === lid));
+      setFilters((f) => ({ ...f, id: valid }));
+      form.setFieldValue('id', valid);
     }
   }, [searchParams, letters]);
 

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -333,9 +333,10 @@ export default function CourtCasesPage() {
         .split(',')
         .map((s) => Number(s))
         .filter(Boolean);
-      setFilters((f) => ({ ...f, ids: arr }));
+      const valid = arr.filter((id) => cases.some((c) => c.id === id));
+      setFilters((f) => ({ ...f, ids: valid }));
     }
-  }, [searchParams]);
+  }, [searchParams, cases]);
 
   useEffect(() => {
     if (!searchParams.get('case_id')) {

--- a/src/pages/TicketsPage/TicketsPage.tsx
+++ b/src/pages/TicketsPage/TicketsPage.tsx
@@ -42,10 +42,11 @@ export default function TicketsPage() {
         .split(',')
         .map((v) => Number(v))
         .filter(Boolean);
-      setInitialFilters({ id: arr });
-      setFilters((f) => ({ ...f, id: arr }));
+      const valid = arr.filter((tid) => tickets.some((t) => t.id === tid));
+      setInitialFilters({ id: valid });
+      setFilters((f) => ({ ...f, id: valid }));
     }
-  }, [searchParams]);
+  }, [searchParams, tickets]);
   const initialValues = {
     project_id: searchParams.get('project_id')
       ? Number(searchParams.get('project_id')!)


### PR DESCRIPTION
## Summary
- ensure deleted cases are not added to ID filter on Court Cases page
- ensure deleted tickets are not added to ID filter on Tickets page
- ensure deleted letters are not added to ID filter on Correspondence page

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6847ba9ea48c832eaff5607b4603bf53