### PR TITLE
Add id column to letter links

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -344,6 +344,13 @@
   },
   {
     "table_name": "letter_links",
+    "column_name": "id",
+    "data_type": "bigint",
+    "is_nullable": "NO",
+    "column_default": "nextval('letter_links_id_seq'::regclass)"
+  },
+  {
+    "table_name": "letter_links",
     "column_name": "parent_id",
     "data_type": "bigint",
     "is_nullable": "NO",

--- a/src/entities/correspondence/index.ts
+++ b/src/entities/correspondence/index.ts
@@ -17,7 +17,7 @@ export function useLetterLinks() {
     queryFn: async () => {
       const { data, error } = await supabase
         .from(LINKS_TABLE)
-        .select('parent_id, child_id');
+        .select('id, parent_id, child_id');
       if (error) throw error;
       return (data ?? []) as LetterLink[];
     },
@@ -38,7 +38,7 @@ export function useLetters() {
       if (error) throw error;
       const { data: links, error: linkErr } = await supabase
         .from(LINKS_TABLE)
-        .select('parent_id, child_id');
+        .select('id, parent_id, child_id');
       if (linkErr) throw linkErr;
       const allIds = Array.from(
         new Set((data ?? []).flatMap((r: any) => r.attachment_ids || [])),

--- a/src/shared/types/correspondence.ts
+++ b/src/shared/types/correspondence.ts
@@ -53,6 +53,10 @@ export interface CorrespondenceAttachment {
 
 /** Связь писем: parent_id - родительское письмо, child_id - дочернее */
 export interface LetterLink {
+  /** Уникальный идентификатор связи */
+  id: string;
+  /** Идентификатор родительского письма */
   parent_id: string;
+  /** Идентификатор дочернего письма */
   child_id: string;
 }


### PR DESCRIPTION
## Summary
- add `id` column metadata for `letter_links`
- expose this id via `LetterLink` type
- include new field in correspondence queries

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6847be9e5894832e8eb298b3442ea82e