### PR TITLE
Unify filter blocks style

### DIFF
--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -261,14 +261,14 @@ export default function CorrespondencePage() {
             }
           }}
         >
-          <Form
-            form={form}
-            layout="vertical"
-            onValuesChange={handleFiltersChange}
-            initialValues={filters}
-            className="filter-grid"
-            style={{ marginBottom: 16 }}
-          >
+          <Card style={{ marginBottom: 24 }}>
+            <Form
+              form={form}
+              layout="vertical"
+              onValuesChange={handleFiltersChange}
+              initialValues={filters}
+              className="filter-grid"
+            >
             <Form.Item name="type" label="Тип письма">
               <Select allowClear placeholder="Все типы">
                 <Select.Option value="incoming">Входящее</Select.Option>
@@ -319,7 +319,8 @@ export default function CorrespondencePage() {
                 Сбросить фильтры
               </Button>
             </Form.Item>
-          </Form>
+            </Form>
+          </Card>
           <CorrespondenceTable
             letters={filtered}
             onView={setView}

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -800,81 +800,80 @@ export default function CourtCasesPage() {
           }
         }}
       >
-      <Row gutter={16} style={{ marginBottom: 12 }}>
-        <Col>
-          <Select
-            allowClear
-            placeholder="Статус"
-            onChange={(v) => setFilters((f) => ({ ...f, status: v }))}
-            style={{ width: 150 }}
-          >
-            {stages.map((s) => (
-              <Select.Option key={s.id} value={s.id}>
-                {s.name}
-              </Select.Option>
-            ))}
-          </Select>
-        </Col>
-        <Col>
-          <Input
-            placeholder="Проект"
-            onChange={(e) => setFilters((f) => ({ ...f, project: e.target.value }))}
-          />
-        </Col>
-        <Col>
-          <Select
-            mode="multiple"
-            allowClear
-            placeholder="ID"
-            options={idOptions}
-            value={filters.ids}
-            onChange={(v) => setFilters((f) => ({ ...f, ids: v }))}
-            style={{ minWidth: 120 }}
-          />
-        </Col>
-        <Col>
-          <Input
-            placeholder="Фильтр по объекту"
-            onChange={(e) => setFilters((f) => ({ ...f, object: e.target.value }))}
-          />
-        </Col>
-        <Col>
-          <Input
-            placeholder="Истец"
-            onChange={(e) => setFilters((f) => ({ ...f, plaintiff: e.target.value }))}
-          />
-        </Col>
-        <Col>
-          <Input
-            placeholder="Ответчик"
-            onChange={(e) => setFilters((f) => ({ ...f, defendant: e.target.value }))}
-          />
-        </Col>
-        <Col>
-          <Input
-            placeholder="Юрист"
-            onChange={(e) => setFilters((f) => ({ ...f, lawyer: e.target.value }))}
-          />
-        </Col>
-        <Col>
-          <Switch
-            checked={!!filters.hideClosed}
-            onChange={(checked) => {
-              setFilters((f) => ({ ...f, hideClosed: checked }));
-              try {
-                localStorage.setItem(LS_KEY, JSON.stringify(checked));
-              } catch {}
-            }}
-          />{' '}
-          Скрыть закрытые
-        </Col>
-        <Col flex="auto">
-          <Input
-            placeholder="Поиск"
-            onChange={(e) => setFilters((f) => ({ ...f, search: e.target.value }))}
-          />
-        </Col>
-      </Row>
+      <Card style={{ marginBottom: 24 }}>
+        <Form layout="vertical" className="filter-grid">
+          <Form.Item label="Статус">
+            <Select
+              allowClear
+              placeholder="Статус"
+              onChange={(v) => setFilters((f) => ({ ...f, status: v }))}
+            >
+              {stages.map((s) => (
+                <Select.Option key={s.id} value={s.id}>
+                  {s.name}
+                </Select.Option>
+              ))}
+            </Select>
+          </Form.Item>
+          <Form.Item label="Проект">
+            <Input
+              placeholder="Проект"
+              onChange={(e) => setFilters((f) => ({ ...f, project: e.target.value }))}
+            />
+          </Form.Item>
+          <Form.Item label="ID">
+            <Select
+              mode="multiple"
+              allowClear
+              placeholder="ID"
+              options={idOptions}
+              value={filters.ids}
+              onChange={(v) => setFilters((f) => ({ ...f, ids: v }))}
+            />
+          </Form.Item>
+          <Form.Item label="Объект">
+            <Input
+              placeholder="Фильтр по объекту"
+              onChange={(e) => setFilters((f) => ({ ...f, object: e.target.value }))}
+            />
+          </Form.Item>
+          <Form.Item label="Истец">
+            <Input
+              placeholder="Истец"
+              onChange={(e) => setFilters((f) => ({ ...f, plaintiff: e.target.value }))}
+            />
+          </Form.Item>
+          <Form.Item label="Ответчик">
+            <Input
+              placeholder="Ответчик"
+              onChange={(e) => setFilters((f) => ({ ...f, defendant: e.target.value }))}
+            />
+          </Form.Item>
+          <Form.Item label="Юрист">
+            <Input
+              placeholder="Юрист"
+              onChange={(e) => setFilters((f) => ({ ...f, lawyer: e.target.value }))}
+            />
+          </Form.Item>
+          <Form.Item label="Скрыть закрытые" valuePropName="checked">
+            <Switch
+              checked={!!filters.hideClosed}
+              onChange={(checked) => {
+                setFilters((f) => ({ ...f, hideClosed: checked }));
+                try {
+                  localStorage.setItem(LS_KEY, JSON.stringify(checked));
+                } catch {}
+              }}
+            />
+          </Form.Item>
+          <Form.Item label="Поиск">
+            <Input
+              placeholder="Поиск"
+              onChange={(e) => setFilters((f) => ({ ...f, search: e.target.value }))}
+            />
+          </Form.Item>
+        </Form>
+      </Card>
 
       <Table
         rowKey="id"

--- a/src/widgets/TicketsFilters.tsx
+++ b/src/widgets/TicketsFilters.tsx
@@ -84,13 +84,8 @@ export default function TicketsFilters({ options, onChange, initialValues = {} }
       form={form}
       layout="vertical"
       onValuesChange={handleValuesChange}
-      style={{
-        marginBottom: 20,
-        display: "grid",
-        gridTemplateColumns: "repeat(auto-fit, minmax(170px, 1fr))",
-        gap: 12,
-        alignItems: "end",
-      }}
+      className="filter-grid"
+      style={{ marginBottom: 20 }}
     >
       <Form.Item name="period" label="Период получения замечаний">
         <RangePicker format="DD.MM.YYYY" style={{ width: "100%" }} />


### PR DESCRIPTION
## Summary
- reuse `filter-grid` for ticket filters
- wrap filters on court cases in a card with the same grid layout
- do the same for correspondence filters

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684bb3f3b598832e8dc5b1de264947cb