### PR TITLE
Add excel export for tickets

### DIFF
--- a/src/features/ticket/ExportTicketsButton.tsx
+++ b/src/features/ticket/ExportTicketsButton.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Button } from 'antd';
+import { FileExcelOutlined } from '@ant-design/icons';
+import * as XLSX from 'xlsx';
+import { saveAs } from 'file-saver';
+import { Ticket } from '@/shared/types/ticket';
+import { TicketFilters } from '@/shared/types/ticketFilters';
+import { filterTickets } from '@/shared/utils/ticketFilter';
+
+export interface ExportTicketsButtonProps {
+  /** Список замечаний */
+  tickets: Ticket[];
+  /** Активные фильтры */
+  filters: TicketFilters;
+}
+
+/** Кнопка экспорта списка замечаний в Excel */
+export default function ExportTicketsButton({ tickets, filters }: ExportTicketsButtonProps) {
+  const handleClick = React.useCallback(() => {
+    const rows = filterTickets(tickets, filters).map((t) => ({
+      ID: t.id,
+      Проект: t.projectName,
+      Объекты: t.unitNames,
+      Гарантия: t.isWarranty ? 'Да' : 'Нет',
+      Статус: t.statusName,
+      'Замечание закрыто': t.isClosed ? 'Да' : 'Нет',
+      'Тип замечания': t.typeName,
+      'Дата получения': t.receivedAt ? t.receivedAt.format('DD.MM.YYYY') : '',
+      'Дата устранения': t.fixedAt ? t.fixedAt.format('DD.MM.YYYY') : '',
+      '№ заявки от Заказчика': t.customerRequestNo ?? '',
+      'Дата заявки Заказчика': t.customerRequestDate
+        ? t.customerRequestDate.format('DD.MM.YYYY')
+        : '',
+      'Ответственный инженер': t.responsibleEngineerName ?? '',
+      Название: t.title,
+    }));
+    const wb = XLSX.utils.book_new();
+    const ws = XLSX.utils.json_to_sheet(rows);
+    XLSX.utils.book_append_sheet(wb, ws, 'Tickets');
+    const wbout = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });
+    saveAs(new Blob([wbout], { type: 'application/octet-stream' }), 'tickets.xlsx');
+  }, [tickets, filters]);
+
+  return (
+    <Button icon={<FileExcelOutlined />} onClick={handleClick} style={{ marginLeft: 16 }}>
+      Выгрузить в Excel
+    </Button>
+  );
+}

--- a/src/pages/TicketsPage/TicketsPage.tsx
+++ b/src/pages/TicketsPage/TicketsPage.tsx
@@ -16,6 +16,7 @@ import TicketsFilters from "@/widgets/TicketsFilters";
 import TicketFormAntd from "@/features/ticket/TicketFormAntd";
 import TicketViewModal from "@/features/ticket/TicketViewModal";
 import LinkTicketsDialog from "@/features/ticket/LinkTicketsDialog";
+import ExportTicketsButton from "@/features/ticket/ExportTicketsButton";
 import { useNotify } from "@/shared/hooks/useNotify";
 
 export default function TicketsPage() {
@@ -148,6 +149,7 @@ export default function TicketsPage() {
         >
           {showAddForm ? 'Скрыть форму' : 'Добавить замечание'}
         </Button>
+        <ExportTicketsButton tickets={ticketsWithNames} filters={filters} />
         {showAddForm && (
           <Card style={{ marginBottom: 24 }}>
             <TicketFormAntd

--- a/src/shared/types/ticketFilters.ts
+++ b/src/shared/types/ticketFilters.ts
@@ -1,0 +1,16 @@
+import { Dayjs } from 'dayjs';
+
+/** Набор фильтров для списка замечаний. */
+export interface TicketFilters {
+  id?: number[];
+  hideClosed?: boolean;
+  period?: [Dayjs, Dayjs];
+  requestPeriod?: [Dayjs, Dayjs];
+  requestNo?: string;
+  project?: string;
+  units?: string[];
+  warranty?: 'yes' | 'no';
+  status?: string;
+  type?: string;
+  responsible?: string;
+}

--- a/src/shared/utils/ticketFilter.ts
+++ b/src/shared/utils/ticketFilter.ts
@@ -1,0 +1,62 @@
+import { Dayjs } from 'dayjs';
+import { TicketFilters } from '@/shared/types/ticketFilters';
+
+/**
+ * Фильтрация массива замечаний согласно заданным фильтрам.
+ * @param rows массив замечаний
+ * @param f активные фильтры
+ */
+export function filterTickets<T extends {
+  id: number;
+  isClosed?: boolean;
+  receivedAt?: Dayjs | null;
+  customerRequestDate?: Dayjs | null;
+  customerRequestNo?: string | null;
+  projectName?: string;
+  unitNames?: string;
+  isWarranty?: boolean;
+  statusName?: string;
+  typeName?: string;
+  responsibleEngineerName?: string | null;
+}>(rows: T[], f: TicketFilters): T[] {
+  return rows.filter((r) => {
+    if (Array.isArray(f.id) && f.id.length > 0 && !f.id.includes(r.id)) {
+      return false;
+    }
+    if (f.hideClosed && r.isClosed) return false;
+    if (f.period && f.period.length === 2) {
+      const [from, to] = f.period;
+      if (!r.receivedAt) return false;
+      if (r.receivedAt.isBefore(from, 'day') || r.receivedAt.isAfter(to, 'day')) {
+        return false;
+      }
+    }
+    if (f.requestPeriod && f.requestPeriod.length === 2) {
+      const [from, to] = f.requestPeriod;
+      if (!r.customerRequestDate) return false;
+      if (
+        r.customerRequestDate.isBefore(from, 'day') ||
+        r.customerRequestDate.isAfter(to, 'day')
+      ) {
+        return false;
+      }
+    }
+    if (f.requestNo && r.customerRequestNo !== f.requestNo) return false;
+    if (f.project && r.projectName !== f.project) return false;
+    if (Array.isArray(f.units) && f.units.length > 0 && r.unitNames) {
+      const rowUnits = r.unitNames.split(',').map((u) => u.trim());
+      const hasMatch = f.units.some((u) => rowUnits.includes(u));
+      if (!hasMatch) return false;
+    }
+    if (f.warranty) {
+      const want = f.warranty === 'yes';
+      if (r.isWarranty !== want) return false;
+    }
+    if (f.status && r.statusName !== f.status) return false;
+    if (f.type && r.typeName !== f.type) return false;
+    if (f.responsible && r.responsibleEngineerName !== f.responsible) {
+      return false;
+    }
+    return true;
+  });
+}


### PR DESCRIPTION
## Summary
- add button to export filtered tickets to Excel
- share ticket filter logic
- use new TicketFilters type

## Testing
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_684bbcbef204832ea239f043387fac95