### PR TITLE
Add excel export on correspondence page

### DIFF
--- a/src/features/correspondence/ExportLettersButton.tsx
+++ b/src/features/correspondence/ExportLettersButton.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { Button, Tooltip } from 'antd';
+import { DownloadOutlined } from '@ant-design/icons';
+import * as XLSX from 'xlsx';
+import { saveAs } from 'file-saver';
+import dayjs from 'dayjs';
+import { CorrespondenceLetter } from '@/shared/types/correspondence';
+import { useNotify } from '@/shared/hooks/useNotify';
+
+interface Option { id: number | string; name: string; }
+
+interface ExportLettersButtonProps {
+  letters: CorrespondenceLetter[];
+  users: Option[];
+  letterTypes: Option[];
+  projects: Option[];
+  units: Option[];
+}
+
+/**
+ * Кнопка выгрузки списка писем в Excel.
+ * Использует библиотеку xlsx и file-saver.
+ */
+export default function ExportLettersButton({
+  letters,
+  users,
+  letterTypes,
+  projects,
+  units,
+}: ExportLettersButtonProps) {
+  const notify = useNotify();
+
+  const maps = React.useMemo(() => {
+    const m = {
+      user: {} as Record<string, string>,
+      type: {} as Record<number, string>,
+      project: {} as Record<number, string>,
+      unit: {} as Record<number, string>,
+    };
+    users.forEach((u) => (m.user[u.id as string] = u.name));
+    letterTypes.forEach((t) => (m.type[t.id as number] = t.name));
+    projects.forEach((p) => (m.project[p.id as number] = p.name));
+    units.forEach((u) => (m.unit[u.id as number] = u.name));
+    return m;
+  }, [users, letterTypes, projects, units]);
+
+  const handleExport = () => {
+    const data = letters.map((l) => ({
+      ID: l.id,
+      Тип: l.type === 'incoming' ? 'Входящее' : 'Исходящее',
+      Номер: l.number,
+      Дата: dayjs(l.date).format('DD.MM.YYYY'),
+      Отправитель: l.sender,
+      Получатель: l.receiver,
+      Тема: l.subject,
+      Проект: l.project_id ? maps.project[l.project_id] : '',
+      Объекты: l.unit_ids.map((id) => maps.unit[id]).filter(Boolean).join(', '),
+      Категория: l.letter_type_id ? maps.type[l.letter_type_id] : '',
+      Ответственный: l.responsible_user_id ? maps.user[l.responsible_user_id] : '',
+    }));
+    const ws = XLSX.utils.json_to_sheet(data);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Letters');
+    const buffer = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });
+    const blob = new Blob([buffer], { type: 'application/octet-stream' });
+    saveAs(blob, 'letters.xlsx');
+    notify.success('Файл сохранён');
+  };
+
+  return (
+    <Tooltip title="Выгрузить в Excel">
+      <Button icon={<DownloadOutlined />} onClick={handleExport} />
+    </Tooltip>
+  );
+}

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -15,6 +15,7 @@ import { AddLetterFormData } from '@/features/correspondence/AddLetterForm';
 import AddLetterForm from '@/features/correspondence/AddLetterForm';
 import LinkLettersDialog from '@/features/correspondence/LinkLettersDialog';
 import EditLetterDialog from '@/features/correspondence/EditLetterDialog';
+import ExportLettersButton from '@/features/correspondence/ExportLettersButton';
 import CorrespondenceTable from '@/widgets/CorrespondenceTable';
 import {
   useLetters,
@@ -336,6 +337,15 @@ export default function CorrespondencePage() {
           <Typography.Text style={{ display: 'block', marginTop: 8 }}>
             Всего писем: {total}
           </Typography.Text>
+          <div style={{ marginTop: 8 }}>
+            <ExportLettersButton
+              letters={filtered}
+              users={users}
+              letterTypes={letterTypes}
+              projects={projects}
+              units={allUnits}
+            />
+          </div>
         </div>
 
         <EditLetterDialog


### PR DESCRIPTION
## Summary
- create `ExportLettersButton` to save filtered letters to Excel
- show export button on correspondence page

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json` *(fails: Property 'isSameOrBefore' does not exist on type 'Dayjs')*


------
https://chatgpt.com/codex/tasks/task_e_684bbd210cfc832eab741f0dc28931fa