### PR TITLE
Update tickets table style and export

### DIFF
--- a/src/features/ticket/ExportTicketsButton.tsx
+++ b/src/features/ticket/ExportTicketsButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from 'antd';
+import { Button, Tooltip } from 'antd';
 import { FileExcelOutlined } from '@ant-design/icons';
 import * as XLSX from 'xlsx';
 import { saveAs } from 'file-saver';
@@ -15,10 +15,14 @@ export interface ExportTicketsButtonProps {
 }
 
 /** Кнопка экспорта списка замечаний в Excel */
-export default function ExportTicketsButton({ tickets, filters }: ExportTicketsButtonProps) {
+export default function ExportTicketsButton({
+  tickets,
+  filters,
+}: ExportTicketsButtonProps) {
   const handleClick = React.useCallback(() => {
     const rows = filterTickets(tickets, filters).map((t) => ({
       ID: t.id,
+      'ID родителя': t.parentId ?? '',
       Проект: t.projectName,
       Объекты: t.unitNames,
       Гарантия: t.isWarranty ? 'Да' : 'Нет',
@@ -32,7 +36,7 @@ export default function ExportTicketsButton({ tickets, filters }: ExportTicketsB
         ? t.customerRequestDate.format('DD.MM.YYYY')
         : '',
       'Ответственный инженер': t.responsibleEngineerName ?? '',
-      Название: t.title,
+      Название: t.parentId ? `↳ ${t.title}` : t.title,
     }));
     const wb = XLSX.utils.book_new();
     const ws = XLSX.utils.json_to_sheet(rows);
@@ -42,8 +46,8 @@ export default function ExportTicketsButton({ tickets, filters }: ExportTicketsB
   }, [tickets, filters]);
 
   return (
-    <Button icon={<FileExcelOutlined />} onClick={handleClick} style={{ marginLeft: 16 }}>
-      Выгрузить в Excel
-    </Button>
+    <Tooltip title="Выгрузить в Excel">
+      <Button icon={<FileExcelOutlined />} onClick={handleClick} />
+    </Tooltip>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -54,13 +54,14 @@ body {
 }
 
 .main-ticket-row {
-    background: #fffbe6 !important;
+    background: #eaf4ff !important;
     font-weight: 600;
+    box-shadow: 0 1px 0 #b5d3f7;
 }
 .child-ticket-row {
-    background: #fcfcfc !important;
+    background: #f8fafb !important;
     color: #888;
     font-style: italic;
-    border-left: 3px solid #faad14;
+    border-left: 3px solid #1890ff;
 }
 /* Skeleton эффекты были выше (оставил без изменений) */

--- a/src/widgets/TicketsTable.tsx
+++ b/src/widgets/TicketsTable.tsx
@@ -300,6 +300,7 @@ export default function TicketsTable({
         indentSize: 24,
       }}
       rowClassName={rowClassName}
+      style={{ background: '#fff' }}
     />
   );
 }


### PR DESCRIPTION
## Summary
- align tickets table styling with correspondence tables
- icon-only Excel export button and include parent link info

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684bc2f99478832e99793ed92c680cce