### PR TITLE
Implement court case linking

### DIFF
--- a/src/features/courtCase/LinkCasesDialog.tsx
+++ b/src/features/courtCase/LinkCasesDialog.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Modal, Input, Table, Button } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { CourtCase } from '@/shared/types/courtCase';
+
+interface Props {
+  open: boolean;
+  parent: CourtCase | null;
+  cases: (CourtCase & any)[];
+  onClose: () => void;
+  onSubmit: (ids: string[]) => void;
+}
+
+/** Диалог выбора судебных дел для связывания */
+export default function LinkCasesDialog({ open, parent, cases, onClose, onSubmit }: Props) {
+  const [selected, setSelected] = useState<string[]>([]);
+  const [search, setSearch] = useState('');
+
+  useEffect(() => {
+    setSelected([]);
+    setSearch('');
+  }, [parent, open]);
+
+  const parents = useMemo(() => {
+    const ids = new Set<string>();
+    cases.forEach((c) => {
+      if (c.parent_id) ids.add(String(c.parent_id));
+    });
+    return ids;
+  }, [cases]);
+
+  const filtered = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    return cases
+      .filter((c) => String(c.id) !== String(parent?.id))
+      .filter((c) => c.parent_id == null)
+      .filter((c) => !parents.has(String(c.id)))
+      .filter(
+        (c) =>
+          !term ||
+          String(c.id).includes(term) ||
+          (c.number ?? '').toLowerCase().includes(term),
+      );
+  }, [cases, parent, search, parents]);
+
+  const columns: ColumnsType<CourtCase & any> = [
+    { title: 'ID', dataIndex: 'id', width: 80 },
+    { title: '№ дела', dataIndex: 'number', ellipsis: true },
+    { title: 'Статус', dataIndex: 'statusName', width: 160 },
+  ];
+
+  return (
+    <Modal
+      title="Связать существующие дела"
+      open={open}
+      onCancel={onClose}
+      footer={[
+        <Button key="cancel" onClick={onClose}>
+          Отмена
+        </Button>,
+        <Button
+          key="link"
+          type="primary"
+          disabled={selected.length === 0}
+          onClick={() => onSubmit(selected)}
+        >
+          Связать
+        </Button>,
+      ]}
+      width={700}
+      destroyOnClose
+    >
+      <Input
+        placeholder="Поиск по ID или номеру"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        allowClear
+        style={{ marginBottom: 16 }}
+      />
+      <Table<CourtCase & any>
+        rowKey="id"
+        columns={columns}
+        dataSource={filtered}
+        size="small"
+        pagination={{ pageSize: 8, showSizeChanger: false }}
+        scroll={{ y: 320 }}
+        rowSelection={{
+          selectedRowKeys: selected,
+          onChange: (keys) => setSelected(keys as string[]),
+        }}
+        locale={{ emptyText: 'Нет подходящих дел' }}
+      />
+    </Modal>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -64,4 +64,15 @@ body {
     font-style: italic;
     border-left: 3px solid #1890ff;
 }
+.main-case-row {
+    background: #eaf4ff !important;
+    font-weight: 600;
+    box-shadow: 0 1px 0 #b5d3f7;
+}
+.child-case-row {
+    background: #f8fafb !important;
+    color: #888;
+    font-style: italic;
+    border-left: 3px solid #722ed1;
+}
 /* Skeleton эффекты были выше (оставил без изменений) */

--- a/src/shared/types/courtCase.ts
+++ b/src/shared/types/courtCase.ts
@@ -11,6 +11,8 @@ export type CaseStatus = 'active' | 'won' | 'lost' | 'settled';
 
 export interface CourtCase {
   id: number;
+  /** Идентификатор родительского дела */
+  parent_id?: number | null;
   project_id: number;
   /** Идентификаторы объектов проекта */
   unit_ids: number[];
@@ -28,4 +30,14 @@ export interface CourtCase {
   /** Ссылки на загруженные файлы */
   attachment_ids?: number[];
   defects: Defect[];
+}
+
+/** Связь дел: parent_id - родительское дело, child_id - дочернее */
+export interface CourtCaseLink {
+  /** Уникальный идентификатор связи */
+  id: string;
+  /** Идентификатор родительского дела */
+  parent_id: string;
+  /** Идентификатор дочернего дела */
+  child_id: string;
 }


### PR DESCRIPTION
## Summary
- add parent_id field and CourtCaseLink type
- extend court case hooks with linking APIs
- implement LinkCasesDialog
- enable linking UI on /court-cases page
- add row styles for linked court cases

## Testing
- `npm run lint` *(fails: Missing ESLint dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684bc6954540832ebf146b3a3cb52d9b