### PR TITLE
Fix attachments links export

### DIFF
--- a/src/features/ticket/ExportTicketsButton.tsx
+++ b/src/features/ticket/ExportTicketsButton.tsx
@@ -45,7 +45,7 @@ export default function ExportTicketsButton({
       'Подробное описание': t.description ?? '',
       'Ссылки на прикрепленные файлы': (t.attachments ?? [])
         .map((a) => a.url)
-        .join(', '),
+        .join('\n'),
       Название: t.parentId ? `↳ ${t.title}` : t.title,
     }));
     const wb = XLSX.utils.book_new();


### PR DESCRIPTION
## Summary
- fix Excel export to use newline-separated attachment links

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684bc96ad3f8832e8bfc87270e246d3d