### PR TITLE
Fix tickets count display

### DIFF
--- a/src/pages/TicketsPage/TicketsPage.tsx
+++ b/src/pages/TicketsPage/TicketsPage.tsx
@@ -208,7 +208,7 @@ export default function TicketsPage() {
             )}
           </Card>
           <Typography.Text style={{ display: 'block', marginTop: 8 }}>
-            Всего замечаний, из них закрытых: {closedCount} и не закрытых: {openCount}
+            Всего замечаний: {total}, из них закрытых: {closedCount} и не закрытых: {openCount}
           </Typography.Text>
           <Typography.Text style={{ display: 'block', marginTop: 4 }}>
             Готовых замечаний к выгрузке: {readyToExport}


### PR DESCRIPTION
## Summary
- show total tickets count on /tickets page

## Testing
- `npm run lint` *(fails: Parsing error due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684bd1b02da0832eaeb25f4c81d9eeaa