### PR TITLE
Implement letter status defaults and export improvements

### DIFF
--- a/src/features/correspondence/AddLetterForm.tsx
+++ b/src/features/correspondence/AddLetterForm.tsx
@@ -23,6 +23,7 @@ import { usePersons, useDeletePerson } from '@/entities/person';
 import { useAttachmentTypes } from '@/entities/attachmentType';
 import PersonModal from '@/features/person/PersonModal';
 import ContractorModal from '@/features/contractor/ContractorModal';
+import { useLetterStatuses } from '@/entities/letterStatus';
 import { useAuthStore } from '@/shared/store/authStore';
 
 export interface AddLetterFormData {
@@ -37,6 +38,8 @@ export interface AddLetterFormData {
   letter_type_id: number | null;
   project_id: number | null;
   unit_ids: number[];
+  /** Статус письма */
+  status_id: number | null;
   attachments: { file: File; type_id: number | null }[];
   parent_id: string | null;
 }
@@ -68,6 +71,7 @@ export default function AddLetterForm({ onSubmit, parentId = null, initialValues
   const { data: contractors = [], isLoading: loadingContractors } = useContractors();
   const { data: persons = [], isLoading: loadingPersons } = usePersons();
   const { data: attachmentTypes = [], isLoading: loadingAttachmentTypes } = useAttachmentTypes();
+  const { data: statuses = [] } = useLetterStatuses();
   const deletePerson = useDeletePerson();
   const deleteContractor = useDeleteContractor();
 
@@ -126,6 +130,7 @@ export default function AddLetterForm({ onSubmit, parentId = null, initialValues
     onSubmit({
       ...values,
       date: values.date ?? dayjs(),
+      status_id: statuses[0]?.id ?? null,
       attachments: files,
       parent_id: parentId,
     });

--- a/src/features/correspondence/ExportLettersButton.tsx
+++ b/src/features/correspondence/ExportLettersButton.tsx
@@ -15,6 +15,7 @@ interface ExportLettersButtonProps {
   letterTypes: Option[];
   projects: Option[];
   units: Option[];
+  statuses: Option[];
 }
 
 /**
@@ -27,6 +28,7 @@ export default function ExportLettersButton({
   letterTypes,
   projects,
   units,
+  statuses,
 }: ExportLettersButtonProps) {
   const notify = useNotify();
 
@@ -36,13 +38,15 @@ export default function ExportLettersButton({
       type: {} as Record<number, string>,
       project: {} as Record<number, string>,
       unit: {} as Record<number, string>,
+      status: {} as Record<number, string>,
     };
     users.forEach((u) => (m.user[u.id as string] = u.name));
     letterTypes.forEach((t) => (m.type[t.id as number] = t.name));
     projects.forEach((p) => (m.project[p.id as number] = p.name));
     units.forEach((u) => (m.unit[u.id as number] = u.name));
+    statuses.forEach((s) => (m.status[s.id as number] = s.name));
     return m;
-  }, [users, letterTypes, projects, units]);
+  }, [users, letterTypes, projects, units, statuses]);
 
   const handleExport = () => {
     const data = letters.map((l) => ({
@@ -57,7 +61,9 @@ export default function ExportLettersButton({
       Проект: l.project_id ? maps.project[l.project_id] : '',
       Объекты: l.unit_ids.map((id) => maps.unit[id]).filter(Boolean).join(', '),
       Категория: l.letter_type_id ? maps.type[l.letter_type_id] : '',
+      Статус: l.status_id ? maps.status[l.status_id] : '',
       Ответственный: l.responsible_user_id ? maps.user[l.responsible_user_id] : '',
+      Содержание: l.content,
       'Ссылки на файлы': (l.attachments ?? []).map((a) => a.file_url).join('\n'),
     }));
     const ws = XLSX.utils.json_to_sheet(data);

--- a/src/features/correspondence/LetterStatusSelect.tsx
+++ b/src/features/correspondence/LetterStatusSelect.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Select, Tag } from 'antd';
+import { useLetterStatuses } from '@/entities/letterStatus';
+import { useUpdateLetterStatus } from '@/entities/correspondence';
+
+interface Props {
+  letterId: string;
+  statusId: number | null;
+  statusName?: string | null;
+  statusColor?: string | null;
+}
+
+export default function LetterStatusSelect({
+  letterId,
+  statusId,
+  statusName,
+  statusColor,
+}: Props) {
+  const { data: statuses = [], isLoading } = useLetterStatuses();
+  const update = useUpdateLetterStatus();
+  const [editing, setEditing] = React.useState(false);
+
+  const options = React.useMemo(
+    () =>
+      statuses.map((s) => ({
+        label: <Tag color={s.color ?? undefined}>{s.name}</Tag>,
+        value: s.id,
+      })),
+    [statuses],
+  );
+
+  const current = React.useMemo(
+    () =>
+      statuses.find((s) => s.id === statusId) ||
+      (statusId
+        ? { id: statusId, name: statusName ?? String(statusId), color: statusColor ?? undefined }
+        : null),
+    [statuses, statusId, statusName, statusColor],
+  );
+
+  const handleChange = (value: number) => {
+    (update as any).mutate({ id: letterId, statusId: value });
+    setEditing(false);
+  };
+
+  if (!editing) {
+    return (
+      <Tag color={current?.color} onClick={() => setEditing(true)} style={{ cursor: 'pointer' }}>
+        {current?.name ?? '—'}
+      </Tag>
+    );
+  }
+
+  return (
+    <Select
+      size="small"
+      autoFocus
+      open
+      defaultValue={statusId ?? undefined}
+      onBlur={() => setEditing(false)}
+      onChange={handleChange}
+      loading={isLoading || update.isPending}
+      optionLabelProp="label"
+      options={options}
+      style={{ width: '100%' }}
+    />
+  );
+}

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -187,7 +187,7 @@ export default function CorrespondencePage() {
         responsible_user_id: data.responsible_user_id || null,
         date: data.date ? data.date.toISOString() : dayjs().toISOString(),
       },
-      ['responsible_user_id', 'letter_type_id', 'project_id'],
+      ['responsible_user_id', 'letter_type_id', 'project_id', 'status_id'],
     );
 
     add.mutate(safeData, {
@@ -405,6 +405,7 @@ export default function CorrespondencePage() {
             letterTypes={letterTypes}
             projects={projects}
             units={allUnits}
+            statuses={statuses}
           />
           <Typography.Text style={{ display: 'block', marginTop: 8 }}>
             Всего писем: {total}
@@ -416,6 +417,7 @@ export default function CorrespondencePage() {
               letterTypes={letterTypes}
               projects={projects}
               units={allUnits}
+              statuses={statuses}
             />
           </div>
         </div>

--- a/src/widgets/CorrespondenceTable.tsx
+++ b/src/widgets/CorrespondenceTable.tsx
@@ -4,6 +4,7 @@ import { Table, Space, Button, Popconfirm, Tag, Tooltip } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { EyeOutlined, DeleteOutlined, PlusOutlined, MailOutlined, BranchesOutlined, LinkOutlined } from '@ant-design/icons';
 import { CorrespondenceLetter } from '@/shared/types/correspondence';
+import LetterStatusSelect from '@/features/correspondence/LetterStatusSelect';
 
 interface Option { id: number | string; name: string; }
 
@@ -17,6 +18,7 @@ interface CorrespondenceTableProps {
   letterTypes: Option[];
   projects: Option[];
   units: Option[];
+  statuses: Option[];
 }
 
 /** Таблица писем с иерархией и кнопкой "исключить из связи" */
@@ -30,6 +32,7 @@ export default function CorrespondenceTable({
                                               letterTypes,
                                               projects,
                                               units,
+                                              statuses,
                                             }: CorrespondenceTableProps) {
   const maps = useMemo(() => {
     const m = {
@@ -37,13 +40,15 @@ export default function CorrespondenceTable({
       type: {} as Record<number, string>,
       project: {} as Record<number, string>,
       unit: {} as Record<number, string>,
+      status: {} as Record<number, string>,
     };
     users.forEach((u) => (m.user[u.id as string] = u.name));
     letterTypes.forEach((t) => (m.type[t.id as number] = t.name));
     projects.forEach((p) => (m.project[p.id as number] = p.name));
     units.forEach((u) => (m.unit[u.id as number] = u.name));
+    statuses.forEach((s) => (m.status[s.id as number] = s.name));
     return m;
-  }, [users, letterTypes, projects, units]);
+  }, [users, letterTypes, projects, units, statuses]);
 
   const treeData = useMemo(() => {
     const map = new Map<string, any>();
@@ -62,6 +67,7 @@ export default function CorrespondenceTable({
         responsibleName: l.responsible_user_id
             ? maps.user[l.responsible_user_id]
             : null,
+        statusName: l.status_id ? maps.status[l.status_id] : null,
         children: [],
       };
       map.set(l.id, row);
@@ -174,6 +180,18 @@ export default function CorrespondenceTable({
       dataIndex: 'letterTypeName',
       sorter: (a, b) =>
           (a.letterTypeName || '').localeCompare(b.letterTypeName || ''),
+    },
+    {
+      title: 'Статус',
+      dataIndex: 'statusName',
+      sorter: (a, b) => (a.statusName || '').localeCompare(b.statusName || ''),
+      render: (_: any, row: any) => (
+        <LetterStatusSelect
+          letterId={row.id}
+          statusId={row.status_id}
+          statusName={row.statusName}
+        />
+      ),
     },
     {
       title: 'Ответственный',


### PR DESCRIPTION
## Summary
- choose default letter status when creating a letter
- show letter status column in correspondence table with inline editing
- include status and content in Excel export
- add helper to update letter status

## Testing
- `npm run lint` *(fails: eslint plugins missing)*
- `npx tsc -p tsconfig.json` *(fails: missing type packages)*

------
https://chatgpt.com/codex/tasks/task_e_684bd9985a54832ea7630a141d7b0081