### PR TITLE
Unify Excel export icons

### DIFF
--- a/src/features/courtCase/ExportCourtCasesButton.tsx
+++ b/src/features/courtCase/ExportCourtCasesButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button, Tooltip } from 'antd';
-import { FileExcelOutlined } from '@ant-design/icons';
+import { DownloadOutlined } from '@ant-design/icons';
 import * as XLSX from 'xlsx';
 import { saveAs } from 'file-saver';
 import dayjs from 'dayjs';
@@ -76,7 +76,7 @@ export default function ExportCourtCasesButton({
 
   return (
     <Tooltip title="Выгрузить в Excel">
-      <Button icon={<FileExcelOutlined />} loading={loading} onClick={handleExport} />
+      <Button icon={<DownloadOutlined />} loading={loading} onClick={handleExport} />
     </Tooltip>
   );
 }

--- a/src/features/ticket/ExportTicketsButton.tsx
+++ b/src/features/ticket/ExportTicketsButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button, Tooltip } from 'antd';
-import { FileExcelOutlined } from '@ant-design/icons';
+import { DownloadOutlined } from '@ant-design/icons';
 import * as XLSX from 'xlsx';
 import { saveAs } from 'file-saver';
 import dayjs from 'dayjs';
@@ -60,7 +60,7 @@ export default function ExportTicketsButton({
 
   return (
     <Tooltip title="Выгрузить в Excel">
-      <Button icon={<FileExcelOutlined />} onClick={handleClick} />
+      <Button icon={<DownloadOutlined />} onClick={handleClick} />
     </Tooltip>
   );
 }


### PR DESCRIPTION
## Summary
- use `DownloadOutlined` on ticket export
- use `DownloadOutlined` on court case export

## Testing
- `npm run lint` *(fails: parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_684be21bd330832ea904879a4627e618