### PR TITLE
Remove unused join tables

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -665,48 +665,6 @@
     "column_default": "now()"
   },
   {
-    "table_name": "ticket_status_history",
-    "column_name": "id",
-    "data_type": "integer",
-    "is_nullable": "NO",
-    "column_default": "nextval('ticket_status_history_id_seq'::regclass)"
-  },
-  {
-    "table_name": "ticket_status_history",
-    "column_name": "ticket_id",
-    "data_type": "integer",
-    "is_nullable": "YES",
-    "column_default": null
-  },
-  {
-    "table_name": "ticket_status_history",
-    "column_name": "status_id",
-    "data_type": "integer",
-    "is_nullable": "YES",
-    "column_default": null
-  },
-  {
-    "table_name": "ticket_status_history",
-    "column_name": "changed_at",
-    "data_type": "timestamp with time zone",
-    "is_nullable": "YES",
-    "column_default": "now()"
-  },
-  {
-    "table_name": "ticket_status_history",
-    "column_name": "changed_by",
-    "data_type": "uuid",
-    "is_nullable": "YES",
-    "column_default": null
-  },
-  {
-    "table_name": "ticket_status_history",
-    "column_name": "comment",
-    "data_type": "text",
-    "is_nullable": "YES",
-    "column_default": null
-  },
-  {
     "table_name": "ticket_statuses",
     "column_name": "id",
     "data_type": "integer",
@@ -915,20 +873,6 @@
     "data_type": "timestamp with time zone",
     "is_nullable": "YES",
     "column_default": "now()"
-  },
-  {
-    "table_name": "unit_persons",
-    "column_name": "unit_id",
-    "data_type": "integer",
-    "is_nullable": "NO",
-    "column_default": null
-  },
-  {
-    "table_name": "unit_persons",
-    "column_name": "person_id",
-    "data_type": "bigint",
-    "is_nullable": "NO",
-    "column_default": null
   },
   {
     "table_name": "units",

--- a/src/entities/unit.js
+++ b/src/entities/unit.js
@@ -14,9 +14,6 @@ const SELECT = `
   id, name, building, section, floor,
   project_id,
   project:projects ( id, name ),
-  unit_persons (
-    person:persons ( id, full_name, phone, email )
-  ),
   person_id
 `;
 
@@ -47,7 +44,7 @@ export const useUnits = () => {
 
             return (data ?? []).map((u) => ({
                 ...u,
-                persons: (u.unit_persons?.map((l) => l.person).filter(Boolean)) ?? [],
+                persons: [], // unit_persons removed
             }));
         },
         staleTime: 5 * 60_000,
@@ -69,7 +66,7 @@ export const useUnitsByProject = (projectId) =>
 
             return (data ?? []).map((u) => ({
                 ...u,
-                persons: (u.unit_persons?.map((l) => l.person).filter(Boolean)) ?? [],
+                persons: [], // unit_persons removed
             }));
         },
         staleTime: 5 * 60_000,
@@ -120,7 +117,7 @@ export const useUnit = (unitId) => {
 
             return {
                 ...data,
-                persons: (data.unit_persons?.map((l) => l.person).filter(Boolean)) ?? [],
+                persons: [], // unit_persons removed
             };
         },
         staleTime: 5 * 60_000,
@@ -193,7 +190,7 @@ const updateUnit = async ({ id, updates }) => {
 
     return {
         ...data,
-        persons: (data.unit_persons?.map((l) => l.person).filter(Boolean)) ?? [],
+        persons: [], // unit_persons removed
     };
 };
 

--- a/src/features/person/PersonModal.tsx
+++ b/src/features/person/PersonModal.tsx
@@ -45,12 +45,7 @@ export default function PersonModal({
       const res = isEdit
         ? await update.mutateAsync({ id: initialData.id, updates: values })
         : await add.mutateAsync(values);
-      if (unitId && !isEdit) {
-        await supabase.from('unit_persons').insert({
-          unit_id: unitId,
-          person_id: res.id,
-        });
-      }
+      // unit_persons table removed
       message.success(isEdit ? 'Физлицо обновлено' : 'Физлицо добавлено');
       qc.invalidateQueries({ queryKey: ['projectPersons'] });
       onSelect(res.full_name);

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -1863,9 +1863,7 @@ function AddPersonModal({ open, onClose, unitId, onSelect, initialData = null }:
       : addPersonMutation.mutateAsync(values);
     action
       .then(async (person: any) => {
-        if (unitId && !isEdit) {
-          await supabase.from('unit_persons').insert({ unit_id: unitId, person_id: person.id });
-        }
+        // unit_persons table removed
         notify.success(isEdit ? 'Физлицо обновлено' : 'Физлицо добавлено');
         qc.invalidateQueries({ queryKey: ['projectPersons'] });
         onSelect(person.id);


### PR DESCRIPTION
## Summary
- drop `ticket_status_history` and `unit_persons` tables from db structure
- remove all `unit_persons` related queries

## Testing
- `npm run lint` *(fails: Parsing error: The keyword 'interface' is reserved)*

------
https://chatgpt.com/codex/tasks/task_e_684be7e0a78c832e80f8eb1b93f73617