### PR TITLE
Fix ticket export types

### DIFF
--- a/src/features/ticket/ExportTicketsButton.tsx
+++ b/src/features/ticket/ExportTicketsButton.tsx
@@ -4,13 +4,13 @@ import { DownloadOutlined } from '@ant-design/icons';
 import * as XLSX from 'xlsx';
 import { saveAs } from 'file-saver';
 import dayjs from 'dayjs';
-import { Ticket } from '@/shared/types/ticket';
+import type { TicketWithNames } from '@/shared/types/ticketWithNames';
 import { TicketFilters } from '@/shared/types/ticketFilters';
 import { filterTickets } from '@/shared/utils/ticketFilter';
 
 export interface ExportTicketsButtonProps {
   /** Список замечаний */
-  tickets: Ticket[];
+  tickets: TicketWithNames[];
   /** Активные фильтры */
   filters: TicketFilters;
 }

--- a/src/pages/TicketsPage/TicketsPage.tsx
+++ b/src/pages/TicketsPage/TicketsPage.tsx
@@ -17,6 +17,7 @@ import TicketFormAntd from "@/features/ticket/TicketFormAntd";
 import TicketViewModal from "@/features/ticket/TicketViewModal";
 import LinkTicketsDialog from "@/features/ticket/LinkTicketsDialog";
 import ExportTicketsButton from "@/features/ticket/ExportTicketsButton";
+import type { TicketWithNames } from "@/shared/types/ticketWithNames";
 import { useNotify } from "@/shared/hooks/useNotify";
 import { filterTickets } from "@/shared/utils/ticketFilter";
 
@@ -89,7 +90,7 @@ export default function TicketsPage() {
     return map;
   }, [units]);
 
-  const ticketsWithNames = useMemo(
+  const ticketsWithNames: TicketWithNames[] = useMemo(
     () =>
       tickets.map((t) => ({
         ...t,
@@ -120,8 +121,8 @@ export default function TicketsPage() {
     };
   }, [ticketsWithNames]);
 
-  const handleUnlink = (id: string) => {
-    unlinkTicket.mutate(id, {
+  const handleUnlink = (id: number) => {
+    unlinkTicket.mutate(String(id), {
       onSuccess: () => notify.success('Замечание исключено из связи'),
     });
   };

--- a/src/shared/types/ticketWithNames.ts
+++ b/src/shared/types/ticketWithNames.ts
@@ -1,0 +1,9 @@
+import type { Ticket } from '@/entities/ticket';
+
+/** Замечание с дополнительными именами пользователей */
+export interface TicketWithNames extends Ticket {
+  /** Имя ответственного инженера */
+  responsibleEngineerName: string | null;
+  /** Имя автора замечания */
+  createdByName: string | null;
+}

--- a/src/widgets/TicketsTable.tsx
+++ b/src/widgets/TicketsTable.tsx
@@ -28,6 +28,8 @@ import { useDeleteTicket } from "@/entities/ticket";
 import TicketStatusSelect from "@/features/ticket/TicketStatusSelect";
 import TicketClosedSelect from "@/features/ticket/TicketClosedSelect";
 import { filterTickets } from "@/shared/utils/ticketFilter";
+import type { TicketFilters } from "@/shared/types/ticketFilters";
+import type { TicketWithNames } from "@/shared/types/ticketWithNames";
 
 /** Форматирование даты */
 const fmt = (d, withTime = false) =>
@@ -50,6 +52,15 @@ const daysPassed = (receivedAt) =>
  * @param {Function} onAddChild - открыть диалог для связывания
  * @param {Function} onUnlink - удалить связь
  */
+interface Props {
+  tickets: TicketWithNames[];
+  filters: TicketFilters;
+  loading?: boolean;
+  onView?: (id: number) => void;
+  onAddChild?: (ticket: TicketWithNames) => void;
+  onUnlink?: (id: number) => void;
+}
+
 export default function TicketsTable({
   tickets,
   filters,
@@ -57,7 +68,7 @@ export default function TicketsTable({
   onView,
   onAddChild,
   onUnlink,
-}) {
+}: Props) {
   const { mutateAsync: remove, isPending } = useDeleteTicket();
 
   const columns: ColumnsType<any> = useMemo(


### PR DESCRIPTION
## Summary
- extend ticket type for UI exports
- fix export button typings
- type tickets page and table accordingly

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_684bf1f03168832e8b7ae57af61935fa