### PR TITLE
Fix case table ID wrapping

### DIFF
--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -395,6 +395,9 @@ export default function CourtCasesPage() {
       dataIndex: 'id',
       width: 80,
       sorter: (a, b) => a.id - b.id,
+      render: (id: number) => (
+        <span style={{ whiteSpace: 'nowrap' }}>{id}</span>
+      ),
     },
     {
       title: 'Проект',


### PR DESCRIPTION
## Summary
- prevent Court Case ID from breaking lines when child cases expanded

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c0510e6f4832eb1afc088f1ef6a2a