### PR TITLE
Switch from xlsx to exceljs

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react-table": "^7.8.0",
     "react-window": "^1.8.11",
     "slugify": "^1.6.6",
-    "xlsx": "^0.18.5",
+    "exceljs": "^4.4.0",
     "yup": "^1.6.1",
     "zod": "^3.24.3",
     "zustand": "^5.0.3"


### PR DESCRIPTION
## Summary
- replace deprecated `xlsx` with `exceljs`
- update exports to use `exceljs`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c0679ba38832e8ef58c4a65c6fa54