### PR TITLE
Fix column reorder on CourtCasesPage

### DIFF
--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -211,7 +211,7 @@ export default function CourtCasesPage() {
   const columnDefs = React.useMemo(() => {
     const map: Record<string, any> = {
       tree: {
-        title: '',
+        title: 'Иконка',
         dataIndex: 'tree',
         width: 40,
         render: (_: any, record: any) => {
@@ -450,9 +450,10 @@ export default function CourtCasesPage() {
                           <div
                             ref={p.innerRef}
                             {...p.draggableProps}
+                            {...p.dragHandleProps}
                             style={{ display: 'flex', alignItems: 'center', marginBottom: 8, ...p.draggableProps.style }}
                           >
-                            <MenuOutlined style={{ marginRight: 8, cursor: 'grab' }} {...p.dragHandleProps} />
+                            <MenuOutlined style={{ marginRight: 8, cursor: 'grab' }} />
                             <Checkbox
                               checked={!hiddenColumns.includes(k)}
                               onChange={(e) => {


### PR DESCRIPTION
## Summary
- enable drag-and-drop on whole row in CourtCasesPage column settings
- label icon column correctly as `Иконка`

## Testing
- `npm install --no-audit --progress=false`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c3b78df0c832e81bb4799306bea18