### PR TITLE
Add Excel export shortcut and column order controls

### DIFF
--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -33,6 +33,8 @@ import {
   BranchesOutlined,
   SettingOutlined,
   MenuOutlined,
+  ArrowUpOutlined,
+  ArrowDownOutlined,
 } from '@ant-design/icons';
 import {
   useCourtCases,
@@ -365,6 +367,10 @@ export default function CourtCasesPage() {
             {showFilters ? 'Скрыть фильтры' : 'Показать фильтры'}
           </Button>
           <Button icon={<SettingOutlined />} onClick={() => setColumnsDrawer(true)} />
+          <ExportCourtCasesButton
+            cases={filteredCases}
+            stages={Object.fromEntries(stages.map((s) => [s.id, s.name]))}
+          />
         </Space>
         {showAddForm && (
           <AddCourtCaseFormAntd
@@ -408,6 +414,7 @@ export default function CourtCasesPage() {
 
           <Table
             rowKey="id"
+            key={columnKeys.join('-')}
             columns={columns}
             dataSource={treeData}
             loading={casesLoading}
@@ -450,10 +457,12 @@ export default function CourtCasesPage() {
                           <div
                             ref={p.innerRef}
                             {...p.draggableProps}
-                            {...p.dragHandleProps}
                             style={{ display: 'flex', alignItems: 'center', marginBottom: 8, ...p.draggableProps.style }}
                           >
-                            <MenuOutlined style={{ marginRight: 8, cursor: 'grab' }} />
+                            <MenuOutlined
+                              style={{ marginRight: 8, cursor: 'grab' }}
+                              {...p.dragHandleProps}
+                            />
                             <Checkbox
                               checked={!hiddenColumns.includes(k)}
                               onChange={(e) => {
@@ -464,6 +473,32 @@ export default function CourtCasesPage() {
                             >
                               {columnDefs[k].title}
                             </Checkbox>
+                            <Space style={{ marginLeft: 'auto' }}>
+                              <Button
+                                size="small"
+                                icon={<ArrowUpOutlined />}
+                                onClick={() => {
+                                  setColumnKeys((prev) => {
+                                    if (index === 0) return prev;
+                                    const arr = [...prev];
+                                    [arr[index - 1], arr[index]] = [arr[index], arr[index - 1]];
+                                    return arr;
+                                  });
+                                }}
+                              />
+                              <Button
+                                size="small"
+                                icon={<ArrowDownOutlined />}
+                                onClick={() => {
+                                  setColumnKeys((prev) => {
+                                    if (index === prev.length - 1) return prev;
+                                    const arr = [...prev];
+                                    [arr[index], arr[index + 1]] = [arr[index + 1], arr[index]];
+                                    return arr;
+                                  });
+                                }}
+                              />
+                            </Space>
                           </div>
                         )}
                       </Draggable>


### PR DESCRIPTION
## Summary
- add export button near column settings
- allow reordering columns with up/down arrows
- limit drag handle to icon and remount table when columns change

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684c3d211c00832e9e4dff67a6ae0d82