### PR TITLE
Fix modals warnings

### DIFF
--- a/src/features/correspondence/LinkLettersDialog.tsx
+++ b/src/features/correspondence/LinkLettersDialog.tsx
@@ -105,7 +105,7 @@ export default function LinkLettersDialog({
             </Button>,
           ]}
           width={700}
-          destroyOnClose
+          destroyOnHidden
       >
         <Input
             placeholder="Поиск по номеру, теме, корреспонденту"

--- a/src/features/courtCase/LinkCasesDialog.tsx
+++ b/src/features/courtCase/LinkCasesDialog.tsx
@@ -68,7 +68,7 @@ export default function LinkCasesDialog({ open, parent, cases, onClose, onSubmit
         </Button>,
       ]}
       width={700}
-      destroyOnClose
+      destroyOnHidden
     >
       <Input
         placeholder="Поиск по ID или номеру"

--- a/src/features/history/HistoryDialog.tsx
+++ b/src/features/history/HistoryDialog.tsx
@@ -138,7 +138,7 @@ export default function HistoryDialog({ open, unit, onClose, onOpenCourtCase }: 
             title={unit ? `История объекта ${unit.name}` : 'История'}
             width={700}
             zIndex={1400}
-            destroyOnClose
+            destroyOnHidden
         >
           <Space style={{ marginBottom: 12 }}>
             <Switch checked={primaryOnly} onChange={setPrimaryOnly} />

--- a/src/features/ticket/LinkTicketsDialog.tsx
+++ b/src/features/ticket/LinkTicketsDialog.tsx
@@ -74,7 +74,7 @@ export default function LinkTicketsDialog({
         </Button>,
       ]}
       width={700}
-      destroyOnClose
+      destroyOnHidden
     >
       <Input
         placeholder="Поиск по ID или названию"


### PR DESCRIPTION
## Summary
- replace deprecated `destroyOnClose` prop with `destroyOnHidden` in modal dialogs

## Testing
- `npm run lint` *(fails: Parsing errors)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3e9c70b8832e945bd8ae77425f20