### PR TITLE
Fix column reordering

### DIFF
--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -69,6 +69,7 @@ export default function CourtCasesPage() {
   const [showAddForm, setShowAddForm] = useState(false);
   const [showFilters, setShowFilters] = useState(true);
   const [columnsDrawer, setColumnsDrawer] = useState(false);
+  const LS_COL_ORDER = 'courtCasesColumnOrder';
   const [columnKeys, setColumnKeys] = useState<string[]>([]);
   const [hiddenColumns, setHiddenColumns] = useState<string[]>([]);
   const hideOnScroll = useRef(false);
@@ -336,7 +337,30 @@ export default function CourtCasesPage() {
     return map;
   }, [unlinkCase, deleteCaseMutation]);
 
+  const moveColumn = (from: number, to: number) => {
+    setColumnKeys((prev) => {
+      const arr = [...prev];
+      if (to < 0 || to >= arr.length) return prev;
+      const [moved] = arr.splice(from, 1);
+      arr.splice(to, 0, moved);
+      try {
+        localStorage.setItem(LS_COL_ORDER, JSON.stringify(arr));
+      } catch {}
+      return arr;
+    });
+  };
+
   useEffect(() => {
+    const saved = localStorage.getItem(LS_COL_ORDER);
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved) as string[];
+        if (parsed.length) {
+          setColumnKeys(parsed);
+          return;
+        }
+      } catch {}
+    }
     setColumnKeys(Object.keys(columnDefs));
   }, [columnDefs]);
 
@@ -442,10 +466,7 @@ export default function CourtCasesPage() {
             <DragDropContext
               onDragEnd={(result: DropResult) => {
                 if (!result.destination) return;
-                const newOrder = Array.from(columnKeys);
-                const [moved] = newOrder.splice(result.source.index, 1);
-                newOrder.splice(result.destination.index, 0, moved);
-                setColumnKeys(newOrder);
+                moveColumn(result.source.index, result.destination.index);
               }}
             >
               <Droppable droppableId="cols">
@@ -477,26 +498,12 @@ export default function CourtCasesPage() {
                               <Button
                                 size="small"
                                 icon={<ArrowUpOutlined />}
-                                onClick={() => {
-                                  setColumnKeys((prev) => {
-                                    if (index === 0) return prev;
-                                    const arr = [...prev];
-                                    [arr[index - 1], arr[index]] = [arr[index], arr[index - 1]];
-                                    return arr;
-                                  });
-                                }}
+                                onClick={() => moveColumn(index, index - 1)}
                               />
                               <Button
                                 size="small"
                                 icon={<ArrowDownOutlined />}
-                                onClick={() => {
-                                  setColumnKeys((prev) => {
-                                    if (index === prev.length - 1) return prev;
-                                    const arr = [...prev];
-                                    [arr[index], arr[index + 1]] = [arr[index + 1], arr[index]];
-                                    return arr;
-                                  });
-                                }}
+                                onClick={() => moveColumn(index, index + 1)}
                               />
                             </Space>
                           </div>


### PR DESCRIPTION
## Summary
- fix column reorder buttons in CourtCasesPage

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c404b82bc832eb8e026a889b02824