### PR TITLE
Fix navigation issue with HashRouter

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./app/App";
-import { BrowserRouter } from "react-router-dom";
+import { HashRouter } from "react-router-dom";
 import { SnackbarProvider } from "notistack";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
@@ -21,9 +21,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
           maxSnack={3}
           anchorOrigin={{ vertical: "top", horizontal: "right" }}
         >
-          <BrowserRouter>
+          <HashRouter>
             <App />
-          </BrowserRouter>
+          </HashRouter>
         </SnackbarProvider>
         <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>


### PR DESCRIPTION
## Summary
- switch routing to `HashRouter` so navigation works when opening built files or hosted on static servers

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c43fbf5a0832e9d15159e09c6ad38