### PR TITLE
Add column settings drawer

### DIFF
--- a/src/shared/types/tableColumnSetting.ts
+++ b/src/shared/types/tableColumnSetting.ts
@@ -1,0 +1,8 @@
+export interface TableColumnSetting {
+  /** Уникальный ключ столбца */
+  key: string;
+  /** Отображаемое название столбца */
+  title: string;
+  /** Виден ли столбец */
+  visible: boolean;
+}

--- a/src/widgets/TableColumnsDrawer.tsx
+++ b/src/widgets/TableColumnsDrawer.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Drawer, Switch, Button } from 'antd';
+import { UpOutlined, DownOutlined } from '@ant-design/icons';
+import type { TableColumnSetting } from '@/shared/types/tableColumnSetting';
+
+interface Props {
+  open: boolean;
+  columns: TableColumnSetting[];
+  onChange: (cols: TableColumnSetting[]) => void;
+  onClose: () => void;
+}
+
+/**
+ * Боковая панель настройки столбцов таблицы.
+ */
+export default function TableColumnsDrawer({ open, columns, onChange, onClose }: Props) {
+  const move = (from: number, to: number) => {
+    if (to < 0 || to >= columns.length) return;
+    const updated = [...columns];
+    const [item] = updated.splice(from, 1);
+    updated.splice(to, 0, item);
+    onChange(updated);
+  };
+
+  const toggle = (index: number, value: boolean) => {
+    const updated = [...columns];
+    updated[index] = { ...updated[index], visible: value };
+    onChange(updated);
+  };
+
+  return (
+    <Drawer title="Настройка столбцов" placement="right" onClose={onClose} open={open}>
+      {columns.map((c, idx) => (
+        <div key={c.key} style={{ display: 'flex', alignItems: 'center', marginBottom: 8 }}>
+          <Switch checked={c.visible} onChange={(v) => toggle(idx, v)} size="small" />
+          <span style={{ marginLeft: 8, flexGrow: 1 }}>{c.title || '(без названия)'}</span>
+          <Button
+            size="small"
+            type="text"
+            icon={<UpOutlined />}
+            disabled={idx === 0}
+            onClick={() => move(idx, idx - 1)}
+          />
+          <Button
+            size="small"
+            type="text"
+            icon={<DownOutlined />}
+            disabled={idx === columns.length - 1}
+            onClick={() => move(idx, idx + 1)}
+          />
+        </div>
+      ))}
+    </Drawer>
+  );
+}


### PR DESCRIPTION
## Summary
- add `TableColumnsDrawer` widget for column visibility and ordering
- store column settings in local storage on court cases page
- show settings button with gear icon

## Testing
- `npm run lint` *(fails: parsing errors)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c4b78b8d8832e9752fd8cc192f651