### PR TITLE
feat(court-cases): remember UI state

### DIFF
--- a/src/features/courtCase/ExportCourtCasesButton.tsx
+++ b/src/features/courtCase/ExportCourtCasesButton.tsx
@@ -13,6 +13,8 @@ export interface ExportCourtCasesButtonProps {
   cases: (CourtCase & Record<string, any>)[];
   /** Словарь названий стадий по идентификатору. */
   stages: Record<number, string>;
+  /** Стили кнопки (опционально). */
+  style?: React.CSSProperties;
 }
 
 /**
@@ -23,6 +25,7 @@ export interface ExportCourtCasesButtonProps {
 export default function ExportCourtCasesButton({
   cases,
   stages,
+  style,
 }: ExportCourtCasesButtonProps) {
   const [loading, setLoading] = React.useState(false);
 
@@ -79,7 +82,12 @@ export default function ExportCourtCasesButton({
 
   return (
     <Tooltip title="Выгрузить в Excel">
-      <Button icon={<DownloadOutlined />} loading={loading} onClick={handleExport} />
+      <Button
+        icon={<DownloadOutlined />}
+        loading={loading}
+        onClick={handleExport}
+        style={style}
+      />
     </Tooltip>
   );
 }

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -46,6 +46,10 @@ import type { TableColumnSetting } from '@/shared/types/tableColumnSetting';
 
 const LS_KEY = 'courtCasesHideClosed';
 const LS_COLUMNS_KEY = 'courtCasesColumns';
+/** Ключ в localStorage для состояния показа фильтров */
+const LS_SHOW_FILTERS_KEY = 'courtCasesShowFilters';
+/** Ключ в localStorage для раскрытых строк таблицы судебных дел */
+const LS_EXPANDED_KEY = 'courtCasesExpandedRows';
 
 export default function CourtCasesPage() {
   const { data: cases = [], isPending: casesLoading } = useCourtCases();
@@ -55,7 +59,14 @@ export default function CourtCasesPage() {
   const unlinkCase = useUnlinkCase();
   const [linkFor, setLinkFor] = useState<CourtCase | null>(null);
   const [showAddForm, setShowAddForm] = useState(false);
-  const [showFilters, setShowFilters] = useState(true);
+  const [showFilters, setShowFilters] = useState(() => {
+    try {
+      const saved = localStorage.getItem(LS_SHOW_FILTERS_KEY);
+      return saved ? JSON.parse(saved) : true;
+    } catch {
+      return true;
+    }
+  });
   const [showColumnsDrawer, setShowColumnsDrawer] = useState(false);
   const hideOnScroll = useRef(false);
 
@@ -104,6 +115,24 @@ export default function CourtCasesPage() {
     window.addEventListener('storage', handler);
     return () => window.removeEventListener('storage', handler);
   }, []);
+
+  useEffect(() => {
+    const handler = (e: StorageEvent) => {
+      if (e.key === LS_SHOW_FILTERS_KEY) {
+        try {
+          setShowFilters(JSON.parse(e.newValue || 'true'));
+        } catch {}
+      }
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(LS_SHOW_FILTERS_KEY, JSON.stringify(showFilters));
+    } catch {}
+  }, [showFilters]);
 
   const handleFiltersChange = (v: CourtCasesFiltersValues) => {
     if (v.hideClosed !== filters.hideClosed) {
@@ -346,6 +375,29 @@ export default function CourtCasesPage() {
     [columnsState],
   );
 
+  const [expandedRowKeys, setExpandedRowKeys] = useState<React.Key[]>([]);
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(LS_EXPANDED_KEY);
+      if (saved) {
+        const parsed: React.Key[] = JSON.parse(saved);
+        const valid = parsed.filter((id) =>
+          filteredCases.some((c) => String(c.id) === String(id)),
+        );
+        setExpandedRowKeys(valid);
+        return;
+      }
+    } catch {}
+    setExpandedRowKeys(filteredCases.map((c) => c.id));
+  }, [filteredCases]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(LS_EXPANDED_KEY, JSON.stringify(expandedRowKeys));
+    } catch {}
+  }, [expandedRowKeys]);
+
 
   const total = cases.length;
   const closedCount = React.useMemo(
@@ -368,6 +420,11 @@ export default function CourtCasesPage() {
           icon={<SettingOutlined />}
           style={{ marginTop: 16, marginLeft: 8 }}
           onClick={() => setShowColumnsDrawer(true)}
+        />
+        <ExportCourtCasesButton
+          cases={filteredCases}
+          stages={Object.fromEntries(stages.map((s) => [s.id, s.name]))}
+          style={{ marginTop: 16, marginLeft: 8 }}
         />
         {showAddForm && (
           <AddCourtCaseFormAntd
@@ -422,7 +479,19 @@ export default function CourtCasesPage() {
             loading={casesLoading}
             pagination={{ pageSize: 25, showSizeChanger: true }}
             size="middle"
-            expandable={{ expandRowByClick: true, defaultExpandAllRows: true, indentSize: 24 }}
+            expandable={{
+              expandRowByClick: true,
+              indentSize: 24,
+              expandedRowKeys,
+              onExpand: (expanded, record) => {
+                setExpandedRowKeys((prev) => {
+                  const set = new Set(prev);
+                  if (expanded) set.add(record.id);
+                  else set.delete(record.id);
+                  return Array.from(set);
+                });
+              },
+            }}
             rowClassName={(record) => (record.parent_id ? 'child-case-row' : 'main-case-row')}
           />
 
@@ -432,9 +501,6 @@ export default function CourtCasesPage() {
           <Typography.Text style={{ display: 'block', marginTop: 4 }}>
             Готовых дел к выгрузке: {readyToExport}
           </Typography.Text>
-          <div style={{ marginTop: 8 }}>
-            <ExportCourtCasesButton cases={filteredCases} stages={Object.fromEntries(stages.map((s) => [s.id, s.name]))} />
-          </div>
         </div>
       </>
     </ConfigProvider>


### PR DESCRIPTION
## Summary
- remember filters visibility and table expansion state on CourtCasesPage
- move Excel export icon near settings
- allow styling ExportCourtCasesButton

## Testing
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_684c4e3f5ce4832e91a05f5f2c4c1aee