### PR TITLE
Implement table column settings and filter toggles

### DIFF
--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -10,6 +10,10 @@ import {
   Button,
   Card,
   DatePicker,
+  Tooltip,
+  Space,
+  Popconfirm,
+  Tag,
 } from 'antd';
 import ruRU from 'antd/locale/ru_RU';
 import dayjs from 'dayjs';
@@ -20,6 +24,9 @@ import EditLetterDialog from '@/features/correspondence/EditLetterDialog';
 import ExportLettersButton from '@/features/correspondence/ExportLettersButton';
 import CorrespondenceTable from '@/widgets/CorrespondenceTable';
 import CorrespondenceFilters from '@/widgets/CorrespondenceFilters';
+import TableColumnsDrawer from '@/widgets/TableColumnsDrawer';
+import type { TableColumnSetting } from '@/shared/types/tableColumnSetting';
+import type { ColumnsType } from 'antd/es/table';
 import {
   useLetters,
   useAddLetter,
@@ -39,6 +46,15 @@ import { useNotify } from '@/shared/hooks/useNotify';
 import { useLetterStatuses } from '@/entities/letterStatus';
 import { useContractors } from '@/entities/contractor';
 import { usePersons } from '@/entities/person';
+import {
+  SettingOutlined,
+  EyeOutlined,
+  DeleteOutlined,
+  PlusOutlined,
+  MailOutlined,
+  BranchesOutlined,
+  LinkOutlined,
+} from '@ant-design/icons';
 
 interface Filters {
   period?: [dayjs.Dayjs, dayjs.Dayjs] | null;
@@ -103,6 +119,17 @@ export default function CorrespondencePage() {
   const [linkFor, setLinkFor] = useState<CorrespondenceLetter | null>(null);
   const [showAddForm, setShowAddForm] = useState(false);
   const hideOnScroll = useRef(false);
+  const LS_FILTERS_VISIBLE_KEY = 'correspondenceFiltersVisible';
+  const LS_COLUMNS_KEY = 'correspondenceColumns';
+  const [showFilters, setShowFilters] = useState(() => {
+    try {
+      const saved = localStorage.getItem(LS_FILTERS_VISIBLE_KEY);
+      return saved ? JSON.parse(saved) : true;
+    } catch {
+      return true;
+    }
+  });
+  const [showColumnsDrawer, setShowColumnsDrawer] = useState(false);
 
   React.useEffect(() => {
     const id = searchParams.get('letter_id');
@@ -240,6 +267,165 @@ export default function CorrespondencePage() {
     });
   };
 
+  const getBaseColumns = () => {
+    return {
+      treeIcon: {
+        title: '',
+        dataIndex: 'treeIcon',
+        width: 40,
+        render: (_: any, record: any) => {
+          if (!record.parent_id) {
+            return (
+              <Tooltip title="Главное письмо">
+                <MailOutlined style={{ color: '#1890ff', fontSize: 17 }} />
+              </Tooltip>
+            );
+          }
+          return (
+            <Tooltip title="Связанное письмо">
+              <BranchesOutlined style={{ color: '#52c41a', fontSize: 16 }} />
+            </Tooltip>
+          );
+        },
+      },
+      id: { title: 'ID', dataIndex: 'id', width: 80 },
+      type: {
+        title: 'Тип',
+        dataIndex: 'type',
+        width: 100,
+        sorter: (a: any, b: any) => a.type.localeCompare(b.type),
+        render: (v: string) => (
+          <Tag color={v === 'incoming' ? 'success' : 'processing'}>
+            {v === 'incoming' ? 'Входящее' : 'Исходящее'}
+          </Tag>
+        ),
+      },
+      number: {
+        title: 'Номер',
+        dataIndex: 'number',
+        width: 120,
+        sorter: (a: any, b: any) => a.number.localeCompare(b.number),
+        render: (num: string, record: any) => (
+          <b style={!record.parent_id ? { fontWeight: 600 } : {}}>{num}</b>
+        ),
+      },
+      date: {
+        title: 'Дата',
+        dataIndex: 'date',
+        width: 120,
+        sorter: (a: any, b: any) => dayjs(a.date).valueOf() - dayjs(b.date).valueOf(),
+        render: (v: string) => dayjs(v).format('DD.MM.YYYY'),
+      },
+      sender: {
+        title: 'Отправитель',
+        dataIndex: 'sender',
+        sorter: (a: any, b: any) => (a.sender || '').localeCompare(b.sender || ''),
+        render: (val: string, record: any) => (
+          <span style={record.parent_id ? { color: '#888' } : {}}>{val}</span>
+        ),
+      },
+      receiver: {
+        title: 'Получатель',
+        dataIndex: 'receiver',
+        sorter: (a: any, b: any) => (a.receiver || '').localeCompare(b.receiver || ''),
+        render: (val: string, record: any) => (
+          <span style={record.parent_id ? { color: '#888' } : {}}>{val}</span>
+        ),
+      },
+      subject: {
+        title: 'Тема',
+        dataIndex: 'subject',
+        sorter: (a: any, b: any) => a.subject.localeCompare(b.subject),
+        render: (val: string, record: any) => (
+          <span style={record.parent_id ? { color: '#888' } : {}}>{val}</span>
+        ),
+      },
+      projectName: {
+        title: 'Проект',
+        dataIndex: 'projectName',
+        sorter: (a: any, b: any) => (a.projectName || '').localeCompare(b.projectName || ''),
+      },
+      unitNames: {
+        title: 'Объекты',
+        dataIndex: 'unitNames',
+        sorter: (a: any, b: any) => (a.unitNames || '').localeCompare(b.unitNames || ''),
+      },
+      letterTypeName: {
+        title: 'Категория',
+        dataIndex: 'letterTypeName',
+        sorter: (a: any, b: any) => (a.letterTypeName || '').localeCompare(b.letterTypeName || ''),
+      },
+      statusName: {
+        title: 'Статус',
+        dataIndex: 'statusName',
+        sorter: (a: any, b: any) => (a.statusName || '').localeCompare(b.statusName || ''),
+        render: (_: any, row: any) => (
+          <LetterStatusSelect letterId={row.id} statusId={row.status_id} statusName={row.statusName} />
+        ),
+      },
+      responsibleName: {
+        title: 'Ответственный',
+        dataIndex: 'responsibleName',
+        sorter: (a: any, b: any) => (a.responsibleName || '').localeCompare(b.responsibleName || ''),
+        render: (name: string) => name || '—',
+      },
+      actions: {
+        title: 'Действия',
+        key: 'actions',
+        width: 130,
+        render: (_: any, record: CorrespondenceLetter) => (
+          <Space size="middle">
+            <Button type="text" icon={<EyeOutlined />} onClick={() => setView(record)} />
+            <Button type="text" icon={<PlusOutlined />} onClick={() => setLinkFor(record)} />
+            {record.parent_id && (
+              <Tooltip title="Исключить из связи">
+                <Button
+                  type="text"
+                  icon={<LinkOutlined style={{ color: '#c41d7f', textDecoration: 'line-through', fontWeight: 700 }} />}
+                  onClick={() => handleUnlink(record.id)}
+                />
+              </Tooltip>
+            )}
+            <Popconfirm title="Удалить письмо?" okText="Да" cancelText="Нет" onConfirm={() => handleDelete(record.id)}>
+              <Button type="text" danger icon={<DeleteOutlined />} />
+            </Popconfirm>
+          </Space>
+        ),
+      },
+    } as Record<string, ColumnsType<any>[number]>;
+  };
+
+  const [columnsState, setColumnsState] = useState<TableColumnSetting[]>(() => {
+    const base = getBaseColumns();
+    const defaults = Object.keys(base).map((key) => ({ key, title: base[key].title as string, visible: true }));
+    try {
+      const saved = localStorage.getItem(LS_COLUMNS_KEY);
+      if (saved) {
+        const parsed = JSON.parse(saved) as TableColumnSetting[];
+        return parsed.filter((c) => base[c.key]);
+      }
+    } catch {}
+    return defaults;
+  });
+
+  React.useEffect(() => {
+    try {
+      localStorage.setItem(LS_COLUMNS_KEY, JSON.stringify(columnsState));
+    } catch {}
+  }, [columnsState]);
+
+  React.useEffect(() => {
+    try {
+      localStorage.setItem(LS_FILTERS_VISIBLE_KEY, JSON.stringify(showFilters));
+    } catch {}
+  }, [showFilters]);
+
+  const baseColumns = React.useMemo(getBaseColumns, [remove.isPending]);
+  const columns: ColumnsType<any> = React.useMemo(
+    () => columnsState.filter((c) => c.visible).map((c) => baseColumns[c.key]),
+    [columnsState, baseColumns],
+  );
+
   /** ID статуса "Закрыто", определяется по названию */
   const closedStatusId = React.useMemo(
     () => statuses.find((s) => /закры/i.test(s.name))?.id ?? null,
@@ -307,10 +493,28 @@ export default function CorrespondencePage() {
         <Button
           type="primary"
           onClick={() => setShowAddForm((p) => !p)}
-          style={{ marginTop: 16 }}
+          style={{ marginTop: 16, marginRight: 8 }}
         >
           {showAddForm ? 'Скрыть форму' : 'Добавить письмо'}
         </Button>
+        <Button onClick={() => setShowFilters((p) => !p)} style={{ marginTop: 16 }}>
+          {showFilters ? 'Скрыть фильтры' : 'Показать фильтры'}
+        </Button>
+        <Button
+          icon={<SettingOutlined />}
+          style={{ marginTop: 16, marginLeft: 8 }}
+          onClick={() => setShowColumnsDrawer(true)}
+        />
+        <span style={{ marginTop: 16, marginLeft: 8, display: 'inline-block' }}>
+          <ExportLettersButton
+            letters={filtered}
+            users={users}
+            letterTypes={letterTypes}
+            projects={projects}
+            units={allUnits}
+            statuses={statuses}
+          />
+        </span>
         {showAddForm && (
           <div style={{ marginTop: 16 }}>
             <AddLetterForm onSubmit={handleAdd} initialValues={initialValues} />
@@ -332,6 +536,12 @@ export default function CorrespondencePage() {
             });
           }}
         />
+        <TableColumnsDrawer
+          open={showColumnsDrawer}
+          columns={columnsState}
+          onChange={setColumnsState}
+          onClose={() => setShowColumnsDrawer(false)}
+        />
 
         <div
           style={{ marginTop: 24 }}
@@ -342,21 +552,23 @@ export default function CorrespondencePage() {
             }
           }}
         >
-          <Card style={{ marginBottom: 24 }}>
-            <CorrespondenceFilters
-              form={form}
-              filters={filters}
-              onChange={handleFiltersChange}
-              users={users.map((u) => ({ value: u.id, label: u.name }))}
-              letterTypes={letterTypes.map((t) => ({ value: t.id, label: t.name }))}
-              projects={projects.map((p) => ({ value: p.id, label: p.name }))}
-              projectUnits={projectUnits.map((u) => ({ value: u.id, label: u.name }))}
-              contactOptions={contactOptions}
-              statuses={statuses.map((s) => ({ value: s.id, label: s.name }))}
-              idOptions={idOptions}
-              onReset={resetFilters}
-            />
-          </Card>
+          {showFilters && (
+            <Card style={{ marginBottom: 24 }}>
+              <CorrespondenceFilters
+                form={form}
+                filters={filters}
+                onChange={handleFiltersChange}
+                users={users.map((u) => ({ value: u.id, label: u.name }))}
+                letterTypes={letterTypes.map((t) => ({ value: t.id, label: t.name }))}
+                projects={projects.map((p) => ({ value: p.id, label: p.name }))}
+                projectUnits={projectUnits.map((u) => ({ value: u.id, label: u.name }))}
+                contactOptions={contactOptions}
+                statuses={statuses.map((s) => ({ value: s.id, label: s.name }))}
+                idOptions={idOptions}
+                onReset={resetFilters}
+              />
+            </Card>
+          )}
           <CorrespondenceTable
             letters={filtered}
             onView={setView}
@@ -368,6 +580,7 @@ export default function CorrespondencePage() {
             projects={projects}
             units={allUnits}
             statuses={statuses}
+            columns={columns}
           />
           <Typography.Text style={{ display: 'block', marginTop: 8 }}>
             Всего писем: {total}, из них закрытых: {closedCount} и не закрытых: {openCount}
@@ -375,16 +588,6 @@ export default function CorrespondencePage() {
           <Typography.Text style={{ display: 'block', marginTop: 4 }}>
             Готовых писем к выгрузке: {readyToExport}
           </Typography.Text>
-          <div style={{ marginTop: 8 }}>
-            <ExportLettersButton
-              letters={filtered}
-              users={users}
-              letterTypes={letterTypes}
-              projects={projects}
-              units={allUnits}
-              statuses={statuses}
-            />
-          </div>
         </div>
 
         <EditLetterDialog

--- a/src/pages/TicketsPage/TicketsPage.tsx
+++ b/src/pages/TicketsPage/TicketsPage.tsx
@@ -3,12 +3,24 @@
 // -----------------------------------------------------------------------------
 import React, { useState, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
-import { ConfigProvider, Typography, Alert, Card, Button } from "antd";
+import { ConfigProvider, Typography, Alert, Card, Button, message, Tooltip, Space, Popconfirm, Tag } from "antd";
+import {
+  SettingOutlined,
+  EyeOutlined,
+  DeleteOutlined,
+  PlusOutlined,
+  BranchesOutlined,
+  LinkOutlined,
+  FileTextOutlined,
+  CheckCircleTwoTone,
+  CloseCircleTwoTone,
+} from "@ant-design/icons";
+import dayjs from "dayjs";
 import ruRU from "antd/locale/ru_RU";
 import { useSnackbar } from "notistack";
 import { useQueryClient } from "@tanstack/react-query";
 
-import { useTickets, useLinkTickets, useUnlinkTicket } from "@/entities/ticket";
+import { useTickets, useLinkTickets, useUnlinkTicket, useDeleteTicket } from "@/entities/ticket";
 import { useUsers } from "@/entities/user";
 import { useUnitsByIds } from "@/entities/unit";
 import TicketsTable from "@/widgets/TicketsTable";
@@ -17,9 +29,17 @@ import TicketFormAntd from "@/features/ticket/TicketFormAntd";
 import TicketViewModal from "@/features/ticket/TicketViewModal";
 import LinkTicketsDialog from "@/features/ticket/LinkTicketsDialog";
 import ExportTicketsButton from "@/features/ticket/ExportTicketsButton";
+import TableColumnsDrawer from "@/widgets/TableColumnsDrawer";
+import type { TableColumnSetting } from "@/shared/types/tableColumnSetting";
+import type { ColumnsType } from "antd/es/table";
 import type { TicketWithNames } from "@/shared/types/ticketWithNames";
 import { useNotify } from "@/shared/hooks/useNotify";
 import { filterTickets } from "@/shared/utils/ticketFilter";
+
+const fmt = (d: any, withTime = false) =>
+  d && dayjs.isDayjs(d) && d.isValid()
+    ? d.format(withTime ? "DD.MM.YYYY HH:mm" : "DD.MM.YYYY")
+    : "—";
 
 export default function TicketsPage() {
   const { enqueueSnackbar } = useSnackbar();
@@ -41,6 +61,19 @@ export default function TicketsPage() {
   const [linkFor, setLinkFor] = useState<any | null>(null);
   const [showAddForm, setShowAddForm] = useState(false);
   const hideOnScroll = React.useRef(false);
+  const deleteTicketMutation = useDeleteTicket();
+
+  const LS_FILTERS_VISIBLE_KEY = 'ticketsFiltersVisible';
+  const LS_COLUMNS_KEY = 'ticketsColumns';
+  const [showFilters, setShowFilters] = useState(() => {
+    try {
+      const saved = localStorage.getItem(LS_FILTERS_VISIBLE_KEY);
+      return saved ? JSON.parse(saved) : true;
+    } catch {
+      return true;
+    }
+  });
+  const [showColumnsDrawer, setShowColumnsDrawer] = useState(false);
 
   React.useEffect(() => {
     const id = searchParams.get('ticket_id');
@@ -140,6 +173,207 @@ export default function TicketsPage() {
     );
   };
 
+  const getBaseColumns = () => {
+    return {
+      tree: {
+        title: '',
+        dataIndex: 'tree',
+        width: 40,
+        render: (_: any, record: any) => {
+          if (!record.parentId) {
+            return (
+              <Tooltip title="Основное замечание">
+                <FileTextOutlined style={{ color: '#1890ff', fontSize: 17 }} />
+              </Tooltip>
+            );
+          }
+          return (
+            <Tooltip title="Связанное замечание">
+              <BranchesOutlined style={{ color: '#52c41a', fontSize: 16 }} />
+            </Tooltip>
+          );
+        },
+      },
+      id: {
+        title: 'ID',
+        dataIndex: 'id',
+        width: 80,
+        sorter: (a: any, b: any) => a.id - b.id,
+      },
+      projectName: {
+        title: 'Проект',
+        dataIndex: 'projectName',
+        width: 180,
+        sorter: (a: any, b: any) => a.projectName.localeCompare(b.projectName),
+      },
+      unitNames: {
+        title: 'Объекты',
+        dataIndex: 'unitNames',
+        width: 160,
+        sorter: (a: any, b: any) => a.unitNames.localeCompare(b.unitNames),
+      },
+      isWarranty: {
+        title: 'Гарантия',
+        dataIndex: 'isWarranty',
+        width: 110,
+        sorter: (a: any, b: any) => Number(a.isWarranty) - Number(b.isWarranty),
+        render: (v: boolean) =>
+          v ? (
+            <Tag icon={<CheckCircleTwoTone twoToneColor="#52c41a" />} color="success">Да</Tag>
+          ) : (
+            <Tag icon={<CloseCircleTwoTone twoToneColor="#eb2f96" />} color="default">Нет</Tag>
+          ),
+      },
+      statusId: {
+        title: 'Статус',
+        dataIndex: 'statusId',
+        width: 160,
+        sorter: (a: any, b: any) => a.statusName.localeCompare(b.statusName),
+        render: (_: any, row: any) => (
+          <TicketStatusSelect
+            ticketId={row.id}
+            statusId={row.statusId}
+            statusColor={row.statusColor}
+            statusName={row.statusName}
+          />
+        ),
+      },
+      isClosed: {
+        title: 'Замечание закрыто',
+        dataIndex: 'isClosed',
+        width: 160,
+        sorter: (a: any, b: any) => Number(a.isClosed) - Number(b.isClosed),
+        render: (_: any, row: any) => <TicketClosedSelect ticketId={row.id} isClosed={row.isClosed} />,
+      },
+      typeName: {
+        title: 'Тип замечания',
+        dataIndex: 'typeName',
+        width: 160,
+        sorter: (a: any, b: any) => a.typeName.localeCompare(b.typeName),
+      },
+      days: {
+        title: 'Прошло дней с Даты получения',
+        dataIndex: 'days',
+        width: 120,
+        sorter: (a: any, b: any) => (a.days ?? -1) - (b.days ?? -1),
+      },
+      receivedAt: {
+        title: 'Дата получения',
+        dataIndex: 'receivedAt',
+        width: 140,
+        defaultSortOrder: 'descend' as const,
+        sorter: (a: any, b: any) =>
+          (a.receivedAt ? a.receivedAt.valueOf() : 0) - (b.receivedAt ? b.receivedAt.valueOf() : 0),
+        render: (v: any) => fmt(v),
+      },
+      fixedAt: {
+        title: 'Дата устранения',
+        dataIndex: 'fixedAt',
+        width: 140,
+        sorter: (a: any, b: any) =>
+          (a.fixedAt ? a.fixedAt.valueOf() : 0) - (b.fixedAt ? b.fixedAt.valueOf() : 0),
+        render: (v: any) => fmt(v),
+      },
+      customerRequestNo: {
+        title: '№ заявки от Заказчика',
+        dataIndex: 'customerRequestNo',
+        width: 160,
+        sorter: (a: any, b: any) => (a.customerRequestNo || '').localeCompare(b.customerRequestNo || ''),
+      },
+      customerRequestDate: {
+        title: 'Дата заявки Заказчика',
+        dataIndex: 'customerRequestDate',
+        width: 160,
+        sorter: (a: any, b: any) =>
+          (a.customerRequestDate ? a.customerRequestDate.valueOf() : 0) -
+          (b.customerRequestDate ? b.customerRequestDate.valueOf() : 0),
+        render: (v: any) => fmt(v),
+      },
+      responsibleEngineerName: {
+        title: 'Ответственный инженер',
+        dataIndex: 'responsibleEngineerName',
+        width: 180,
+        sorter: (a: any, b: any) =>
+          (a.responsibleEngineerName || '').localeCompare(b.responsibleEngineerName || ''),
+      },
+      actions: {
+        title: 'Действия',
+        key: 'actions',
+        width: 100,
+        render: (_: any, record: any) => (
+          <Space size="middle">
+            <Tooltip title="Просмотр">
+              <Button
+                size="small"
+                type="text"
+                icon={<EyeOutlined />}
+                onClick={() => setViewId(record.id)}
+              />
+            </Tooltip>
+            <Button size="small" type="text" icon={<PlusOutlined />} onClick={() => setLinkFor(record)} />
+            {record.parentId && (
+              <Tooltip title="Исключить из связи">
+                <Button
+                  size="small"
+                  type="text"
+                  icon={<LinkOutlined style={{ color: '#c41d7f', textDecoration: 'line-through', fontWeight: 700 }} />}
+                  onClick={() => handleUnlink(record.id)}
+                />
+              </Tooltip>
+            )}
+            <Popconfirm
+              title="Удалить замечание?"
+              okText="Да"
+              cancelText="Нет"
+              onConfirm={async () => {
+                await deleteTicketMutation.mutateAsync(record.id);
+                message.success('Удалено');
+              }}
+              disabled={deleteTicketMutation.isPending}
+            >
+              <Button size="small" type="text" danger icon={<DeleteOutlined />} loading={deleteTicketMutation.isPending} />
+            </Popconfirm>
+          </Space>
+        ),
+      },
+    } as Record<string, ColumnsType<any>[number]>;
+  };
+
+  const [columnsState, setColumnsState] = useState<TableColumnSetting[]>(() => {
+    const base = getBaseColumns();
+    const defaults = Object.keys(base).map((key) => ({
+      key,
+      title: base[key].title as string,
+      visible: true,
+    }));
+    try {
+      const saved = localStorage.getItem(LS_COLUMNS_KEY);
+      if (saved) {
+        const parsed = JSON.parse(saved) as TableColumnSetting[];
+        return parsed.filter((c) => base[c.key]);
+      }
+    } catch {}
+    return defaults;
+  });
+
+  React.useEffect(() => {
+    try {
+      localStorage.setItem(LS_COLUMNS_KEY, JSON.stringify(columnsState));
+    } catch {}
+  }, [columnsState]);
+
+  React.useEffect(() => {
+    try {
+      localStorage.setItem(LS_FILTERS_VISIBLE_KEY, JSON.stringify(showFilters));
+    } catch {}
+  }, [showFilters]);
+
+  const baseColumns = React.useMemo(getBaseColumns, [deleteTicketMutation.isPending]);
+  const columns: ColumnsType<any> = React.useMemo(
+    () => columnsState.filter((c) => c.visible).map((c) => baseColumns[c.key]),
+    [columnsState, baseColumns],
+  );
+
   const total = tickets.length;
   const closedCount = useMemo(() => tickets.filter((t) => t.isClosed).length, [tickets]);
   const openCount = total - closedCount;
@@ -155,10 +389,21 @@ export default function TicketsPage() {
         <Button
           type="primary"
           onClick={() => setShowAddForm((p) => !p)}
-          style={{ marginBottom: 16 }}
+          style={{ marginBottom: 16, marginRight: 8 }}
         >
           {showAddForm ? 'Скрыть форму' : 'Добавить замечание'}
         </Button>
+        <Button onClick={() => setShowFilters((p) => !p)} style={{ marginBottom: 16 }}>
+          {showFilters ? 'Скрыть фильтры' : 'Показать фильтры'}
+        </Button>
+        <Button
+          icon={<SettingOutlined />}
+          style={{ marginBottom: 16, marginLeft: 8 }}
+          onClick={() => setShowColumnsDrawer(true)}
+        />
+        <span style={{ marginBottom: 16, marginLeft: 8, display: 'inline-block' }}>
+          <ExportTicketsButton tickets={ticketsWithNames} filters={filters} />
+        </span>
         {showAddForm && (
           <Card style={{ marginBottom: 24 }}>
             <TicketFormAntd
@@ -178,6 +423,12 @@ export default function TicketsPage() {
           onClose={() => setLinkFor(null)}
           onSubmit={handleLink}
         />
+        <TableColumnsDrawer
+          open={showColumnsDrawer}
+          columns={columnsState}
+          onChange={setColumnsState}
+          onClose={() => setShowColumnsDrawer(false)}
+        />
         <div
           onWheel={() => {
             if (hideOnScroll.current) {
@@ -186,13 +437,15 @@ export default function TicketsPage() {
             }
           }}
         >
-          <Card style={{ marginBottom: 24 }}>
-            <TicketsFilters
-              options={options}
-              onChange={setFilters}
-              initialValues={initialFilters}
-            />
-          </Card>
+          {showFilters && (
+            <Card style={{ marginBottom: 24 }}>
+              <TicketsFilters
+                options={options}
+                onChange={setFilters}
+                initialValues={initialFilters}
+              />
+            </Card>
+          )}
 
           <Card>
             {error ? (
@@ -202,6 +455,7 @@ export default function TicketsPage() {
                 tickets={ticketsWithNames}
                 filters={filters}
                 loading={isLoading}
+                columns={columns}
                 onView={(id) => setViewId(id)}
                 onAddChild={setLinkFor}
                 onUnlink={handleUnlink}
@@ -214,9 +468,6 @@ export default function TicketsPage() {
           <Typography.Text style={{ display: 'block', marginTop: 4 }}>
             Готовых замечаний к выгрузке: {readyToExport}
           </Typography.Text>
-          <div style={{ marginTop: 8 }}>
-            <ExportTicketsButton tickets={ticketsWithNames} filters={filters} />
-          </div>
         </div>
         <TicketViewModal
           open={viewId !== null}

--- a/src/widgets/CorrespondenceTable.tsx
+++ b/src/widgets/CorrespondenceTable.tsx
@@ -14,6 +14,8 @@ interface CorrespondenceTableProps {
   onDelete: (id: string) => void;
   onAddChild: (parent: CorrespondenceLetter) => void;
   onUnlink: (letterId: string) => void; // <--- новый проп
+  /** Колонки таблицы. Если не переданы, используется набор по умолчанию */
+  columns?: ColumnsType<any>;
   users: Option[];
   letterTypes: Option[];
   projects: Option[];
@@ -31,6 +33,7 @@ export default function CorrespondenceTable({
                                               onDelete,
                                               onAddChild,
                                               onUnlink,
+                                              columns: columnsProp,
                                               users,
                                               letterTypes,
                                               projects,
@@ -115,7 +118,8 @@ export default function CorrespondenceTable({
     } catch {}
   }, [expandedRowKeys]);
 
-  const columns: ColumnsType<any> = [
+  const defaultColumns: ColumnsType<any> = React.useMemo(
+    () => [
     {
       title: '',
       dataIndex: 'treeIcon',
@@ -269,7 +273,11 @@ export default function CorrespondenceTable({
           </Space>
       ),
     },
-  ];
+  ],
+    [onView, onAddChild, onUnlink, onDelete],
+  );
+
+  const columns = columnsProp ?? defaultColumns;
 
   const rowClassName = (record: any) => {
     if (!record.parent_id) return 'main-letter-row';

--- a/src/widgets/TicketsTable.tsx
+++ b/src/widgets/TicketsTable.tsx
@@ -56,6 +56,8 @@ interface Props {
   tickets: TicketWithNames[];
   filters: TicketFilters;
   loading?: boolean;
+  /** Колонки таблицы. Если не переданы, используется набор по умолчанию */
+  columns?: ColumnsType<any>;
   onView?: (id: number) => void;
   onAddChild?: (ticket: TicketWithNames) => void;
   onUnlink?: (id: number) => void;
@@ -68,13 +70,14 @@ export default function TicketsTable({
   tickets,
   filters,
   loading,
+  columns: columnsProp,
   onView,
   onAddChild,
   onUnlink,
 }: Props) {
   const { mutateAsync: remove, isPending } = useDeleteTicket();
 
-  const columns: ColumnsType<any> = useMemo(
+  const defaultColumns: ColumnsType<any> = useMemo(
     () => [
       {
         title: '',
@@ -253,8 +256,10 @@ export default function TicketsTable({
       },
     ],
 
-    [onView, remove, isPending],
+    [onView, remove, isPending, onAddChild, onUnlink],
   );
+
+  const columns = columnsProp ?? defaultColumns;
 
   const filtered = useMemo(
     () => filterTickets(tickets, filters),


### PR DESCRIPTION
## Summary
- add optional `columns` prop to table widgets
- support column customization and filter toggle on Tickets and Correspondence pages
- move Excel export buttons to page headers

## Testing
- `npm run lint` *(fails: Parsing error: The keyword 'interface' is reserved)*

------
https://chatgpt.com/codex/tasks/task_e_684c51d4c254832ea1cefe14c5f52a56