### PR TITLE
Add columns reset button in table settings

### DIFF
--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -415,6 +415,19 @@ export default function CorrespondencePage() {
     return defaults;
   });
 
+  /**
+   * Сброс колонок к начальному состоянию
+   */
+  const handleResetColumns = () => {
+    const base = getBaseColumns();
+    const defaults = Object.keys(base).map((key) => ({
+      key,
+      title: base[key].title as string,
+      visible: true,
+    }));
+    setColumnsState(defaults);
+  };
+
   React.useEffect(() => {
     try {
       localStorage.setItem(LS_COLUMNS_KEY, JSON.stringify(columnsState));
@@ -548,6 +561,7 @@ export default function CorrespondencePage() {
           columns={columnsState}
           onChange={setColumnsState}
           onClose={() => setShowColumnsDrawer(false)}
+          onReset={handleResetColumns}
         />
 
         <div

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -354,6 +354,18 @@ export default function CourtCasesPage() {
     return defaults;
   });
 
+  /**
+   * Сброс колонок к начальному состоянию
+   */
+  const handleResetColumns = () => {
+    const defaults = Object.keys(baseColumns).map((key) => ({
+      key,
+      title: baseColumns[key].title as string,
+      visible: true,
+    }));
+    setColumnsState(defaults);
+  };
+
   useEffect(() => {
     try {
       localStorage.setItem(LS_COLUMNS_KEY, JSON.stringify(columnsState));
@@ -415,6 +427,7 @@ export default function CourtCasesPage() {
           columns={columnsState}
           onChange={setColumnsState}
           onClose={() => setShowColumnsDrawer(false)}
+          onReset={handleResetColumns}
         />
         <div
           style={{ marginTop: 24 }}

--- a/src/pages/TicketsPage/TicketsPage.tsx
+++ b/src/pages/TicketsPage/TicketsPage.tsx
@@ -370,6 +370,19 @@ export default function TicketsPage() {
     return defaults;
   });
 
+  /**
+   * Сброс колонок к начальному состоянию
+   */
+  const handleResetColumns = () => {
+    const base = getBaseColumns();
+    const defaults = Object.keys(base).map((key) => ({
+      key,
+      title: base[key].title as string,
+      visible: true,
+    }));
+    setColumnsState(defaults);
+  };
+
   React.useEffect(() => {
     try {
       localStorage.setItem(LS_COLUMNS_KEY, JSON.stringify(columnsState));
@@ -441,6 +454,7 @@ export default function TicketsPage() {
           columns={columnsState}
           onChange={setColumnsState}
           onClose={() => setShowColumnsDrawer(false)}
+          onReset={handleResetColumns}
         />
         <div
           onWheel={() => {

--- a/src/widgets/TableColumnsDrawer.tsx
+++ b/src/widgets/TableColumnsDrawer.tsx
@@ -8,12 +8,14 @@ interface Props {
   columns: TableColumnSetting[];
   onChange: (cols: TableColumnSetting[]) => void;
   onClose: () => void;
+  /** Сбросить состояние столбцов к изначальному */
+  onReset?: () => void;
 }
 
 /**
  * Боковая панель настройки столбцов таблицы.
  */
-export default function TableColumnsDrawer({ open, columns, onChange, onClose }: Props) {
+export default function TableColumnsDrawer({ open, columns, onChange, onClose, onReset }: Props) {
   const move = (from: number, to: number) => {
     if (to < 0 || to >= columns.length) return;
     const updated = [...columns];
@@ -50,6 +52,11 @@ export default function TableColumnsDrawer({ open, columns, onChange, onClose }:
           />
         </div>
       ))}
+      {onReset && (
+        <Button style={{ marginTop: 16 }} block onClick={onReset}>
+          По умолчанию
+        </Button>
+      )}
     </Drawer>
   );
 }


### PR DESCRIPTION
## Summary
- extend `TableColumnsDrawer` with optional `onReset` prop and reset button
- enable column reset in Tickets, Court Cases and Correspondence pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c58c0b524832e91e4d7f98a6953ea