### PR TITLE
Fix default row state in court cases page

### DIFF
--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -460,7 +460,7 @@ export default function CourtCasesPage() {
             loading={casesLoading}
             pagination={{ pageSize: 25, showSizeChanger: true }}
             size="middle"
-            expandable={{ expandRowByClick: true, defaultExpandAllRows: true, indentSize: 24 }}
+            expandable={{ expandRowByClick: true, defaultExpandAllRows: false, indentSize: 24 }}
             rowClassName={(record) => (record.parent_id ? 'child-case-row' : 'main-case-row')}
           />
 


### PR DESCRIPTION
## Summary
- keep expand control collapsed on court cases table

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c5c28ba84832e92b12162dbbe3cde