### PR TITLE
Fix TicketForm missing hook import

### DIFF
--- a/src/features/ticket/TicketForm.tsx
+++ b/src/features/ticket/TicketForm.tsx
@@ -29,6 +29,7 @@ import { useCreateTicket, useTicket, signedUrl } from "@/entities/ticket";
 import { useProjectId } from "@/shared/hooks/useProjectId";
 import { useUnsavedChangesWarning } from "@/shared/hooks/useUnsavedChangesWarning";
 import { useNotify } from "@/shared/hooks/useNotify";
+import { useTicketAttachments } from "./model/useTicketAttachments";
 import AttachmentEditorTable from "@/shared/ui/AttachmentEditorTable";
 import type { Ticket } from "@/entities/ticket";
 


### PR DESCRIPTION
## Summary
- import `useTicketAttachments` in `TicketForm`

## Testing
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_684c639b92f0832e8049cec7573247b0