### PR TITLE
Fix ticket view modal header

### DIFF
--- a/src/features/ticket/TicketViewModal.tsx
+++ b/src/features/ticket/TicketViewModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Modal } from 'antd';
+import { Modal, Skeleton } from 'antd';
+import { useTicket } from '@/entities/ticket';
 import TicketForm from './TicketForm';
 
 interface Props {
@@ -10,9 +11,20 @@ interface Props {
 
 export default function TicketViewModal({ open, ticketId, onClose }: Props) {
   if (!ticketId) return null;
+  const { data: ticket } = useTicket(ticketId);
+  const title = ticket
+    ? `Замечание (ID ${ticket.id}). Создано ${
+        ticket.createdAt ? ticket.createdAt.format('DD.MM.YYYY [в] HH:mm') : ''
+      }`
+    : 'Замечание';
+
   return (
-    <Modal open={open} onCancel={onClose} footer={null} width="80%">
-      <TicketForm embedded ticketId={String(ticketId)} onCancel={onClose} onCreated={onClose} />
+    <Modal open={open} onCancel={onClose} footer={null} width="80%" title={title}>
+      {ticket ? (
+        <TicketForm embedded ticketId={String(ticketId)} onCancel={onClose} onCreated={onClose} />
+      ) : (
+        <Skeleton active />
+      )}
     </Modal>
   );
 }


### PR DESCRIPTION
## Summary
- show ticket info in ticket view modal header

## Testing
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_684c6d893ffc832e937cb88ee5a2381c