### PR TITLE
Fix ticket view modal header

### DIFF
--- a/src/features/ticket/TicketViewModal.tsx
+++ b/src/features/ticket/TicketViewModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Modal } from 'antd';
+import { Modal, Skeleton, Typography } from 'antd';
+import { useTicket } from '@/entities/ticket';
 import TicketForm from './TicketForm';
 
 interface Props {
@@ -8,11 +9,29 @@ interface Props {
   onClose: () => void;
 }
 
+/** Модальное окно просмотра замечания */
 export default function TicketViewModal({ open, ticketId, onClose }: Props) {
   if (!ticketId) return null;
+  const { data: ticket } = useTicket(ticketId);
+  const titleText = ticket
+    ? `Замечание №${ticket.id}. Создано ${
+        ticket.createdAt ? ticket.createdAt.format('DD.MM.YYYY [в] HH:mm') : ''
+      }`
+    : 'Замечание';
+
   return (
-    <Modal open={open} onCancel={onClose} footer={null} width="80%">
-      <TicketForm embedded ticketId={String(ticketId)} onCancel={onClose} onCreated={onClose} />
+    <Modal
+      open={open}
+      onCancel={onClose}
+      footer={null}
+      width="80%"
+      title={<Typography.Title level={4} style={{ margin: 0 }}>{titleText}</Typography.Title>}
+    >
+      {ticket ? (
+        <TicketForm embedded ticketId={String(ticketId)} onCancel={onClose} onCreated={onClose} />
+      ) : (
+        <Skeleton active />
+      )}
     </Modal>
   );
 }


### PR DESCRIPTION
## Summary
- show ID and creation date in ticket view modal header
- emphasize ticket modal title

## Testing
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_684c6d893ffc832e937cb88ee5a2381c