### PR TITLE
Switch edit ticket form to AntD

### DIFF
--- a/src/features/ticket/TicketViewModal.tsx
+++ b/src/features/ticket/TicketViewModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Modal, Skeleton, Typography } from 'antd';
 import { useTicket } from '@/entities/ticket';
-import TicketForm from './TicketForm';
+import TicketFormAntdEdit from './TicketFormAntdEdit';
 
 interface Props {
   open: boolean;
@@ -28,7 +28,12 @@ export default function TicketViewModal({ open, ticketId, onClose }: Props) {
       title={<Typography.Title level={4} style={{ margin: 0 }}>{titleText}</Typography.Title>}
     >
       {ticket ? (
-        <TicketForm embedded ticketId={String(ticketId)} onCancel={onClose} onCreated={onClose} />
+        <TicketFormAntdEdit
+          embedded
+          ticketId={String(ticketId)}
+          onCancel={onClose}
+          onCreated={onClose}
+        />
       ) : (
         <Skeleton active />
       )}

--- a/src/pages/TicketsPage/TicketFormPage.tsx
+++ b/src/pages/TicketsPage/TicketFormPage.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { Box, Paper, Typography, Alert } from "@mui/material";
 import { useParams } from "react-router-dom";
 
-import TicketForm from "@/features/ticket/TicketForm";
+import TicketFormAntdEdit from "@/features/ticket/TicketFormAntdEdit";
 import { useProjectId } from "@/shared/hooks/useProjectId";
 
 export default function TicketFormPage() {
@@ -44,7 +44,7 @@ export default function TicketFormPage() {
         </Box>
         {/* --- форма --- */}
         <Box sx={{ p: { xs: 3, md: 5 } }}>
-          <TicketForm
+          <TicketFormAntdEdit
             key={`${projectId ?? "none"}-${ticketId ?? "new"}`}
             ticketId={ticketId}
             onCreated={() => {}}


### PR DESCRIPTION
## Summary
- implement `TicketFormAntdEdit` component with Ant Design
- use `TicketFormAntdEdit` in view modal and form page

## Testing
- `npm run lint` *(fails: Parsing errors due to missing TypeScript ESLint packages)*

------
https://chatgpt.com/codex/tasks/task_e_684c7353bd78832eae70dc3eee919227