### PR TITLE
Fix import typo for ticket statuses

### DIFF
--- a/src/features/ticket/TicketFormAntdEdit.tsx
+++ b/src/features/ticket/TicketFormAntdEdit.tsx
@@ -11,10 +11,8 @@ import {
   Col,
   Skeleton,
 } from 'antd';
-import {
-  useTicketTypes,
-  useTicketStatuses,
-} from '@/entities/ticketType';
+import { useTicketTypes } from '@/entities/ticketType';
+import { useTicketStatuses } from '@/entities/ticketStatus';
 import { useUnitsByProject } from '@/entities/unit';
 import { useUsers } from '@/entities/user';
 import { useProjects } from '@/entities/project';


### PR DESCRIPTION
## Summary
- fix wrong import path in `TicketFormAntdEdit.tsx`

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ce1f23724832e927f4fb88e7e203b