### PR TITLE
Fix duplicate attachments on ticket view

### DIFF
--- a/src/features/ticket/TicketFormAntdEdit.tsx
+++ b/src/features/ticket/TicketFormAntdEdit.tsx
@@ -119,7 +119,6 @@ export default function TicketFormAntdEdit({
         title: ticket.title,
         description: ticket.description ?? undefined,
       });
-      appendRemote(ticket.attachments || []);
       setFormTouched(false);
     } else {
       form.setFieldsValue({
@@ -130,7 +129,7 @@ export default function TicketFormAntdEdit({
       });
       setFormTouched(false);
     }
-  }, [ticket, form, globalProjectId, profileId, initialUnitId, appendRemote]);
+  }, [ticket, form, globalProjectId, profileId, initialUnitId]);
 
   const handleFiles = (files: File[]) => addFiles(files);
   const handleValuesChange = () => setFormTouched(true);


### PR DESCRIPTION
## Summary
- avoid appending attachments twice in ticket edit form

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ce5814e28832ea2ab546c6deda7a3