### PR TITLE
Fix duplicate attachments on ticket view

### DIFF
--- a/src/features/ticket/TicketForm.tsx
+++ b/src/features/ticket/TicketForm.tsx
@@ -182,9 +182,9 @@ export default function TicketForm({
   const handleDownloadArchive = async () => {
     const files = [
       ...remoteFiles.map((f) => ({
-        name: f.name,
+        name: f.original_name ?? f.name,
         getFile: async () => {
-          const url = await signedUrl(f.path, f.name);
+          const url = await signedUrl(f.path, f.original_name ?? f.name);
           const res = await fetch(url);
           return res.blob();
         },
@@ -243,21 +243,22 @@ export default function TicketForm({
           type_id: type,
         })),
       });
-      if (uploaded?.length) {
-        appendRemote(
-          uploaded.map((u) => ({
-            id: u.id,
-            name:
-              u.original_name ||
-              u.storage_path.split("/").pop() ||
-              "file",
-            path: u.storage_path,
-            url: u.file_url,
-            type: u.file_type,
-            attachment_type_id: u.attachment_type_id ?? null,
-          }))
-        );
-      }
+        if (uploaded?.length) {
+          appendRemote(
+            uploaded.map((u) => ({
+              id: u.id,
+              name:
+                u.original_name ||
+                u.storage_path.split("/").pop() ||
+                "file",
+              original_name: u.original_name ?? null,
+              path: u.storage_path,
+              url: u.file_url,
+              type: u.file_type,
+              attachment_type_id: u.attachment_type_id ?? null,
+            }))
+          );
+        }
       markPersisted();
       onCreated?.();
     } else {
@@ -617,7 +618,7 @@ export default function TicketForm({
           <AttachmentEditorTable
             remoteFiles={remoteFiles.map((f) => ({
               id: String(f.id),
-              name: f.name,
+              name: f.original_name ?? f.name,
               path: f.path,
               typeId: changedTypes[f.id] ?? f.attachment_type_id,
               typeName: f.attachment_type_name,

--- a/src/features/ticket/TicketFormAntdEdit.tsx
+++ b/src/features/ticket/TicketFormAntdEdit.tsx
@@ -119,7 +119,6 @@ export default function TicketFormAntdEdit({
         title: ticket.title,
         description: ticket.description ?? undefined,
       });
-      appendRemote(ticket.attachments || []);
       setFormTouched(false);
     } else {
       form.setFieldsValue({
@@ -130,7 +129,7 @@ export default function TicketFormAntdEdit({
       });
       setFormTouched(false);
     }
-  }, [ticket, form, globalProjectId, profileId, initialUnitId, appendRemote]);
+  }, [ticket, form, globalProjectId, profileId, initialUnitId]);
 
   const handleFiles = (files: File[]) => addFiles(files);
   const handleValuesChange = () => setFormTouched(true);
@@ -138,9 +137,9 @@ export default function TicketFormAntdEdit({
   const handleDownloadArchive = async () => {
     const files = [
       ...remoteFiles.map((f) => ({
-        name: f.name,
+        name: f.original_name ?? f.name,
         getFile: async () => {
-          const url = await signedUrl(f.path, f.name);
+          const url = await signedUrl(f.path, f.original_name ?? f.name);
           const res = await fetch(url);
           return res.blob();
         },
@@ -197,6 +196,7 @@ export default function TicketFormAntdEdit({
             uploaded.map((u: any) => ({
               id: u.id,
               name: u.original_name || u.storage_path.split('/').pop() || 'file',
+              original_name: u.original_name ?? null,
               path: u.storage_path,
               url: u.file_url,
               type: u.file_type,
@@ -355,7 +355,7 @@ export default function TicketFormAntdEdit({
         <AttachmentEditorTable
           remoteFiles={remoteFiles.map((f) => ({
             id: String(f.id),
-            name: f.name,
+            name: f.original_name ?? f.name,
             path: f.path,
             typeId: changedTypes[f.id] ?? f.attachment_type_id,
             typeName: f.attachment_type_name,

--- a/src/features/ticket/model/useTicketAttachments.ts
+++ b/src/features/ticket/model/useTicketAttachments.ts
@@ -25,13 +25,15 @@ export function useTicketAttachments(options: {
       const storagePath = 'storage_path' in file ? (file as any).storage_path : (file as any).path;
       const fileUrl = (file as any).file_url ?? (file as any).url ?? '';
       const fileType = (file as any).file_type ?? (file as any).type ?? '';
+      const originalName = (file as any).original_name ?? null;
       const name =
-        (file as any).original_name ||
+        originalName ||
         (storagePath ? storagePath.split('/').pop() : (file as any).name) ||
         'file';
       return {
         id: (file as any).id,
         name,
+        original_name: originalName,
         path: storagePath ?? '',
         url: fileUrl,
         type: fileType,

--- a/src/shared/types/ticketFile.ts
+++ b/src/shared/types/ticketFile.ts
@@ -2,6 +2,7 @@
 export interface RemoteTicketFile {
   id: string | number;
   name: string;
+  original_name?: string | null;
   path: string;
   url: string;
   type: string;


### PR DESCRIPTION
## Summary
- avoid appending attachments twice in ticket edit form
- show and download files using `original_name`

## Testing
- `npm run lint` *(fails: Parsing errors)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ce5814e28832ea2ab546c6deda7a3