### PR TITLE
Fix attachment names and download

### DIFF
--- a/src/entities/ticket.js
+++ b/src/entities/ticket.js
@@ -135,6 +135,7 @@ function mapTicket(r) {
     return {
       id: a.id,
       path: a.storage_path,
+      original_name: a.original_name ?? null,
       name,
       url: a.file_url,
       type: a.file_type,

--- a/src/features/ticket/TicketFormAntdEdit.tsx
+++ b/src/features/ticket/TicketFormAntdEdit.tsx
@@ -367,6 +367,7 @@ export default function TicketFormAntdEdit({
           onRemoveNew={removeNew}
           onChangeRemoteType={changeRemoteType}
           onChangeNewType={changeNewType}
+          getSignedUrl={(path, name) => signedUrl(path, name)}
         />
       </Form.Item>
       <Form.Item style={{ textAlign: 'right' }}>

--- a/src/features/ticket/model/useTicketAttachments.ts
+++ b/src/features/ticket/model/useTicketAttachments.ts
@@ -38,7 +38,7 @@ export function useTicketAttachments(options: {
         url: fileUrl,
         type: fileType,
         attachment_type_id: file.attachment_type_id ?? null,
-        attachment_type_name: typeObj?.name || fileType || '—',
+        attachment_type_name: typeObj?.name || fileType || '',
       } as RemoteTicketFile;
     });
     setRemoteFiles(attachmentsWithType);


### PR DESCRIPTION
## Summary
- include `original_name` when mapping ticket attachments
- adjust attachments hook to show empty type when undefined
- enable signed download in ticket view

## Testing
- `npm run lint` *(fails: many parsing errors)*
- `npm test` *(fails: missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684cec5c0944832ebcc3d73261dca234