### PR TITLE
Fix Attachment type select styles

### DIFF
--- a/src/shared/ui/AttachmentEditorList.tsx
+++ b/src/shared/ui/AttachmentEditorList.tsx
@@ -96,14 +96,14 @@ export default function AttachmentEditorList({
             displayEmpty
             sx={{ mr: 1, minWidth: 120 }}
           >
-            <MenuItem value="">
-              <em>Тип не указан</em>
+          <MenuItem value="" sx={{ textDecoration: 'none' }}>
+            <em>Тип не указан</em>
+          </MenuItem>
+          {attachmentTypes.map((t) => (
+            <MenuItem key={t.id} value={t.id} sx={{ textDecoration: 'none' }}>
+              {t.name}
             </MenuItem>
-            {attachmentTypes.map((t) => (
-              <MenuItem key={t.id} value={t.id}>
-                {t.name}
-              </MenuItem>
-            ))}
+          ))}
           </Select>
           <Tooltip title="Скачать">
             <IconButton onClick={() => forceDownload(f)}>
@@ -138,14 +138,14 @@ export default function AttachmentEditorList({
             displayEmpty
             sx={{ mr: 1, minWidth: 120 }}
           >
-            <MenuItem value="">
-              <em>Тип не указан</em>
+          <MenuItem value="" sx={{ textDecoration: 'none' }}>
+            <em>Тип не указан</em>
+          </MenuItem>
+          {attachmentTypes.map((t) => (
+            <MenuItem key={t.id} value={t.id} sx={{ textDecoration: 'none' }}>
+              {t.name}
             </MenuItem>
-            {attachmentTypes.map((t) => (
-              <MenuItem key={t.id} value={t.id}>
-                {t.name}
-              </MenuItem>
-            ))}
+          ))}
           </Select>
           <Tooltip title="Скачать">
             <IconButton component="a" href={objUrls[i]} download={f.file.name}>

--- a/src/shared/ui/AttachmentEditorTable.tsx
+++ b/src/shared/ui/AttachmentEditorTable.tsx
@@ -112,21 +112,25 @@ export default function AttachmentEditorTable({
                 displayEmpty
                 sx={{ minWidth: 120 }}
               >
-                <MenuItem value="">
+                <MenuItem value="" sx={{ textDecoration: 'none' }}>
                   <em>Тип не указан</em>
                 </MenuItem>
                 {attachmentTypes.map((t) => (
-                  <MenuItem key={t.id} value={t.id}>
+                  <MenuItem key={t.id} value={t.id} sx={{ textDecoration: 'none' }}>
                     {t.name}
                   </MenuItem>
                 ))}
               </Select>
               {!onChangeRemoteType && (
                 f.typeName ? (
-                  <span style={{ marginLeft: 8, fontSize: '0.8em' }}>{f.typeName}</span>
+                  <span style={{ marginLeft: 8, fontSize: '0.8em', textDecoration: 'none' }}>
+                    {f.typeName}
+                  </span>
                 ) : (
                   f.mime && (
-                    <span style={{ marginLeft: 8, fontSize: '0.8em' }}>{f.mime}</span>
+                    <span style={{ marginLeft: 8, fontSize: '0.8em', textDecoration: 'none' }}>
+                      {f.mime}
+                    </span>
                   )
                 )
               )}
@@ -164,18 +168,20 @@ export default function AttachmentEditorTable({
                 displayEmpty
                 sx={{ minWidth: 120 }}
               >
-                <MenuItem value="">
+                <MenuItem value="" sx={{ textDecoration: 'none' }}>
                   <em>Тип не указан</em>
                 </MenuItem>
                 {attachmentTypes.map((t) => (
-                  <MenuItem key={t.id} value={t.id}>
+                  <MenuItem key={t.id} value={t.id} sx={{ textDecoration: 'none' }}>
                     {t.name}
                   </MenuItem>
                 ))}
               </Select>
               {!onChangeNewType &&
                 f.mime && (
-                  <span style={{ marginLeft: 8, fontSize: '0.8em' }}>{f.mime}</span>
+                  <span style={{ marginLeft: 8, fontSize: '0.8em', textDecoration: 'none' }}>
+                    {f.mime}
+                  </span>
                 )}
             </TableCell>
             <TableCell align="right">


### PR DESCRIPTION
## Summary
- remove strikethrough style from attachment type MenuItem components

## Testing
- `npm run lint` *(fails: missing eslint dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684cf2dae964832eae945141269dd85e