### PR TITLE
Fix file type select style

### DIFF
--- a/src/shared/ui/AttachmentEditorTable.tsx
+++ b/src/shared/ui/AttachmentEditorTable.tsx
@@ -9,6 +9,7 @@ import {
   Tooltip,
   Select,
   MenuItem,
+  OutlinedInput,
 } from '@mui/material';
 import FileIcon from '@mui/icons-material/InsertDriveFileOutlined';
 import DeleteIcon from '@mui/icons-material/DeleteOutline';
@@ -110,6 +111,7 @@ export default function AttachmentEditorTable({
                   )
                 }
                 displayEmpty
+                input={<OutlinedInput notched={false} />}
                 sx={{ minWidth: 120 }}
               >
                 <MenuItem value="">
@@ -162,6 +164,7 @@ export default function AttachmentEditorTable({
                   )
                 }
                 displayEmpty
+                input={<OutlinedInput notched={false} />}
                 sx={{ minWidth: 120 }}
               >
                 <MenuItem value="">


### PR DESCRIPTION
## Summary
- remove notched outline for attachment type select to get rid of strange strike line

## Testing
- `npm run lint` *(fails: eslint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_684cf4fef904832eaecaf910192e9ceb