### PR TITLE
Add view modals for court cases and correspondence

### DIFF
--- a/src/features/correspondence/LetterFormAntdEdit.tsx
+++ b/src/features/correspondence/LetterFormAntdEdit.tsx
@@ -1,0 +1,172 @@
+import React, { useEffect } from 'react';
+import dayjs, { Dayjs } from 'dayjs';
+import { Form, Input, Select, DatePicker, Button, Row, Col, Skeleton } from 'antd';
+import { useUsers } from '@/entities/user';
+import { useLetterTypes } from '@/entities/letterType';
+import { useProjects } from '@/entities/project';
+import { useUnitsByProject } from '@/entities/unit';
+import { useAttachmentTypes } from '@/entities/attachmentType';
+import { useLetter, useUpdateLetter } from '@/entities/correspondence';
+import FileDropZone from '@/shared/ui/FileDropZone';
+import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
+import { useLetterAttachments } from './model/useLetterAttachments';
+import { useNotify } from '@/shared/hooks/useNotify';
+
+export interface LetterFormAntdEditProps {
+  letterId: string;
+  onCancel?: () => void;
+  onSaved?: () => void;
+  embedded?: boolean;
+}
+
+export interface LetterFormValues {
+  type: 'incoming' | 'outgoing';
+  number: string;
+  date: Dayjs | null;
+  sender: string;
+  receiver: string;
+  subject: string;
+  content: string;
+  responsible_user_id: string | null;
+  letter_type_id: number | null;
+  project_id: number | null;
+  unit_ids: number[];
+  status_id: number | null;
+}
+
+/** Форма редактирования письма */
+export default function LetterFormAntdEdit({ letterId, onCancel, onSaved, embedded = false }: LetterFormAntdEditProps) {
+  const [form] = Form.useForm<LetterFormValues>();
+  const { data: letter } = useLetter(letterId);
+  const update = useUpdateLetter();
+  const notify = useNotify();
+
+  const { data: users = [] } = useUsers();
+  const { data: letterTypes = [] } = useLetterTypes();
+  const { data: projects = [] } = useProjects();
+  const projectId = Form.useWatch('project_id', form);
+  const { data: units = [] } = useUnitsByProject(projectId);
+  const { data: attachmentTypes = [] } = useAttachmentTypes();
+
+  const attachments = useLetterAttachments({ letter, attachmentTypes });
+
+  useEffect(() => {
+    if (!letter) return;
+    form.setFieldsValue({
+      type: letter.type,
+      number: letter.number,
+      date: letter.date ? dayjs(letter.date) : null,
+      sender: letter.sender,
+      receiver: letter.receiver,
+      subject: letter.subject,
+      content: letter.content,
+      responsible_user_id: letter.responsible_user_id,
+      letter_type_id: letter.letter_type_id,
+      project_id: letter.project_id,
+      unit_ids: letter.unit_ids,
+      status_id: letter.status_id ?? null,
+    });
+    attachments.reset();
+  }, [letter]);
+
+  const handleFiles = (files: File[]) => attachments.addFiles(files);
+
+  const onFinish = async (values: LetterFormValues) => {
+    try {
+      if (attachments.newFiles.some((f) => f.type_id == null) || attachments.remoteFiles.some((f) => (attachments.changedTypes[f.id] ?? null) == null)) {
+        notify.error('Укажите тип файла для всех вложений');
+        return;
+      }
+      await update.mutateAsync({
+        id: Number(letterId),
+        updates: {
+          number: values.number,
+          letter_type_id: values.letter_type_id,
+          project_id: values.project_id,
+          unit_ids: values.unit_ids,
+          letter_date: values.date ? values.date.format('YYYY-MM-DD') : dayjs().format('YYYY-MM-DD'),
+          sender: values.sender,
+          receiver: values.receiver,
+          subject: values.subject,
+          content: values.content,
+          responsible_user_id: values.responsible_user_id,
+          status_id: values.status_id,
+        } as any,
+        newAttachments: attachments.newFiles,
+        removedAttachmentIds: attachments.removedIds.map(Number),
+        updatedAttachments: Object.entries(attachments.changedTypes).map(([id, t]) => ({ id: Number(id), type_id: t })),
+      });
+      attachments.markPersisted();
+      notify.success('Письмо обновлено');
+      onSaved?.();
+    } catch (e: any) {
+      notify.error(e.message);
+    }
+  };
+
+  if (!letter) return <Skeleton active />;
+
+  return (
+    <Form form={form} layout="vertical" onFinish={onFinish} style={{ maxWidth: embedded ? 'none' : 640 }} autoComplete="off">
+      <Row gutter={16}>
+        <Col span={8}>
+          <Form.Item name="type" label="Тип письма">
+            <Select>
+              <Select.Option value="incoming">Входящее</Select.Option>
+              <Select.Option value="outgoing">Исходящее</Select.Option>
+            </Select>
+          </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item name="number" label="Номер письма" rules={[{ required: true }]}> <Input /> </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item name="date" label="Дата" rules={[{ required: true }]}> <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} /> </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={12}>
+          <Form.Item name="sender" label="Отправитель"> <Input /> </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item name="receiver" label="Получатель"> <Input /> </Form.Item>
+        </Col>
+      </Row>
+      <Form.Item name="subject" label="Тема"> <Input /> </Form.Item>
+      <Form.Item name="content" label="Содержание"> <Input.TextArea rows={2} /> </Form.Item>
+      <Row gutter={16}>
+        <Col span={12}>
+          <Form.Item name="project_id" label="Проект"> <Select allowClear options={projects.map((p) => ({ value: p.id, label: p.name }))} /> </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item name="unit_ids" label="Объекты"> <Select mode="multiple" options={units.map((u) => ({ value: u.id, label: u.name }))} /> </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={12}>
+          <Form.Item name="letter_type_id" label="Категория"> <Select options={letterTypes.map((t) => ({ value: t.id, label: t.name }))} /> </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item name="status_id" label="Статус"> <Select options={[]} allowClear /> </Form.Item>
+        </Col>
+      </Row>
+      <Form.Item name="responsible_user_id" label="Ответственный"> <Select allowClear options={users.map((u) => ({ value: u.id, label: u.name }))} /> </Form.Item>
+      <Form.Item label="Файлы">
+        <FileDropZone onFiles={handleFiles} />
+        <AttachmentEditorTable
+          remoteFiles={attachments.remoteFiles.map((f) => ({ id: String(f.id), name: f.name, path: f.path, typeId: attachments.changedTypes[f.id] ?? f.attachment_type_id, typeName: f.attachment_type_name }))}
+          newFiles={attachments.newFiles.map((f) => ({ file: f.file, typeId: f.type_id }))}
+          attachmentTypes={attachmentTypes}
+          onRemoveRemote={(id) => attachments.removeRemote(id)}
+          onRemoveNew={(idx) => attachments.removeNew(idx)}
+          onChangeRemoteType={(id, t) => attachments.changeRemoteType(id, t)}
+          onChangeNewType={(idx, t) => attachments.changeNewType(idx, t)}
+        />
+      </Form.Item>
+      <Form.Item style={{ textAlign: 'right' }}>
+        {onCancel && <Button style={{ marginRight: 8 }} onClick={onCancel}>Отмена</Button>}
+        <Button type="primary" htmlType="submit" loading={update.isPending}>Сохранить</Button>
+      </Form.Item>
+    </Form>
+  );
+}

--- a/src/features/correspondence/LetterViewModal.tsx
+++ b/src/features/correspondence/LetterViewModal.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Modal, Typography } from 'antd';
+import LetterFormAntdEdit from './LetterFormAntdEdit';
+import { useLetter } from '@/entities/correspondence';
+
+interface Props {
+  open: boolean;
+  letterId: string | number | null;
+  onClose: () => void;
+}
+
+/** Модальное окно просмотра письма */
+export default function LetterViewModal({ open, letterId, onClose }: Props) {
+  const { data: letter } = useLetter(letterId || undefined);
+  const titleText = letter ? `Письмо №${letter.number}` : 'Письмо';
+
+  if (!letterId) return null;
+
+  return (
+    <Modal open={open} onCancel={onClose} footer={null} width="80%" title={<Typography.Title level={4} style={{ margin: 0 }}>{titleText}</Typography.Title>}>
+      {letter ? (
+        <LetterFormAntdEdit letterId={String(letterId)} onCancel={onClose} onSaved={onClose} embedded />
+      ) : null}
+    </Modal>
+  );
+}

--- a/src/features/correspondence/model/useLetterAttachments.ts
+++ b/src/features/correspondence/model/useLetterAttachments.ts
@@ -1,0 +1,122 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { AttachmentType } from '@/shared/types/attachmentType';
+import type { CorrespondenceLetter } from '@/shared/types/correspondence';
+import type { RemoteLetterFile, NewLetterFile } from '@/shared/types/letterFile';
+
+/** Хук управления вложениями письма. */
+export function useLetterAttachments(options: {
+  letter?: CorrespondenceLetter | null;
+  attachmentTypes: AttachmentType[];
+}) {
+  const { letter, attachmentTypes } = options;
+
+  const [remoteFiles, setRemoteFiles] = useState<RemoteLetterFile[]>([]);
+  const [changedTypes, setChangedTypes] = useState<Record<string, number | null>>({});
+  const [initialTypes, setInitialTypes] = useState<Record<string, number | null>>({});
+  const [newFiles, setNewFiles] = useState<NewLetterFile[]>([]);
+  const [removedIds, setRemovedIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!letter) return;
+    const attachmentsWithType = (letter.attachments || []).map((file) => {
+      const typeObj = attachmentTypes.find((t) => t.id === file.attachment_type_id);
+      const storagePath = (file as any).storage_path ?? file.path;
+      const fileUrl = (file as any).file_url ?? file.url ?? '';
+      const fileType = (file as any).file_type ?? file.type ?? '';
+      const originalName = (file as any).original_name ?? null;
+      const name =
+        originalName ||
+        (storagePath ? storagePath.split('/').pop() : (file as any).name) ||
+        'file';
+      return {
+        id: (file as any).id,
+        name,
+        original_name: originalName,
+        path: storagePath ?? '',
+        url: fileUrl,
+        type: fileType,
+        attachment_type_id: file.attachment_type_id ?? null,
+        attachment_type_name: typeObj?.name || fileType || '',
+      } as RemoteLetterFile;
+    });
+    setRemoteFiles(attachmentsWithType);
+    const map: Record<string, number | null> = {};
+    attachmentsWithType.forEach((f) => {
+      map[String(f.id)] = f.attachment_type_id ?? null;
+    });
+    setChangedTypes(map);
+    setInitialTypes(map);
+  }, [letter, attachmentTypes]);
+
+  const addFiles = useCallback(
+    (files: File[]) =>
+      setNewFiles((p) => [...p, ...files.map((f) => ({ file: f, type_id: null }))]),
+    [],
+  );
+  const removeNew = useCallback(
+    (idx: number) => setNewFiles((p) => p.filter((_, i) => i !== idx)),
+    [],
+  );
+  const removeRemote = useCallback((id: string) => {
+    setRemoteFiles((p) => p.filter((f) => String(f.id) !== String(id)));
+    setRemovedIds((p) => [...p, id]);
+  }, []);
+  const changeRemoteType = useCallback(
+    (id: string, type: number | null) =>
+      setChangedTypes((p) => ({ ...p, [id]: type })),
+    [],
+  );
+  const changeNewType = useCallback(
+    (idx: number, type: number | null) =>
+      setNewFiles((p) => p.map((f, i) => (i === idx ? { ...f, type_id: type } : f))),
+    [],
+  );
+  const appendRemote = useCallback((files: RemoteLetterFile[]) => {
+    setRemoteFiles((p) => [...p, ...files]);
+    setChangedTypes((prev) => {
+      const copy = { ...prev };
+      files.forEach((f) => {
+        copy[String(f.id)] = f.attachment_type_id ?? null;
+      });
+      return copy;
+    });
+    setInitialTypes((prev) => {
+      const copy = { ...prev };
+      files.forEach((f) => {
+        copy[String(f.id)] = f.attachment_type_id ?? null;
+      });
+      return copy;
+    });
+  }, []);
+  const markPersisted = useCallback(() => {
+    setNewFiles([]);
+    setRemovedIds([]);
+    setInitialTypes((prev) => ({ ...prev, ...changedTypes }));
+  }, [changedTypes]);
+  const attachmentsChanged =
+    newFiles.length > 0 ||
+    removedIds.length > 0 ||
+    Object.keys(changedTypes).some((id) => changedTypes[id] !== initialTypes[id]);
+  const resetAll = useCallback(() => {
+    setNewFiles([]);
+    setRemoteFiles([]);
+    setChangedTypes({});
+    setInitialTypes({});
+    setRemovedIds([]);
+  }, []);
+  return {
+    remoteFiles,
+    newFiles,
+    changedTypes,
+    removedIds,
+    addFiles,
+    removeNew,
+    removeRemote,
+    changeRemoteType,
+    changeNewType,
+    appendRemote,
+    markPersisted,
+    attachmentsChanged,
+    reset: resetAll,
+  };
+}

--- a/src/features/courtCase/CourtCaseFormAntdEdit.tsx
+++ b/src/features/courtCase/CourtCaseFormAntdEdit.tsx
@@ -1,0 +1,176 @@
+import React, { useEffect } from 'react';
+import dayjs, { Dayjs } from 'dayjs';
+import { Form, Input, Select, DatePicker, Button, Row, Col, Skeleton } from 'antd';
+import { useProjects } from '@/entities/project';
+import { useUnitsByProject } from '@/entities/unit';
+import { useUsers } from '@/entities/user';
+import { useLitigationStages } from '@/entities/litigationStage';
+import { useAttachmentTypes } from '@/entities/attachmentType';
+import { useCourtCase, useUpdateCourtCaseFull } from '@/entities/courtCase';
+import FileDropZone from '@/shared/ui/FileDropZone';
+import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
+import { useCaseAttachments } from './model/useCaseAttachments';
+import { useNotify } from '@/shared/hooks/useNotify';
+
+export interface CourtCaseFormAntdEditProps {
+  caseId: string;
+  onCancel?: () => void;
+  onSaved?: () => void;
+  embedded?: boolean;
+}
+
+export interface CourtCaseFormValues {
+  project_id: number | null;
+  unit_ids: number[];
+  number: string;
+  date: Dayjs | null;
+  plaintiff_id: number | null;
+  defendant_id: number | null;
+  responsible_lawyer_id: string | null;
+  status: number;
+  fix_start_date: Dayjs | null;
+  fix_end_date: Dayjs | null;
+  description: string;
+}
+
+/** Форма редактирования судебного дела */
+export default function CourtCaseFormAntdEdit({ caseId, onCancel, onSaved, embedded = false }: CourtCaseFormAntdEditProps) {
+  const [form] = Form.useForm<CourtCaseFormValues>();
+  const { data: courtCase } = useCourtCase(caseId);
+  const update = useUpdateCourtCaseFull();
+  const notify = useNotify();
+
+  const { data: projects = [] } = useProjects();
+  const projectId = Form.useWatch('project_id', form);
+  const { data: units = [] } = useUnitsByProject(projectId);
+  const { data: users = [] } = useUsers();
+  const { data: stages = [] } = useLitigationStages();
+  const { data: attachmentTypes = [] } = useAttachmentTypes();
+
+  const attachments = useCaseAttachments({ courtCase, attachmentTypes });
+
+  useEffect(() => {
+    if (!courtCase) return;
+    form.setFieldsValue({
+      project_id: courtCase.project_id,
+      unit_ids: courtCase.unit_ids,
+      number: courtCase.number,
+      date: courtCase.date ? dayjs(courtCase.date) : null,
+      plaintiff_id: courtCase.plaintiff_id ?? null,
+      defendant_id: courtCase.defendant_id ?? null,
+      responsible_lawyer_id: courtCase.responsible_lawyer_id ?? null,
+      status: courtCase.status,
+      fix_start_date: courtCase.fix_start_date ? dayjs(courtCase.fix_start_date) : null,
+      fix_end_date: courtCase.fix_end_date ? dayjs(courtCase.fix_end_date) : null,
+      description: courtCase.description,
+    });
+    attachments.reset();
+  }, [courtCase]);
+
+  const handleFiles = (files: File[]) => attachments.addFiles(files);
+
+  const onFinish = async (values: CourtCaseFormValues) => {
+    try {
+      if (attachments.newFiles.some((f) => f.type_id == null) || attachments.remoteFiles.some((f) => (attachments.changedTypes[f.id] ?? null) == null)) {
+        notify.error('Укажите тип файла для всех вложений');
+        return;
+      }
+      await update.mutateAsync({
+        id: Number(caseId),
+        updates: {
+          project_id: values.project_id!,
+          unit_ids: values.unit_ids,
+          number: values.number,
+          date: values.date ? values.date.format('YYYY-MM-DD') : null,
+          plaintiff_id: values.plaintiff_id!,
+          defendant_id: values.defendant_id!,
+          responsible_lawyer_id: values.responsible_lawyer_id,
+          status: values.status,
+          fix_start_date: values.fix_start_date ? values.fix_start_date.format('YYYY-MM-DD') : null,
+          fix_end_date: values.fix_end_date ? values.fix_end_date.format('YYYY-MM-DD') : null,
+          description: values.description,
+        },
+        newAttachments: attachments.newFiles,
+        removedAttachmentIds: attachments.removedIds.map(Number),
+        updatedAttachments: Object.entries(attachments.changedTypes).map(([id, t]) => ({ id: Number(id), type_id: t })),
+      });
+      attachments.markPersisted();
+      notify.success('Дело обновлено');
+      onSaved?.();
+    } catch (e: any) {
+      notify.error(e.message);
+    }
+  };
+
+  if (!courtCase) return <Skeleton active />;
+
+  return (
+    <Form form={form} layout="vertical" onFinish={onFinish} style={{ maxWidth: embedded ? 'none' : 640 }} autoComplete="off">
+      <Row gutter={16}>
+        <Col span={12}>
+          <Form.Item name="project_id" label="Проект" rules={[{ required: true }]}> 
+            <Select options={projects.map((p) => ({ value: p.id, label: p.name }))} />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item name="unit_ids" label="Объекты" rules={[{ required: true }]}> 
+            <Select mode="multiple" options={units.map((u) => ({ value: u.id, label: u.name }))} />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={12}>
+          <Form.Item name="responsible_lawyer_id" label="Ответственный юрист" rules={[{ required: true }]}> 
+            <Select options={users.map((u) => ({ value: u.id, label: u.name }))} />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item name="status" label="Статус" rules={[{ required: true }]}> 
+            <Select options={stages.map((s) => ({ value: s.id, label: s.name }))} />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={12}>
+          <Form.Item name="number" label="Номер" rules={[{ required: true }]}> <Input /> </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item name="date" label="Дата" rules={[{ required: true }]}> <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} /> </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={12}>
+          <Form.Item name="plaintiff_id" label="Истец" rules={[{ required: true }]}> <Input /> </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item name="defendant_id" label="Ответчик" rules={[{ required: true }]}> <Input /> </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={12}>
+          <Form.Item name="fix_start_date" label="Дата начала устранения"> <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} /> </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item name="fix_end_date" label="Дата окончания устранения"> <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} /> </Form.Item>
+        </Col>
+      </Row>
+      <Form.Item name="description" label="Описание"> <Input.TextArea rows={2} /> </Form.Item>
+      <Form.Item label="Файлы">
+        <FileDropZone onFiles={handleFiles} />
+        <AttachmentEditorTable
+          remoteFiles={attachments.remoteFiles.map((f) => ({ id: String(f.id), name: f.name, path: f.path, typeId: attachments.changedTypes[f.id] ?? f.attachment_type_id, typeName: f.attachment_type_name }))}
+          newFiles={attachments.newFiles.map((f) => ({ file: f.file, typeId: f.type_id }))}
+          attachmentTypes={attachmentTypes}
+          onRemoveRemote={(id) => attachments.removeRemote(id)}
+          onRemoveNew={(idx) => attachments.removeNew(idx)}
+          onChangeRemoteType={(id, t) => attachments.changeRemoteType(id, t)}
+          onChangeNewType={(idx, t) => attachments.changeNewType(idx, t)}
+        />
+      </Form.Item>
+      <Form.Item style={{ textAlign: 'right' }}>
+        {onCancel && <Button style={{ marginRight: 8 }} onClick={onCancel}>Отмена</Button>}
+        <Button type="primary" htmlType="submit" loading={update.isPending}>Сохранить</Button>
+      </Form.Item>
+    </Form>
+  );
+}

--- a/src/features/courtCase/CourtCaseViewModal.tsx
+++ b/src/features/courtCase/CourtCaseViewModal.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Modal, Typography } from 'antd';
+import CourtCaseFormAntdEdit from './CourtCaseFormAntdEdit';
+import { useCourtCase } from '@/entities/courtCase';
+
+interface Props {
+  open: boolean;
+  caseId: string | number | null;
+  onClose: () => void;
+}
+
+/** Модальное окно просмотра судебного дела */
+export default function CourtCaseViewModal({ open, caseId, onClose }: Props) {
+  const { data: courtCase } = useCourtCase(caseId || undefined);
+  const titleText = courtCase ? `Дело №${courtCase.id}` : 'Дело';
+
+  if (!caseId) return null;
+
+  return (
+    <Modal open={open} onCancel={onClose} footer={null} width="80%" title={<Typography.Title level={4} style={{ margin: 0 }}>{titleText}</Typography.Title>}>
+      {courtCase ? (
+        <CourtCaseFormAntdEdit caseId={String(caseId)} onCancel={onClose} onSaved={onClose} embedded />
+      ) : null}
+    </Modal>
+  );
+}

--- a/src/features/courtCase/model/useCaseAttachments.ts
+++ b/src/features/courtCase/model/useCaseAttachments.ts
@@ -1,0 +1,124 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { AttachmentType } from '@/shared/types/attachmentType';
+import type { CourtCase } from '@/shared/types/courtCase';
+import type { RemoteCaseFile, NewCaseFile } from '@/shared/types/caseFile';
+
+/** Хук управления вложениями судебного дела. */
+export function useCaseAttachments(options: {
+  courtCase?: CourtCase | null;
+  attachmentTypes: AttachmentType[];
+}) {
+  const { courtCase, attachmentTypes } = options;
+
+  const [remoteFiles, setRemoteFiles] = useState<RemoteCaseFile[]>([]);
+  const [changedTypes, setChangedTypes] = useState<Record<string, number | null>>({});
+  const [initialTypes, setInitialTypes] = useState<Record<string, number | null>>({});
+  const [newFiles, setNewFiles] = useState<NewCaseFile[]>([]);
+  const [removedIds, setRemovedIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!courtCase) return;
+    const attachmentsWithType = (courtCase.attachment_ids || []).map((id, idx) => {
+      const file = (courtCase as any).attachments?.[idx];
+      if (!file) return null;
+      const typeObj = attachmentTypes.find((t) => t.id === file.attachment_type_id);
+      const storagePath = (file as any).storage_path ?? file.path;
+      const fileUrl = (file as any).file_url ?? file.url ?? '';
+      const fileType = (file as any).file_type ?? file.type ?? '';
+      const originalName = (file as any).original_name ?? null;
+      const name =
+        originalName ||
+        (storagePath ? storagePath.split('/').pop() : (file as any).name) ||
+        'file';
+      return {
+        id: (file as any).id,
+        name,
+        original_name: originalName,
+        path: storagePath ?? '',
+        url: fileUrl,
+        type: fileType,
+        attachment_type_id: file.attachment_type_id ?? null,
+        attachment_type_name: typeObj?.name || fileType || '',
+      } as RemoteCaseFile;
+    }).filter(Boolean) as RemoteCaseFile[];
+    setRemoteFiles(attachmentsWithType);
+    const map: Record<string, number | null> = {};
+    attachmentsWithType.forEach((f) => {
+      map[String(f.id)] = f.attachment_type_id ?? null;
+    });
+    setChangedTypes(map);
+    setInitialTypes(map);
+  }, [courtCase, attachmentTypes]);
+
+  const addFiles = useCallback(
+    (files: File[]) =>
+      setNewFiles((p) => [...p, ...files.map((f) => ({ file: f, type_id: null }))]),
+    [],
+  );
+  const removeNew = useCallback(
+    (idx: number) => setNewFiles((p) => p.filter((_, i) => i !== idx)),
+    [],
+  );
+  const removeRemote = useCallback((id: string) => {
+    setRemoteFiles((p) => p.filter((f) => String(f.id) !== String(id)));
+    setRemovedIds((p) => [...p, id]);
+  }, []);
+  const changeRemoteType = useCallback(
+    (id: string, type: number | null) =>
+      setChangedTypes((p) => ({ ...p, [id]: type })),
+    [],
+  );
+  const changeNewType = useCallback(
+    (idx: number, type: number | null) =>
+      setNewFiles((p) => p.map((f, i) => (i === idx ? { ...f, type_id: type } : f))),
+    [],
+  );
+  const appendRemote = useCallback((files: RemoteCaseFile[]) => {
+    setRemoteFiles((p) => [...p, ...files]);
+    setChangedTypes((prev) => {
+      const copy = { ...prev };
+      files.forEach((f) => {
+        copy[String(f.id)] = f.attachment_type_id ?? null;
+      });
+      return copy;
+    });
+    setInitialTypes((prev) => {
+      const copy = { ...prev };
+      files.forEach((f) => {
+        copy[String(f.id)] = f.attachment_type_id ?? null;
+      });
+      return copy;
+    });
+  }, []);
+  const markPersisted = useCallback(() => {
+    setNewFiles([]);
+    setRemovedIds([]);
+    setInitialTypes((prev) => ({ ...prev, ...changedTypes }));
+  }, [changedTypes]);
+  const attachmentsChanged =
+    newFiles.length > 0 ||
+    removedIds.length > 0 ||
+    Object.keys(changedTypes).some((id) => changedTypes[id] !== initialTypes[id]);
+  const resetAll = useCallback(() => {
+    setNewFiles([]);
+    setRemoteFiles([]);
+    setChangedTypes({});
+    setInitialTypes({});
+    setRemovedIds([]);
+  }, []);
+  return {
+    remoteFiles,
+    newFiles,
+    changedTypes,
+    removedIds,
+    addFiles,
+    removeNew,
+    removeRemote,
+    changeRemoteType,
+    changeNewType,
+    appendRemote,
+    markPersisted,
+    attachmentsChanged,
+    reset: resetAll,
+  };
+}

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -25,6 +25,7 @@ import CorrespondenceTable from '@/widgets/CorrespondenceTable';
 import CorrespondenceFilters from '@/widgets/CorrespondenceFilters';
 import TableColumnsDrawer from '@/widgets/TableColumnsDrawer';
 import LetterStatusSelect from '@/features/correspondence/LetterStatusSelect';
+import LetterViewModal from '@/features/correspondence/LetterViewModal';
 import type { TableColumnSetting } from '@/shared/types/tableColumnSetting';
 import type { ColumnsType } from 'antd/es/table';
 import {
@@ -116,6 +117,7 @@ export default function CorrespondencePage() {
   };
   const [linkFor, setLinkFor] = useState<CorrespondenceLetter | null>(null);
   const [showAddForm, setShowAddForm] = useState(false);
+  const [viewId, setViewId] = useState<string | null>(null);
   const hideOnScroll = useRef(false);
   const LS_FILTERS_VISIBLE_KEY = 'correspondenceFiltersVisible';
   const LS_COLUMNS_KEY = 'correspondenceColumns';
@@ -586,6 +588,7 @@ export default function CorrespondencePage() {
             onDelete={handleDelete}
             onAddChild={setLinkFor}
             onUnlink={handleUnlink}
+            onView={(id) => setViewId(String(id))}
             users={users}
             letterTypes={letterTypes}
             projects={projects}
@@ -600,7 +603,7 @@ export default function CorrespondencePage() {
             Готовых писем к выгрузке: {readyToExport}
           </Typography.Text>
         </div>
-
+        <LetterViewModal open={viewId !== null} letterId={viewId} onClose={() => setViewId(null)} />
       </>
     </ConfigProvider>
   );

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -20,6 +20,7 @@ import {
   LinkOutlined,
   FileTextOutlined,
   BranchesOutlined,
+  EyeOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
 import {
@@ -36,6 +37,7 @@ import CourtCaseClosedSelect from '@/features/courtCase/CourtCaseClosedSelect';
 import LinkCasesDialog from '@/features/courtCase/LinkCasesDialog';
 import ExportCourtCasesButton from '@/features/courtCase/ExportCourtCasesButton';
 import AddCourtCaseFormAntd from '@/features/courtCase/AddCourtCaseFormAntd';
+import CourtCaseViewModal from '@/features/courtCase/CourtCaseViewModal';
 import CourtCasesFilters, { CourtCasesFiltersValues } from '@/widgets/CourtCasesFilters';
 import TableColumnsDrawer from '@/widgets/TableColumnsDrawer';
 import type { TableColumnSetting } from '@/shared/types/tableColumnSetting';
@@ -56,6 +58,7 @@ export default function CourtCasesPage() {
   const unlinkCase = useUnlinkCase();
   const [linkFor, setLinkFor] = useState<CourtCase | null>(null);
   const [showAddForm, setShowAddForm] = useState(false);
+  const [viewId, setViewId] = useState<number | null>(null);
   const [showFilters, setShowFilters] = useState(() => {
     try {
       const saved = localStorage.getItem(LS_FILTERS_VISIBLE_KEY);
@@ -312,9 +315,12 @@ export default function CourtCasesPage() {
     actions: {
       title: 'Действия',
       key: 'actions',
-      width: 120,
+      width: 140,
       render: (_: any, record) => (
         <Space size="middle">
+          <Tooltip title="Просмотр">
+            <Button size="small" type="text" icon={<EyeOutlined />} onClick={() => setViewId(record.id)} />
+          </Tooltip>
           <Button type="text" icon={<PlusOutlined />} onClick={() => setLinkFor(record)} />
           {record.parent_id && (
             <Tooltip title="Исключить из связи">
@@ -467,10 +473,11 @@ export default function CourtCasesPage() {
           <Typography.Text style={{ display: 'block', marginTop: 8 }}>
             Всего дел: {total}, из них закрытых: {closedCount} и не закрытых: {openCount}
           </Typography.Text>
-          <Typography.Text style={{ display: 'block', marginTop: 4 }}>
-            Готовых дел к выгрузке: {readyToExport}
-          </Typography.Text>
-        </div>
+        <Typography.Text style={{ display: 'block', marginTop: 4 }}>
+          Готовых дел к выгрузке: {readyToExport}
+        </Typography.Text>
+      </div>
+      <CourtCaseViewModal open={viewId !== null} caseId={viewId} onClose={() => setViewId(null)} />
       </>
     </ConfigProvider>
   );

--- a/src/shared/types/caseFile.ts
+++ b/src/shared/types/caseFile.ts
@@ -1,0 +1,17 @@
+/** Вложение судебного дела, загруженное на сервер */
+export interface RemoteCaseFile {
+  id: string | number;
+  name: string;
+  original_name?: string | null;
+  path: string;
+  url: string;
+  type: string;
+  attachment_type_id: number | null;
+  attachment_type_name?: string;
+}
+
+/** Новый файл для вложения судебного дела */
+export interface NewCaseFile {
+  file: File;
+  type_id: number | null;
+}

--- a/src/shared/types/letterFile.ts
+++ b/src/shared/types/letterFile.ts
@@ -1,0 +1,17 @@
+/** Вложение письма, загруженное на сервер */
+export interface RemoteLetterFile {
+  id: string | number;
+  name: string;
+  original_name?: string | null;
+  path: string;
+  url: string;
+  type: string;
+  attachment_type_id: number | null;
+  attachment_type_name?: string;
+}
+
+/** Новый файл для вложения письма */
+export interface NewLetterFile {
+  file: File;
+  type_id: number | null;
+}

--- a/src/widgets/CorrespondenceTable.tsx
+++ b/src/widgets/CorrespondenceTable.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState, useEffect } from 'react';
 import dayjs from 'dayjs';
 import { Table, Space, Button, Popconfirm, Tag, Tooltip } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
-import { DeleteOutlined, PlusOutlined, MailOutlined, BranchesOutlined, LinkOutlined } from '@ant-design/icons';
+import { DeleteOutlined, PlusOutlined, MailOutlined, BranchesOutlined, LinkOutlined, EyeOutlined } from '@ant-design/icons';
 import { CorrespondenceLetter } from '@/shared/types/correspondence';
 import LetterStatusSelect from '@/features/correspondence/LetterStatusSelect';
 
@@ -13,6 +13,7 @@ interface CorrespondenceTableProps {
   onDelete: (id: string) => void;
   onAddChild: (parent: CorrespondenceLetter) => void;
   onUnlink: (letterId: string) => void; // <--- новый проп
+  onView?: (id: string) => void;
   /** Колонки таблицы. Если не переданы, используется набор по умолчанию */
   columns?: ColumnsType<any>;
   users: Option[];
@@ -31,6 +32,7 @@ export default function CorrespondenceTable({
                                               onDelete,
                                               onAddChild,
                                               onUnlink,
+                                              onView,
                                               columns: columnsProp,
                                               users,
                                               letterTypes,
@@ -229,14 +231,13 @@ export default function CorrespondenceTable({
     {
       title: 'Действия',
       key: 'actions',
-      width: 130,
+      width: 150,
       render: (_: any, record: CorrespondenceLetter) => (
           <Space size="middle">
-            <Button
-                type="text"
-                icon={<PlusOutlined />}
-                onClick={() => onAddChild(record)}
-            />
+            <Tooltip title="Просмотр">
+              <Button size="small" type="text" icon={<EyeOutlined />} onClick={() => onView && onView(record.id)} />
+            </Tooltip>
+            <Button type="text" icon={<PlusOutlined />} onClick={() => onAddChild(record)} />
             {/* Только для связанных писем — показать кнопку "исключить" */}
             {record.parent_id && (
                 <Tooltip title="Исключить из связи">


### PR DESCRIPTION
## Summary
- add attachment hooks and view modals for court cases and correspondence
- enable editing attachments via new forms
- include view buttons in tables

## Testing
- `npm run lint` *(fails: eslint packages missing)*
- `npm run build` *(fails: vite not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684cf8a044c8832eb884b31bc1a3f9d1