### PR TITLE
Add view icon to correspondence table actions

### DIFF
--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -373,9 +373,16 @@ export default function CorrespondencePage() {
       actions: {
         title: 'Действия',
         key: 'actions',
-        width: 130,
+        width: 150,
         render: (_: any, record: CorrespondenceLetter) => (
           <Space size="middle">
+            <Tooltip title="Просмотр">
+              <Button
+                type="text"
+                icon={<EyeOutlined />}
+                onClick={() => setViewId(String(record.id))}
+              />
+            </Tooltip>
             <Button type="text" icon={<PlusOutlined />} onClick={() => setLinkFor(record)} />
             {record.parent_id && (
               <Tooltip title="Исключить из связи">


### PR DESCRIPTION
## Summary
- show eye icon in actions column

## Testing
- `npm run lint` *(fails: Parsing error: The keyword 'interface' is reserved)*

------
https://chatgpt.com/codex/tasks/task_e_684cfccbc974832e8f2a3fab9dc51d6c