### PR TITLE
Add view icon to correspondence table actions

### DIFF
--- a/src/features/correspondence/LinkLettersDialog.tsx
+++ b/src/features/correspondence/LinkLettersDialog.tsx
@@ -105,7 +105,7 @@ export default function LinkLettersDialog({
             </Button>,
           ]}
           width={700}
-          destroyOnClose
+          destroyOnHidden
       >
         <Input
             placeholder="Поиск по номеру, теме, корреспонденту"

--- a/src/features/courtCase/LinkCasesDialog.tsx
+++ b/src/features/courtCase/LinkCasesDialog.tsx
@@ -68,7 +68,7 @@ export default function LinkCasesDialog({ open, parent, cases, onClose, onSubmit
         </Button>,
       ]}
       width={700}
-      destroyOnClose
+      destroyOnHidden
     >
       <Input
         placeholder="Поиск по ID или номеру"

--- a/src/features/history/HistoryDialog.tsx
+++ b/src/features/history/HistoryDialog.tsx
@@ -138,7 +138,7 @@ export default function HistoryDialog({ open, unit, onClose, onOpenCourtCase }: 
             title={unit ? `История объекта ${unit.name}` : 'История'}
             width={700}
             zIndex={1400}
-            destroyOnClose
+            destroyOnHidden
         >
           <Space style={{ marginBottom: 12 }}>
             <Switch checked={primaryOnly} onChange={setPrimaryOnly} />

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -54,6 +54,7 @@ import {
   MailOutlined,
   BranchesOutlined,
   LinkOutlined,
+  EyeOutlined,
 } from '@ant-design/icons';
 
 interface Filters {
@@ -373,9 +374,16 @@ export default function CorrespondencePage() {
       actions: {
         title: 'Действия',
         key: 'actions',
-        width: 130,
+        width: 150,
         render: (_: any, record: CorrespondenceLetter) => (
           <Space size="middle">
+            <Tooltip title="Просмотр">
+              <Button
+                type="text"
+                icon={<EyeOutlined />}
+                onClick={() => setViewId(String(record.id))}
+              />
+            </Tooltip>
             <Button type="text" icon={<PlusOutlined />} onClick={() => setLinkFor(record)} />
             {record.parent_id && (
               <Tooltip title="Исключить из связи">


### PR DESCRIPTION
## Summary
- add missing `EyeOutlined` import
- replace deprecated `destroyOnClose` with `destroyOnHidden`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684cfccbc974832e8f2a3fab9dc51d6c