### PR TITLE
Fix case edit form initial values

### DIFF
--- a/src/features/courtCase/CourtCaseFormAntdEdit.tsx
+++ b/src/features/courtCase/CourtCaseFormAntdEdit.tsx
@@ -64,7 +64,6 @@ export default function CourtCaseFormAntdEdit({ caseId, onCancel, onSaved, embed
       fix_end_date: courtCase.fix_end_date ? dayjs(courtCase.fix_end_date) : null,
       description: courtCase.description,
     });
-    attachments.reset();
   }, [courtCase]);
 
   const handleFiles = (files: File[]) => attachments.addFiles(files);


### PR DESCRIPTION
## Summary
- ensure saved court case values populate edit form

## Testing
- `npm run lint` *(fails: Parsing error: Unexpected token interface)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684cfd568878832eb61ea3939f37e2ad