### PR TITLE
Fix letter form edit fields

### DIFF
--- a/src/features/correspondence/LetterFormAntdEdit.tsx
+++ b/src/features/correspondence/LetterFormAntdEdit.tsx
@@ -50,6 +50,12 @@ export default function LetterFormAntdEdit({ letterId, onCancel, onSaved, embedd
 
   const attachments = useLetterAttachments({ letter, attachmentTypes });
 
+  // Сбрасываем форму при смене письма
+  useEffect(() => {
+    form.resetFields();
+  }, [letterId]);
+
+  // Заполняем поля данными письма
   useEffect(() => {
     if (!letter) return;
     form.setFieldsValue({
@@ -67,7 +73,7 @@ export default function LetterFormAntdEdit({ letterId, onCancel, onSaved, embedd
       status_id: letter.status_id ?? null,
     });
     attachments.reset();
-  }, [letter]);
+  }, [letterId, letter]);
 
   const handleFiles = (files: File[]) => attachments.addFiles(files);
 

--- a/src/features/correspondence/LetterViewModal.tsx
+++ b/src/features/correspondence/LetterViewModal.tsx
@@ -17,7 +17,14 @@ export default function LetterViewModal({ open, letterId, onClose }: Props) {
   if (!letterId) return null;
 
   return (
-    <Modal open={open} onCancel={onClose} footer={null} width="80%" title={<Typography.Title level={4} style={{ margin: 0 }}>{titleText}</Typography.Title>}>
+    <Modal
+      open={open}
+      onCancel={onClose}
+      footer={null}
+      width="80%"
+      destroyOnClose
+      title={<Typography.Title level={4} style={{ margin: 0 }}>{titleText}</Typography.Title>}
+    >
       {letter ? (
         <LetterFormAntdEdit letterId={String(letterId)} onCancel={onClose} onSaved={onClose} embedded />
       ) : null}


### PR DESCRIPTION
## Summary
- reset edit form on letter change and load fields correctly
- unmount letter view modal on close

## Testing
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_684cffe75440832ea20602b6501acee6