### PR TITLE
Fix case form initial fields

### DIFF
--- a/src/features/courtCase/CourtCaseFormAntdEdit.tsx
+++ b/src/features/courtCase/CourtCaseFormAntdEdit.tsx
@@ -7,6 +7,7 @@ import { useUsers } from '@/entities/user';
 import { useLitigationStages } from '@/entities/litigationStage';
 import { useAttachmentTypes } from '@/entities/attachmentType';
 import { useCourtCase, useUpdateCourtCaseFull } from '@/entities/courtCase';
+import type { CourtCase } from '@/shared/types/courtCase';
 import FileDropZone from '@/shared/ui/FileDropZone';
 import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
 import { useCaseAttachments } from './model/useCaseAttachments';
@@ -14,6 +15,8 @@ import { useNotify } from '@/shared/hooks/useNotify';
 
 export interface CourtCaseFormAntdEditProps {
   caseId: string;
+  /** Данные дела, если уже загружены */
+  caseData?: CourtCase;
   onCancel?: () => void;
   onSaved?: () => void;
   embedded?: boolean;
@@ -34,9 +37,10 @@ export interface CourtCaseFormValues {
 }
 
 /** Форма редактирования судебного дела */
-export default function CourtCaseFormAntdEdit({ caseId, onCancel, onSaved, embedded = false }: CourtCaseFormAntdEditProps) {
+export default function CourtCaseFormAntdEdit({ caseId, caseData, onCancel, onSaved, embedded = false }: CourtCaseFormAntdEditProps) {
   const [form] = Form.useForm<CourtCaseFormValues>();
-  const { data: courtCase } = useCourtCase(caseId);
+  const { data: fetchedCase } = useCourtCase(caseData ? undefined : caseId);
+  const courtCase = caseData ?? fetchedCase;
   const update = useUpdateCourtCaseFull();
   const notify = useNotify();
 

--- a/src/features/courtCase/CourtCaseViewModal.tsx
+++ b/src/features/courtCase/CourtCaseViewModal.tsx
@@ -17,9 +17,23 @@ export default function CourtCaseViewModal({ open, caseId, onClose }: Props) {
   if (!caseId) return null;
 
   return (
-    <Modal open={open} onCancel={onClose} footer={null} width="80%" title={<Typography.Title level={4} style={{ margin: 0 }}>{titleText}</Typography.Title>}>
+    <Modal
+      destroyOnClose
+      open={open}
+      onCancel={onClose}
+      footer={null}
+      width="80%"
+      title={<Typography.Title level={4} style={{ margin: 0 }}>{titleText}</Typography.Title>}
+    >
       {courtCase ? (
-        <CourtCaseFormAntdEdit caseId={String(caseId)} onCancel={onClose} onSaved={onClose} embedded />
+        <CourtCaseFormAntdEdit
+          key={String(caseId)}
+          caseId={String(caseId)}
+          caseData={courtCase}
+          onCancel={onClose}
+          onSaved={onClose}
+          embedded
+        />
       ) : null}
     </Modal>
   );


### PR DESCRIPTION
## Summary
- pass fetched court case data to the edit form
- avoid duplicate queries when opening case view modal
- destroy view modal content on close so data is fresh

## Testing
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_684cffb078c8832e8c59cb6877673ca5