### PR TITLE
Add debug logs for court case view

### DIFF
--- a/src/entities/courtCase/index.ts
+++ b/src/entities/courtCase/index.ts
@@ -267,18 +267,23 @@ export function useCourtCase(caseId: number | string | undefined) {
     queryKey: ['court_case', id],
     enabled: !!id,
     queryFn: async () => {
+      console.log('[useCourtCase] fetch start', id);
       const { data, error } = await supabase
         .from(CASES_TABLE)
         .select('*')
         .eq('id', id)
         .single();
+      console.log('[useCourtCase] fetch result', data, error);
       if (error) throw error;
       let attachments: any[] = [];
       if (data?.attachment_ids?.length) {
         const files = await getAttachmentsByIds(data.attachment_ids);
         attachments = files;
+        console.log('[useCourtCase] attachments', files);
       }
-      return { ...(data as any), attachments } as CourtCase & { attachments: any[] };
+      const result = { ...(data as any), attachments } as CourtCase & { attachments: any[] };
+      console.log('[useCourtCase] final', result);
+      return result;
     },
     staleTime: 5 * 60_000,
   });

--- a/src/features/courtCase/CourtCaseFormAntdEdit.tsx
+++ b/src/features/courtCase/CourtCaseFormAntdEdit.tsx
@@ -38,9 +38,13 @@ export interface CourtCaseFormValues {
 
 /** Форма редактирования судебного дела */
 export default function CourtCaseFormAntdEdit({ caseId, caseData, onCancel, onSaved, embedded = false }: CourtCaseFormAntdEditProps) {
+  console.log('[CourtCaseFormAntdEdit] init', { caseId, caseData });
   const [form] = Form.useForm<CourtCaseFormValues>();
   const { data: fetchedCase } = useCourtCase(caseData ? undefined : caseId);
   const courtCase = caseData ?? fetchedCase;
+  useEffect(() => {
+    console.log('[CourtCaseFormAntdEdit] courtCase', courtCase);
+  }, [courtCase]);
   const update = useUpdateCourtCaseFull();
   const notify = useNotify();
 
@@ -52,9 +56,13 @@ export default function CourtCaseFormAntdEdit({ caseId, caseData, onCancel, onSa
   const { data: attachmentTypes = [] } = useAttachmentTypes();
 
   const attachments = useCaseAttachments({ courtCase, attachmentTypes });
+  useEffect(() => {
+    console.log('[CourtCaseFormAntdEdit] attachments', attachments);
+  }, [attachments.remoteFiles, attachments.newFiles]);
 
   useEffect(() => {
     if (!courtCase) return;
+    console.log('[CourtCaseFormAntdEdit] setFieldsValue', courtCase);
     form.setFieldsValue({
       project_id: courtCase.project_id,
       unit_ids: courtCase.unit_ids,
@@ -68,6 +76,7 @@ export default function CourtCaseFormAntdEdit({ caseId, caseData, onCancel, onSa
       fix_end_date: courtCase.fix_end_date ? dayjs(courtCase.fix_end_date) : null,
       description: courtCase.description,
     });
+    console.log('[CourtCaseFormAntdEdit] after setFieldsValue', form.getFieldsValue());
   }, [courtCase]);
 
   const handleFiles = (files: File[]) => attachments.addFiles(files);

--- a/src/features/courtCase/CourtCaseViewModal.tsx
+++ b/src/features/courtCase/CourtCaseViewModal.tsx
@@ -12,6 +12,12 @@ interface Props {
 /** Модальное окно просмотра судебного дела */
 export default function CourtCaseViewModal({ open, caseId, onClose }: Props) {
   const { data: courtCase } = useCourtCase(caseId || undefined);
+  React.useEffect(() => {
+    console.log('[CourtCaseViewModal] open', open, 'caseId', caseId);
+  }, [open, caseId]);
+  React.useEffect(() => {
+    console.log('[CourtCaseViewModal] case data', courtCase);
+  }, [courtCase]);
   const titleText = courtCase ? `Дело №${courtCase.id}` : 'Дело';
 
   if (!caseId) return null;

--- a/src/features/courtCase/model/useCaseAttachments.ts
+++ b/src/features/courtCase/model/useCaseAttachments.ts
@@ -41,7 +41,10 @@ export function useCaseAttachments(options: {
         attachment_type_name: typeObj?.name || fileType || '',
       } as RemoteCaseFile;
     }).filter(Boolean) as RemoteCaseFile[];
+    console.log('[useCaseAttachments] parsed attachments', attachmentsWithType);
     setRemoteFiles(attachmentsWithType);
+    console.log('[useCaseAttachments] setRemoteFiles', attachmentsWithType);
+    console.log('[useCaseAttachments] remoteFiles state', attachmentsWithType);
     const map: Record<string, number | null> = {};
     attachmentsWithType.forEach((f) => {
       map[String(f.id)] = f.attachment_type_id ?? null;
@@ -51,17 +54,23 @@ export function useCaseAttachments(options: {
   }, [courtCase, attachmentTypes]);
 
   const addFiles = useCallback(
-    (files: File[]) =>
-      setNewFiles((p) => [...p, ...files.map((f) => ({ file: f, type_id: null }))]),
+    (files: File[]) => {
+      console.log('[useCaseAttachments] addFiles', files);
+      setNewFiles((p) => [...p, ...files.map((f) => ({ file: f, type_id: null }))]);
+    },
     [],
   );
   const removeNew = useCallback(
-    (idx: number) => setNewFiles((p) => p.filter((_, i) => i !== idx)),
+    (idx: number) => {
+      setNewFiles((p) => p.filter((_, i) => i !== idx));
+      console.log('[useCaseAttachments] removeNew', idx);
+    },
     [],
   );
   const removeRemote = useCallback((id: string) => {
     setRemoteFiles((p) => p.filter((f) => String(f.id) !== String(id)));
     setRemovedIds((p) => [...p, id]);
+    console.log('[useCaseAttachments] removeRemote', id);
   }, []);
   const changeRemoteType = useCallback(
     (id: string, type: number | null) =>
@@ -74,6 +83,7 @@ export function useCaseAttachments(options: {
     [],
   );
   const appendRemote = useCallback((files: RemoteCaseFile[]) => {
+    console.log('[useCaseAttachments] appendRemote', files);
     setRemoteFiles((p) => [...p, ...files]);
     setChangedTypes((prev) => {
       const copy = { ...prev };
@@ -91,6 +101,7 @@ export function useCaseAttachments(options: {
     });
   }, []);
   const markPersisted = useCallback(() => {
+    console.log('[useCaseAttachments] markPersisted');
     setNewFiles([]);
     setRemovedIds([]);
     setInitialTypes((prev) => ({ ...prev, ...changedTypes }));
@@ -100,6 +111,7 @@ export function useCaseAttachments(options: {
     removedIds.length > 0 ||
     Object.keys(changedTypes).some((id) => changedTypes[id] !== initialTypes[id]);
   const resetAll = useCallback(() => {
+    console.log('[useCaseAttachments] resetAll');
     setNewFiles([]);
     setRemoteFiles([]);
     setChangedTypes({});


### PR DESCRIPTION
## Summary
- add console log after setting court case form fields
- log remote file state in `useCaseAttachments`

## Testing
- `npm run lint` *(fails: Parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_684d048f9a48832e86d1c24097d63acd