### PR TITLE
Add debug logs for letter and case view

### DIFF
--- a/src/entities/correspondence/index.ts
+++ b/src/entities/correspondence/index.ts
@@ -313,7 +313,11 @@ export function useLetter(letterId: number | string | undefined) {
         )
         .eq('id', id)
         .single();
-      if (error) throw error;
+      if (error) {
+        console.error('useLetter query error:', error);
+        throw error;
+      }
+      console.debug('useLetter fetched data:', data);
       const { data: link } = await supabase
         .from(LINKS_TABLE)
         .select('parent_id')
@@ -326,7 +330,7 @@ export function useLetter(letterId: number | string | undefined) {
       if (data?.attachment_ids?.length) {
         attachments = await getAttachmentsByIds(data.attachment_ids);
       }
-      return {
+      const result = {
         id: String(data!.id),
         type,
         parent_id: link?.parent_id != null ? String(link.parent_id) : null,
@@ -344,6 +348,8 @@ export function useLetter(letterId: number | string | undefined) {
         content: data?.content ?? '',
         attachments,
       } as CorrespondenceLetter & { attachments: any[] };
+      console.debug('useLetter normalized result:', result);
+      return result;
     },
     staleTime: 5 * 60_000,
   });

--- a/src/entities/courtCase/index.ts
+++ b/src/entities/courtCase/index.ts
@@ -272,13 +272,19 @@ export function useCourtCase(caseId: number | string | undefined) {
         .select('*')
         .eq('id', id)
         .single();
-      if (error) throw error;
+      if (error) {
+        console.error('useCourtCase query error:', error);
+        throw error;
+      }
+      console.debug('useCourtCase fetched data:', data);
       let attachments: any[] = [];
       if (data?.attachment_ids?.length) {
         const files = await getAttachmentsByIds(data.attachment_ids);
         attachments = files;
       }
-      return { ...(data as any), attachments } as CourtCase & { attachments: any[] };
+      const result = { ...(data as any), attachments } as CourtCase & { attachments: any[] };
+      console.debug('useCourtCase normalized result:', result);
+      return result;
     },
     staleTime: 5 * 60_000,
   });

--- a/src/features/correspondence/LetterFormAntdEdit.tsx
+++ b/src/features/correspondence/LetterFormAntdEdit.tsx
@@ -38,6 +38,8 @@ export interface LetterFormValues {
 export default function LetterFormAntdEdit({ letterId, onCancel, onSaved, embedded = false }: LetterFormAntdEditProps) {
   const [form] = Form.useForm<LetterFormValues>();
   const { data: letter } = useLetter(letterId);
+  console.debug('LetterFormAntdEdit letterId:', letterId);
+  console.debug('LetterFormAntdEdit fetched letter:', letter);
   const update = useUpdateLetter();
   const notify = useNotify();
 
@@ -52,12 +54,14 @@ export default function LetterFormAntdEdit({ letterId, onCancel, onSaved, embedd
 
   // Сбрасываем форму при смене письма
   useEffect(() => {
+    console.debug('LetterFormAntdEdit resetting form for letterId', letterId);
     form.resetFields();
   }, [letterId]);
 
   // Заполняем поля данными письма
   useEffect(() => {
     if (!letter) return;
+    console.debug('LetterFormAntdEdit setFields with letter:', letter);
     form.setFieldsValue({
       type: letter.type,
       number: letter.number,

--- a/src/features/correspondence/LetterViewModal.tsx
+++ b/src/features/correspondence/LetterViewModal.tsx
@@ -11,7 +11,9 @@ interface Props {
 
 /** Модальное окно просмотра письма */
 export default function LetterViewModal({ open, letterId, onClose }: Props) {
+  console.debug('LetterViewModal open:', open, 'letterId:', letterId);
   const { data: letter } = useLetter(letterId || undefined);
+  console.debug('LetterViewModal fetched letter:', letter);
   const titleText = letter ? `Письмо №${letter.number}` : 'Письмо';
 
   if (!letterId) return null;

--- a/src/features/courtCase/CourtCaseFormAntdEdit.tsx
+++ b/src/features/courtCase/CourtCaseFormAntdEdit.tsx
@@ -41,6 +41,8 @@ export default function CourtCaseFormAntdEdit({ caseId, caseData, onCancel, onSa
   const [form] = Form.useForm<CourtCaseFormValues>();
   const { data: fetchedCase } = useCourtCase(caseData ? undefined : caseId);
   const courtCase = caseData ?? fetchedCase;
+  console.debug('CourtCaseFormAntdEdit caseId:', caseId);
+  console.debug('CourtCaseFormAntdEdit fetched case:', courtCase);
   const update = useUpdateCourtCaseFull();
   const notify = useNotify();
 
@@ -55,6 +57,7 @@ export default function CourtCaseFormAntdEdit({ caseId, caseData, onCancel, onSa
 
   useEffect(() => {
     if (!courtCase) return;
+    console.debug('CourtCaseFormAntdEdit setFields with case:', courtCase);
     form.setFieldsValue({
       project_id: courtCase.project_id,
       unit_ids: courtCase.unit_ids,

--- a/src/features/courtCase/CourtCaseViewModal.tsx
+++ b/src/features/courtCase/CourtCaseViewModal.tsx
@@ -11,7 +11,9 @@ interface Props {
 
 /** Модальное окно просмотра судебного дела */
 export default function CourtCaseViewModal({ open, caseId, onClose }: Props) {
+  console.debug('CourtCaseViewModal open:', open, 'caseId:', caseId);
   const { data: courtCase } = useCourtCase(caseId || undefined);
+  console.debug('CourtCaseViewModal fetched case:', courtCase);
   const titleText = courtCase ? `Дело №${courtCase.id}` : 'Дело';
 
   if (!caseId) return null;


### PR DESCRIPTION
## Summary
- log letter fetch lifecycle to debug correspondence view form
- log court case fetch lifecycle to debug court case view form

## Testing
- `npm run lint` *(fails: 106 errors)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d051d3ad8832e891f06de2bd9b1b4