### PR TITLE
Add case view modal

### DIFF
--- a/src/features/courtCase/CourtCaseFormAntdEdit.tsx
+++ b/src/features/courtCase/CourtCaseFormAntdEdit.tsx
@@ -1,0 +1,250 @@
+import React, { useEffect } from 'react';
+import dayjs, { Dayjs } from 'dayjs';
+import { Form, Input, Select, DatePicker, Row, Col, Button, Skeleton } from 'antd';
+import { useProjects } from '@/entities/project';
+import { useUnitsByProject } from '@/entities/unit';
+import { useContractors } from '@/entities/contractor';
+import { useUsers } from '@/entities/user';
+import { useLitigationStages } from '@/entities/litigationStage';
+import { usePersons } from '@/entities/person';
+import { useAttachmentTypes } from '@/entities/attachmentType';
+import { useCourtCase, useUpdateCourtCaseFull } from '@/entities/courtCase';
+import FileDropZone from '@/shared/ui/FileDropZone';
+import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
+import { useCaseAttachments } from './model/useCaseAttachments';
+import { useNotify } from '@/shared/hooks/useNotify';
+
+export interface CourtCaseFormAntdEditProps {
+  caseId: string;
+  onCancel?: () => void;
+  onSaved?: () => void;
+  embedded?: boolean;
+}
+
+export default function CourtCaseFormAntdEdit({
+  caseId,
+  onCancel,
+  onSaved,
+  embedded = false,
+}: CourtCaseFormAntdEditProps) {
+  const [form] = Form.useForm();
+  const { data: courtCase } = useCourtCase(caseId);
+  const { data: projects = [] } = useProjects();
+  const projectId = Form.useWatch('project_id', form);
+  const { data: units = [] } = useUnitsByProject(projectId);
+  const { data: contractors = [] } = useContractors();
+  const { data: users = [] } = useUsers();
+  const { data: stages = [] } = useLitigationStages();
+  const { data: personsList = [] } = usePersons();
+  const { data: attachmentTypes = [] } = useAttachmentTypes();
+  const update = useUpdateCourtCaseFull();
+  const notify = useNotify();
+  const attachments = useCaseAttachments({ courtCase, attachmentTypes });
+
+  useEffect(() => {
+    if (!courtCase) return;
+    form.setFieldsValue({
+      project_id: courtCase.project_id,
+      unit_ids: courtCase.unit_ids,
+      number: courtCase.number,
+      date: dayjs(courtCase.date),
+      plaintiff_id: courtCase.plaintiff_id,
+      defendant_id: courtCase.defendant_id,
+      responsible_lawyer_id: courtCase.responsible_lawyer_id ?? undefined,
+      status: courtCase.status,
+      fix_start_date: courtCase.fix_start_date ? dayjs(courtCase.fix_start_date) : null,
+      fix_end_date: courtCase.fix_end_date ? dayjs(courtCase.fix_end_date) : null,
+      description: courtCase.description,
+    });
+  }, [courtCase, form]);
+
+  const handleFiles = (files: File[]) => attachments.addFiles(files);
+
+  const onFinish = async (values: any) => {
+    if (
+      attachments.newFiles.some((f) => f.type_id == null) ||
+      attachments.remoteFiles.some((f) => (attachments.changedTypes[f.id] ?? null) == null)
+    ) {
+      notify.error('Укажите тип файла для всех документов');
+      return;
+    }
+    try {
+      const uploaded = await update.mutateAsync({
+        id: Number(caseId),
+        updates: {
+          project_id: values.project_id,
+          unit_ids: values.unit_ids,
+          number: values.number,
+          date: values.date ? (values.date as Dayjs).format('YYYY-MM-DD') : courtCase?.date,
+          plaintiff_id: values.plaintiff_id,
+          defendant_id: values.defendant_id,
+          responsible_lawyer_id: values.responsible_lawyer_id ?? null,
+          status: values.status,
+          fix_start_date: values.fix_start_date ? (values.fix_start_date as Dayjs).format('YYYY-MM-DD') : null,
+          fix_end_date: values.fix_end_date ? (values.fix_end_date as Dayjs).format('YYYY-MM-DD') : null,
+          description: values.description || '',
+        },
+        newAttachments: attachments.newFiles,
+        removedAttachmentIds: attachments.removedIds.map(Number),
+        updatedAttachments: Object.entries(attachments.changedTypes).map(([id, t]) => ({
+          id: Number(id),
+          type_id: t,
+        })),
+      });
+      if (uploaded?.length) {
+        attachments.appendRemote(
+          uploaded.map((u: any) => ({
+            id: u.id,
+            name: u.original_name || u.storage_path.split('/').pop() || 'file',
+            original_name: u.original_name ?? null,
+            path: u.storage_path,
+            url: u.file_url,
+            type: u.file_type,
+            attachment_type_id: u.attachment_type_id ?? null,
+          })),
+        );
+      }
+      attachments.markPersisted();
+      notify.success('Дело обновлено');
+      onSaved?.();
+    } catch (e: any) {
+      notify.error(e.message);
+    }
+  };
+
+  if (!courtCase) return <Skeleton active />;
+
+  return (
+    <Form
+      form={form}
+      layout="vertical"
+      onFinish={onFinish}
+      style={{ maxWidth: embedded ? 'none' : 640 }}
+      autoComplete="off"
+    >
+      <Row gutter={16}>
+        <Col span={8}>
+          <Form.Item name="project_id" label="Проект" rules={[{ required: true }]}> 
+            <Select options={projects.map((p) => ({ value: p.id, label: p.name }))} />
+          </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item name="unit_ids" label="Объекты" rules={[{ required: true }]}> 
+            <Select mode="multiple" options={units.map((u) => ({ value: u.id, label: u.name }))} disabled={!projectId} />
+          </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item name="responsible_lawyer_id" label="Ответственный юрист" rules={[{ required: true }]}> 
+            <Select options={users.map((u) => ({ value: u.id, label: u.name }))} />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={8}>
+          <Form.Item name="number" label="Номер дела" rules={[{ required: true }]}> 
+            <Input />
+          </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item name="date" label="Дата" rules={[{ required: true }]}> 
+            <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+          </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item name="status" label="Статус" rules={[{ required: true }]}> 
+            <Select options={stages.map((s) => ({ value: s.id, label: s.name }))} />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={12}>
+          <Form.Item name="plaintiff_id" label="Истец" rules={[{ required: true }]}> 
+            <Select
+              showSearch
+              optionFilterProp="label"
+              options={[
+                ...personsList.map((p) => ({ value: p.id, label: p.full_name })),
+                ...contractors.map((c) => ({ value: c.id, label: c.name })),
+              ]}
+            />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item name="defendant_id" label="Ответчик" rules={[{ required: true }]}> 
+            <Select
+              showSearch
+              optionFilterProp="label"
+              options={[
+                ...personsList.map((p) => ({ value: p.id, label: p.full_name })),
+                ...contractors.map((c) => ({ value: c.id, label: c.name })),
+              ]}
+            />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={12}>
+          <Form.Item name="fix_start_date" label="Дата начала устранения">
+            <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item
+            name="fix_end_date"
+            label="Дата завершения устранения"
+            dependencies={["fix_start_date"]}
+            rules={[
+              ({ getFieldValue }) => ({
+                validator(_, value) {
+                  const start = getFieldValue('fix_start_date');
+                  if (!value || !start || value.isSameOrAfter(start, 'day')) {
+                    return Promise.resolve();
+                  }
+                  return Promise.reject(new Error('Дата завершения меньше даты начала'));
+                },
+              }),
+            ]}
+          >
+            <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={24}>
+          <Form.Item name="description" label="Описание">
+            <Input.TextArea rows={1} />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Form.Item label="Файлы">
+        <FileDropZone onFiles={handleFiles} />
+        <AttachmentEditorTable
+          remoteFiles={attachments.remoteFiles.map((f) => ({
+            id: String(f.id),
+            name: f.name,
+            path: f.path,
+            typeId: attachments.changedTypes[f.id] ?? f.attachment_type_id,
+            typeName: f.attachment_type_name,
+            mime: f.type,
+          }))}
+          newFiles={attachments.newFiles.map((f) => ({ file: f.file, typeId: f.type_id, mime: f.file.type }))}
+          attachmentTypes={attachmentTypes}
+          onRemoveRemote={(id) => attachments.removeRemote(id)}
+          onRemoveNew={(idx) => attachments.removeNew(idx)}
+          onChangeRemoteType={(id, t) => attachments.changeRemoteType(id, t)}
+          onChangeNewType={(idx, t) => attachments.changeNewType(idx, t)}
+        />
+      </Form.Item>
+      <Form.Item style={{ textAlign: 'right' }}>
+        {onCancel && (
+          <Button style={{ marginRight: 8 }} onClick={onCancel} disabled={update.isPending}>
+            Отмена
+          </Button>
+        )}
+        <Button type="primary" htmlType="submit" loading={update.isPending}>
+          Сохранить
+        </Button>
+      </Form.Item>
+    </Form>
+  );
+}

--- a/src/features/courtCase/CourtCaseViewModal.tsx
+++ b/src/features/courtCase/CourtCaseViewModal.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Modal, Typography } from 'antd';
+import CourtCaseFormAntdEdit from './CourtCaseFormAntdEdit';
+import { useCourtCase } from '@/entities/courtCase';
+
+interface Props {
+  open: boolean;
+  caseId: string | number | null;
+  onClose: () => void;
+}
+
+/** Модальное окно просмотра судебного дела */
+export default function CourtCaseViewModal({ open, caseId, onClose }: Props) {
+  const { data: courtCase } = useCourtCase(caseId || undefined);
+  const titleText = courtCase ? `Дело №${courtCase.number}` : 'Дело';
+
+  if (!caseId) return null;
+
+  return (
+    <Modal
+      open={open}
+      onCancel={onClose}
+      footer={null}
+      width="80%"
+      destroyOnClose
+      title={<Typography.Title level={4} style={{ margin: 0 }}>{titleText}</Typography.Title>}
+    >
+      {courtCase ? (
+        <CourtCaseFormAntdEdit caseId={String(caseId)} onCancel={onClose} onSaved={onClose} embedded />
+      ) : null}
+    </Modal>
+  );
+}

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -21,6 +21,7 @@ import {
   FileTextOutlined,
   BranchesOutlined,
   SettingOutlined,
+  EyeOutlined,
 } from '@ant-design/icons';
 import {
   useCourtCases,
@@ -36,6 +37,7 @@ import CourtCaseClosedSelect from '@/features/courtCase/CourtCaseClosedSelect';
 import LinkCasesDialog from '@/features/courtCase/LinkCasesDialog';
 import ExportCourtCasesButton from '@/features/courtCase/ExportCourtCasesButton';
 import AddCourtCaseFormAntd from '@/features/courtCase/AddCourtCaseFormAntd';
+import CourtCaseViewModal from '@/features/courtCase/CourtCaseViewModal';
 import CourtCasesFilters, { CourtCasesFiltersValues } from '@/widgets/CourtCasesFilters';
 import TableColumnsDrawer from '@/widgets/TableColumnsDrawer';
 import type { TableColumnSetting } from '@/shared/types/tableColumnSetting';
@@ -65,6 +67,7 @@ export default function CourtCasesPage() {
     }
   });
   const [showColumnsDrawer, setShowColumnsDrawer] = useState(false);
+  const [viewId, setViewId] = useState<number | null>(null);
   const hideOnScroll = useRef(false);
 
   const [searchParams] = useSearchParams();
@@ -315,6 +318,9 @@ export default function CourtCasesPage() {
       width: 140,
       render: (_: any, record) => (
         <Space size="middle">
+          <Tooltip title="Просмотр">
+            <Button type="text" icon={<EyeOutlined />} onClick={() => setViewId(record.id)} />
+          </Tooltip>
           <Button type="text" icon={<PlusOutlined />} onClick={() => setLinkFor(record)} />
           {record.parent_id && (
             <Tooltip title="Исключить из связи">
@@ -429,6 +435,7 @@ export default function CourtCasesPage() {
           onClose={() => setShowColumnsDrawer(false)}
           onReset={handleResetColumns}
         />
+        <CourtCaseViewModal open={viewId !== null} caseId={viewId} onClose={() => setViewId(null)} />
         <div
           style={{ marginTop: 24 }}
           onWheel={() => {


### PR DESCRIPTION
## Summary
- create editable CourtCase form on Ant Design
- add modal for viewing court case
- allow opening view modal from table

## Testing
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_684d1280f9a4832e92e4fb940f6a17e9