### PR TITLE
Add letter viewing modal

### DIFF
--- a/src/entities/correspondence/index.ts
+++ b/src/entities/correspondence/index.ts
@@ -423,3 +423,11 @@ export function useUpdateLetter() {
     },
   });
 }
+
+export async function signedUrl(path: string, filename = ''): Promise<string> {
+  const { data, error } = await supabase.storage
+    .from(ATTACH_BUCKET)
+    .createSignedUrl(path, 60, { download: filename || undefined });
+  if (error) throw error;
+  return data.signedUrl;
+}

--- a/src/features/correspondence/LetterViewModal.tsx
+++ b/src/features/correspondence/LetterViewModal.tsx
@@ -1,0 +1,246 @@
+import React, { useEffect } from 'react';
+import dayjs, { Dayjs } from 'dayjs';
+import {
+  Modal,
+  Form,
+  Input,
+  Select,
+  DatePicker,
+  Row,
+  Col,
+  Skeleton,
+} from 'antd';
+import { useLetter, useUpdateLetter, signedUrl } from '@/entities/correspondence';
+import { useUsers } from '@/entities/user';
+import { useLetterTypes } from '@/entities/letterType';
+import { useProjects } from '@/entities/project';
+import { useUnitsByProject } from '@/entities/unit';
+import { useAttachmentTypes } from '@/entities/attachmentType';
+import { useLetterStatuses } from '@/entities/letterStatus';
+import FileDropZone from '@/shared/ui/FileDropZone';
+import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
+import { useNotify } from '@/shared/hooks/useNotify';
+import { useLetterAttachments } from './model/useLetterAttachments';
+
+export interface LetterViewModalProps {
+  letterId: string | null;
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Модальное окно просмотра и редактирования письма.
+ */
+export default function LetterViewModal({ letterId, open, onClose }: LetterViewModalProps) {
+  const [form] = Form.useForm();
+  const { data: letter, isLoading } = useLetter(letterId ?? undefined);
+  const { data: users = [] } = useUsers();
+  const { data: letterTypes = [] } = useLetterTypes();
+  const { data: projects = [] } = useProjects();
+  const projectId = Form.useWatch('project_id', form);
+  const { data: units = [] } = useUnitsByProject(projectId);
+  const { data: statuses = [] } = useLetterStatuses();
+  const { data: attachmentTypes = [] } = useAttachmentTypes();
+  const update = useUpdateLetter();
+  const notify = useNotify();
+
+  const attachments = useLetterAttachments({ letter, attachmentTypes });
+
+  useEffect(() => {
+    if (!letter) return;
+    form.setFieldsValue({
+      type: letter.type,
+      number: letter.number,
+      date: dayjs(letter.date),
+      sender: letter.sender,
+      receiver: letter.receiver,
+      subject: letter.subject,
+      content: letter.content,
+      responsible_user_id: letter.responsible_user_id ?? undefined,
+      letter_type_id: letter.letter_type_id ?? null,
+      project_id: letter.project_id ?? null,
+      unit_ids: letter.unit_ids,
+      status_id: letter.status_id ?? null,
+    });
+  }, [letter, form]);
+
+  const handleFiles = (files: File[]) => attachments.addFiles(files);
+
+  const submit = async (values: any) => {
+    if (
+      attachments.newFiles.some((f) => f.type_id == null) ||
+      attachments.remoteFiles.some(
+        (f) => (attachments.changedTypes[String(f.id)] ?? null) == null,
+      )
+    ) {
+      notify.error('Укажите тип файла для всех документов');
+      return;
+    }
+    try {
+      const uploaded = await update.mutateAsync({
+        id: Number(letterId),
+        updates: {
+          number: values.number,
+          letter_type_id: values.letter_type_id ?? null,
+          status_id: values.status_id ?? null,
+          letter_date: values.date ? (values.date as Dayjs).format('YYYY-MM-DD') : letter?.date,
+          sender: values.sender,
+          receiver: values.receiver,
+          subject: values.subject,
+          content: values.content,
+          responsible_user_id: values.responsible_user_id ?? null,
+          project_id: values.project_id ?? null,
+          unit_ids: values.unit_ids ?? [],
+        },
+        newAttachments: attachments.newFiles,
+        removedAttachmentIds: attachments.removedIds.map(Number),
+        updatedAttachments: Object.entries(attachments.changedTypes).map(([id, t]) => ({
+          id: Number(id),
+          type_id: t,
+        })),
+      });
+      if (uploaded?.length) {
+        attachments.appendRemote(
+          uploaded.map((u: any) => ({
+            id: u.id,
+            name:
+              u.original_name ||
+              (() => {
+                try {
+                  return decodeURIComponent(
+                    u.storage_path.split('/').pop()?.replace(/^\d+_/, '') || u.storage_path,
+                  );
+                } catch {
+                  return u.storage_path;
+                }
+              })(),
+            original_name: u.original_name ?? null,
+            path: u.storage_path,
+            url: u.file_url,
+            type: u.file_type,
+            attachment_type_id: u.attachment_type_id ?? null,
+          })),
+        );
+      }
+      attachments.markPersisted();
+      notify.success('Письмо обновлено');
+      onClose();
+    } catch (e: any) {
+      notify.error(e.message);
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      onCancel={onClose}
+      onOk={() => form.submit()}
+      title="Просмотр письма"
+      width={720}
+      okText="Сохранить"
+      cancelText="Закрыть"
+      afterClose={() => form.resetFields()}
+    >
+      {isLoading || !letter ? (
+        <Skeleton active />
+      ) : (
+        <Form form={form} layout="vertical" onFinish={submit}>
+          <Row gutter={16}>
+            <Col span={8}>
+              <Form.Item name="type" label="Тип">
+                <Select>
+                  <Select.Option value="incoming">Входящее</Select.Option>
+                  <Select.Option value="outgoing">Исходящее</Select.Option>
+                </Select>
+              </Form.Item>
+            </Col>
+            <Col span={8}>
+              <Form.Item name="number" label="Номер" rules={[{ required: true }]}> 
+                <Input />
+              </Form.Item>
+            </Col>
+            <Col span={8}>
+              <Form.Item name="date" label="Дата" rules={[{ required: true }]}> 
+                <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+              </Form.Item>
+            </Col>
+          </Row>
+          <Row gutter={16}>
+            <Col span={12}>
+              <Form.Item name="sender" label="Отправитель">
+                <Input />
+              </Form.Item>
+            </Col>
+            <Col span={12}>
+              <Form.Item name="receiver" label="Получатель">
+                <Input />
+              </Form.Item>
+            </Col>
+          </Row>
+          <Row gutter={16}>
+            <Col span={12}>
+              <Form.Item name="letter_type_id" label="Категория">
+                <Select allowClear options={letterTypes.map((t) => ({ value: t.id, label: t.name }))} />
+              </Form.Item>
+            </Col>
+            <Col span={12}>
+              <Form.Item name="status_id" label="Статус">
+                <Select allowClear options={statuses.map((s) => ({ value: s.id, label: s.name }))} />
+              </Form.Item>
+            </Col>
+          </Row>
+          <Row gutter={16}>
+            <Col span={12}>
+              <Form.Item name="project_id" label="Проект">
+                <Select allowClear options={projects.map((p) => ({ value: p.id, label: p.name }))} />
+              </Form.Item>
+            </Col>
+            <Col span={12}>
+              <Form.Item name="unit_ids" label="Объекты">
+                <Select
+                  mode="multiple"
+                  options={units.map((u) => ({ value: u.id, label: u.name }))}
+                  disabled={!projectId}
+                />
+              </Form.Item>
+            </Col>
+          </Row>
+          <Row gutter={16}>
+            <Col span={24}>
+              <Form.Item name="responsible_user_id" label="Ответственный">
+                <Select allowClear options={users.map((u) => ({ value: u.id, label: u.name }))} />
+              </Form.Item>
+            </Col>
+          </Row>
+          <Form.Item name="subject" label="Тема">
+            <Input />
+          </Form.Item>
+          <Form.Item name="content" label="Содержание">
+            <Input.TextArea rows={2} />
+          </Form.Item>
+          <Form.Item label="Файлы">
+            <FileDropZone onFiles={handleFiles} />
+            <AttachmentEditorTable
+              remoteFiles={attachments.remoteFiles.map((f) => ({
+                id: String(f.id),
+                name: f.name,
+                path: f.path,
+                typeId: attachments.changedTypes[String(f.id)] ?? f.attachment_type_id,
+                typeName: f.attachment_type_name,
+                mime: f.type,
+              }))}
+              newFiles={attachments.newFiles.map((f) => ({ file: f.file, typeId: f.type_id, mime: f.file.type }))}
+              attachmentTypes={attachmentTypes}
+              onRemoveRemote={(id) => attachments.removeRemote(id)}
+              onRemoveNew={(idx) => attachments.removeNew(idx)}
+              onChangeRemoteType={(id, t) => attachments.changeRemoteType(id, t)}
+              onChangeNewType={(idx, t) => attachments.changeNewType(idx, t)}
+              getSignedUrl={(path, name) => signedUrl(path, name)}
+            />
+          </Form.Item>
+        </Form>
+      )}
+    </Modal>
+  );
+}
+

--- a/src/features/correspondence/model/useLetterAttachments.ts
+++ b/src/features/correspondence/model/useLetterAttachments.ts
@@ -1,0 +1,134 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { AttachmentType } from '@/shared/types/attachmentType';
+import type { CorrespondenceLetter } from '@/shared/types/correspondence';
+import type { RemoteLetterFile, NewLetterFile } from '@/shared/types/letterFile';
+
+/**
+ * Хук управления вложениями письма.
+ */
+export function useLetterAttachments(options: {
+  letter?: (CorrespondenceLetter & { attachments?: any[] }) | null;
+  attachmentTypes: AttachmentType[];
+}) {
+  const { letter, attachmentTypes } = options;
+
+  const [remoteFiles, setRemoteFiles] = useState<RemoteLetterFile[]>([]);
+  const [changedTypes, setChangedTypes] = useState<Record<string, number | null>>({});
+  const [initialTypes, setInitialTypes] = useState<Record<string, number | null>>({});
+  const [newFiles, setNewFiles] = useState<NewLetterFile[]>([]);
+  const [removedIds, setRemovedIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!letter) return;
+    const attachmentsWithType = (letter.attachments || []).map((file: any) => {
+      const typeObj = attachmentTypes.find((t) => t.id === file.attachment_type_id);
+      const storagePath = file.storage_path ?? file.path;
+      const fileUrl = file.file_url ?? file.url ?? '';
+      const fileType = file.file_type ?? file.type ?? '';
+      const originalName = file.original_name ?? null;
+      const name =
+        originalName ||
+        (storagePath ? storagePath.split('/').pop() : file.name) ||
+        'file';
+      return {
+        id: file.id,
+        name,
+        original_name: originalName,
+        path: storagePath ?? '',
+        url: fileUrl,
+        type: fileType,
+        attachment_type_id: file.attachment_type_id ?? null,
+        attachment_type_name: typeObj?.name || fileType || '',
+      } as RemoteLetterFile;
+    });
+    setRemoteFiles(attachmentsWithType);
+    const map: Record<string, number | null> = {};
+    attachmentsWithType.forEach((f) => {
+      map[String(f.id)] = f.attachment_type_id ?? null;
+    });
+    setChangedTypes(map);
+    setInitialTypes(map);
+  }, [letter, attachmentTypes]);
+
+  const addFiles = useCallback(
+    (files: File[]) =>
+      setNewFiles((p) => [...p, ...files.map((f) => ({ file: f, type_id: null }))]),
+    [],
+  );
+
+  const removeNew = useCallback(
+    (idx: number) => setNewFiles((p) => p.filter((_, i) => i !== idx)),
+    [],
+  );
+
+  const removeRemote = useCallback((id: string) => {
+    setRemoteFiles((p) => p.filter((f) => String(f.id) !== String(id)));
+    setRemovedIds((p) => [...p, id]);
+  }, []);
+
+  const changeRemoteType = useCallback(
+    (id: string, type: number | null) =>
+      setChangedTypes((p) => ({ ...p, [id]: type })),
+    [],
+  );
+
+  const changeNewType = useCallback(
+    (idx: number, type: number | null) =>
+      setNewFiles((p) => p.map((f, i) => (i === idx ? { ...f, type_id: type } : f))),
+    [],
+  );
+
+  const appendRemote = useCallback((files: RemoteLetterFile[]) => {
+    setRemoteFiles((p) => [...p, ...files]);
+    setChangedTypes((prev) => {
+      const copy = { ...prev };
+      files.forEach((f) => {
+        copy[String(f.id)] = f.attachment_type_id ?? null;
+      });
+      return copy;
+    });
+    setInitialTypes((prev) => {
+      const copy = { ...prev };
+      files.forEach((f) => {
+        copy[String(f.id)] = f.attachment_type_id ?? null;
+      });
+      return copy;
+    });
+  }, []);
+
+  const markPersisted = useCallback(() => {
+    setNewFiles([]);
+    setRemovedIds([]);
+    setInitialTypes((prev) => ({ ...prev, ...changedTypes }));
+  }, [changedTypes]);
+
+  const attachmentsChanged =
+    newFiles.length > 0 ||
+    removedIds.length > 0 ||
+    Object.keys(changedTypes).some((id) => changedTypes[id] !== initialTypes[id]);
+
+  const reset = useCallback(() => {
+    setNewFiles([]);
+    setRemoteFiles([]);
+    setChangedTypes({});
+    setInitialTypes({});
+    setRemovedIds([]);
+  }, []);
+
+  return {
+    remoteFiles,
+    newFiles,
+    changedTypes,
+    removedIds,
+    addFiles,
+    removeNew,
+    removeRemote,
+    changeRemoteType,
+    changeNewType,
+    appendRemote,
+    markPersisted,
+    attachmentsChanged,
+    reset,
+  };
+}
+

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -21,6 +21,7 @@ import { AddLetterFormData } from '@/features/correspondence/AddLetterForm';
 import AddLetterForm from '@/features/correspondence/AddLetterForm';
 import LinkLettersDialog from '@/features/correspondence/LinkLettersDialog';
 import ExportLettersButton from '@/features/correspondence/ExportLettersButton';
+import LetterViewModal from '@/features/correspondence/LetterViewModal';
 import CorrespondenceTable from '@/widgets/CorrespondenceTable';
 import CorrespondenceFilters from '@/widgets/CorrespondenceFilters';
 import TableColumnsDrawer from '@/widgets/TableColumnsDrawer';
@@ -115,6 +116,7 @@ export default function CorrespondencePage() {
     responsible_user_id: searchParams.get('responsible_user_id') || undefined,
   };
   const [linkFor, setLinkFor] = useState<CorrespondenceLetter | null>(null);
+  const [viewLetterId, setViewLetterId] = useState<string | null>(null);
   const [showAddForm, setShowAddForm] = useState(false);
   const hideOnScroll = useRef(false);
   const LS_FILTERS_VISIBLE_KEY = 'correspondenceFiltersVisible';
@@ -554,6 +556,11 @@ export default function CorrespondencePage() {
           onClose={() => setShowColumnsDrawer(false)}
           onReset={handleResetColumns}
         />
+        <LetterViewModal
+          open={!!viewLetterId}
+          letterId={viewLetterId}
+          onClose={() => setViewLetterId(null)}
+        />
 
         <div
           style={{ marginTop: 24 }}
@@ -586,6 +593,7 @@ export default function CorrespondencePage() {
             onDelete={handleDelete}
             onAddChild={setLinkFor}
             onUnlink={handleUnlink}
+            onView={setViewLetterId}
             users={users}
             letterTypes={letterTypes}
             projects={projects}

--- a/src/widgets/CorrespondenceTable.tsx
+++ b/src/widgets/CorrespondenceTable.tsx
@@ -2,7 +2,14 @@ import React, { useMemo, useState, useEffect } from 'react';
 import dayjs from 'dayjs';
 import { Table, Space, Button, Popconfirm, Tag, Tooltip } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
-import { DeleteOutlined, PlusOutlined, MailOutlined, BranchesOutlined, LinkOutlined } from '@ant-design/icons';
+import {
+  DeleteOutlined,
+  PlusOutlined,
+  MailOutlined,
+  BranchesOutlined,
+  LinkOutlined,
+  EyeOutlined,
+} from '@ant-design/icons';
 import { CorrespondenceLetter } from '@/shared/types/correspondence';
 import LetterStatusSelect from '@/features/correspondence/LetterStatusSelect';
 
@@ -13,6 +20,7 @@ interface CorrespondenceTableProps {
   onDelete: (id: string) => void;
   onAddChild: (parent: CorrespondenceLetter) => void;
   onUnlink: (letterId: string) => void; // <--- новый проп
+  onView: (letterId: string) => void;
   /** Колонки таблицы. Если не переданы, используется набор по умолчанию */
   columns?: ColumnsType<any>;
   users: Option[];
@@ -31,6 +39,7 @@ export default function CorrespondenceTable({
                                               onDelete,
                                               onAddChild,
                                               onUnlink,
+                                              onView,
                                               columns: columnsProp,
                                               users,
                                               letterTypes,
@@ -233,6 +242,9 @@ export default function CorrespondenceTable({
       render: (_: any, record: CorrespondenceLetter) => (
           <Space size="middle">
             <Button type="text" icon={<PlusOutlined />} onClick={() => onAddChild(record)} />
+            <Tooltip title="Просмотр">
+              <Button type="text" icon={<EyeOutlined />} onClick={() => onView(record.id)} />
+            </Tooltip>
             {/* Только для связанных писем — показать кнопку "исключить" */}
             {record.parent_id && (
                 <Tooltip title="Исключить из связи">
@@ -263,7 +275,7 @@ export default function CorrespondenceTable({
       ),
     },
   ],
-    [onAddChild, onUnlink, onDelete],
+    [onAddChild, onUnlink, onDelete, onView],
   );
 
   const columns = columnsProp ?? defaultColumns;


### PR DESCRIPTION
## Summary
- add `LetterViewModal` to view/edit letters with attachments
- manage letter attachments with `useLetterAttachments`
- support signed URLs for letter files
- integrate view modal into correspondence table
- add open icon in correspondence table

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d1ddf3800832e9061b3e4e4925eb1