### PR TITLE
Add letter view modal

### DIFF
--- a/src/entities/attachment.js
+++ b/src/entities/attachment.js
@@ -188,4 +188,17 @@ export async function getAttachmentsByIds(ids) {
     return data ?? [];
 }
 
+/**
+ * Сформировать временную ссылку на скачивание файла.
+ * @param {string} path путь к файлу в хранилище
+ * @param {string} [filename] имя скачиваемого файла
+ */
+export async function signedUrl(path, filename = '') {
+    const { data, error } = await supabase.storage
+        .from(ATTACH_BUCKET)
+        .createSignedUrl(path, 60, { download: filename || undefined });
+    if (error) throw error;
+    return data.signedUrl;
+}
+
 export { ATTACH_BUCKET };

--- a/src/features/correspondence/LetterFormAntdEdit.tsx
+++ b/src/features/correspondence/LetterFormAntdEdit.tsx
@@ -1,0 +1,249 @@
+import React, { useEffect } from 'react';
+import dayjs from 'dayjs';
+import {
+  Form,
+  Input,
+  Select,
+  DatePicker,
+  Button,
+  Row,
+  Col,
+  AutoComplete,
+  Skeleton,
+} from 'antd';
+import { useUsers } from '@/entities/user';
+import { useLetterTypes } from '@/entities/letterType';
+import { useProjects } from '@/entities/project';
+import { useUnitsByProject } from '@/entities/unit';
+import { useLetterStatuses } from '@/entities/letterStatus';
+import { useAttachmentTypes } from '@/entities/attachmentType';
+import { useContractors } from '@/entities/contractor';
+import { usePersons } from '@/entities/person';
+import { useLetter, useUpdateLetter } from '@/entities/correspondence';
+import { useNotify } from '@/shared/hooks/useNotify';
+import FileDropZone from '@/shared/ui/FileDropZone';
+import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
+import { useLetterAttachments } from './model/useLetterAttachments';
+import { signedUrl } from '@/entities/attachment';
+
+interface Props {
+  letterId: string;
+  onCancel?: () => void;
+  onSaved?: () => void;
+  embedded?: boolean;
+}
+
+/** Форма просмотра и редактирования письма */
+export default function LetterFormAntdEdit({
+  letterId,
+  onCancel,
+  onSaved,
+  embedded = false,
+}: Props) {
+  const [form] = Form.useForm();
+  const { data: letter } = useLetter(letterId);
+  const update = useUpdateLetter();
+  const notify = useNotify();
+
+  const { data: users = [] } = useUsers();
+  const { data: letterTypes = [] } = useLetterTypes();
+  const { data: projects = [] } = useProjects();
+  const { data: statuses = [] } = useLetterStatuses();
+  const { data: attachmentTypes = [] } = useAttachmentTypes();
+  const { data: contractors = [] } = useContractors();
+  const { data: persons = [] } = usePersons();
+
+  const projectId = Form.useWatch('project_id', form);
+  const { data: units = [] } = useUnitsByProject(projectId);
+
+  const attachments = useLetterAttachments({ letter, attachmentTypes });
+
+  useEffect(() => {
+    if (!letter) return;
+    form.setFieldsValue({
+      number: letter.number,
+      date: dayjs(letter.date),
+      sender: letter.sender,
+      receiver: letter.receiver,
+      subject: letter.subject,
+      content: letter.content,
+      project_id: letter.project_id ?? null,
+      unit_ids: letter.unit_ids,
+      responsible_user_id: letter.responsible_user_id ?? undefined,
+      letter_type_id: letter.letter_type_id ?? undefined,
+      status_id: letter.status_id ?? undefined,
+    });
+  }, [letter, form]);
+
+  const contactOptions = React.useMemo(
+    () => [
+      ...contractors.map((c) => ({ value: c.name })),
+      ...persons.map((p) => ({ value: p.full_name })),
+    ],
+    [contractors, persons],
+  );
+
+  const handleFiles = (files: File[]) => attachments.addFiles(files);
+
+  const handleSubmit = async (values: any) => {
+    if (
+      attachments.newFiles.some((f) => f.type_id == null) ||
+      attachments.remoteFiles.some(
+        (f) => (attachments.changedTypes[f.id] ?? null) == null,
+      )
+    ) {
+      notify.error('Выберите тип файла для всех документов');
+      return;
+    }
+
+    try {
+      await update.mutateAsync({
+        id: Number(letterId),
+        newAttachments: attachments.newFiles,
+        removedAttachmentIds: attachments.removedIds.map((id) => Number(id)),
+        updatedAttachments: Object.entries(attachments.changedTypes).map(
+          ([id, type]) => ({ id: Number(id), type_id: type }),
+        ),
+        updates: {
+          number: values.number,
+          letter_type_id: values.letter_type_id ?? null,
+          status_id: values.status_id ?? null,
+          letter_date: values.date ? values.date.toISOString() : null,
+          subject: values.subject,
+          content: values.content,
+          sender: values.sender,
+          receiver: values.receiver,
+          responsible_user_id: values.responsible_user_id ?? null,
+          project_id: values.project_id ?? null,
+          unit_ids: values.unit_ids ?? [],
+        },
+      });
+      attachments.markPersisted();
+      notify.success('Письмо обновлено');
+      onSaved?.();
+    } catch (e: any) {
+      notify.error(e.message);
+    }
+  };
+
+  if (!letter) return <Skeleton active />;
+
+  return (
+    <Form
+      form={form}
+      layout="vertical"
+      onFinish={handleSubmit}
+      style={{ maxWidth: embedded ? 'none' : 640 }}
+      autoComplete="off"
+    >
+      <Row gutter={16}>
+        <Col span={6}>
+          <Form.Item name="number" label="Номер" rules={[{ required: true }]}>
+            <Input />
+          </Form.Item>
+        </Col>
+        <Col span={6}>
+          <Form.Item name="date" label="Дата" rules={[{ required: true }]}>
+            <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+          </Form.Item>
+        </Col>
+        <Col span={6}>
+          <Form.Item name="status_id" label="Статус">
+            <Select
+              allowClear
+              options={statuses.map((s) => ({ value: s.id, label: s.name }))}
+            />
+          </Form.Item>
+        </Col>
+        <Col span={6}>
+          <Form.Item name="responsible_user_id" label="Ответственный">
+            <Select
+              showSearch
+              allowClear
+              options={users.map((u) => ({ value: u.id, label: u.name }))}
+            />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={6}>
+          <Form.Item name="letter_type_id" label="Категория">
+            <Select
+              allowClear
+              options={letterTypes.map((t) => ({ value: t.id, label: t.name }))}
+            />
+          </Form.Item>
+        </Col>
+        <Col span={6}>
+          <Form.Item name="project_id" label="Проект">
+            <Select
+              allowClear
+              options={projects.map((p) => ({ value: p.id, label: p.name }))}
+            />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item name="unit_ids" label="Объекты">
+            <Select
+              mode="multiple"
+              disabled={!projectId}
+              options={units.map((u) => ({ value: u.id, label: u.name }))}
+            />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={12}>
+          <Form.Item name="sender" label="Отправитель">
+            <AutoComplete options={contactOptions} allowClear />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item name="receiver" label="Получатель">
+            <AutoComplete options={contactOptions} allowClear />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Form.Item name="subject" label="Тема">
+        <Input />
+      </Form.Item>
+      <Form.Item name="content" label="Содержание">
+        <Input.TextArea rows={2} />
+      </Form.Item>
+      <Form.Item label="Вложения">
+        <FileDropZone onFiles={handleFiles} />
+        <AttachmentEditorTable
+          remoteFiles={attachments.remoteFiles.map((f) => ({
+            id: String(f.id),
+            name: f.name,
+            path: f.path,
+            typeId: attachments.changedTypes[f.id] ?? f.attachment_type_id,
+            typeName: f.attachment_type_name,
+            mime: f.type,
+          }))}
+          newFiles={attachments.newFiles.map((f) => ({
+            file: f.file,
+            typeId: f.type_id,
+            mime: f.file.type,
+          }))}
+          attachmentTypes={attachmentTypes}
+          onRemoveRemote={(id) => attachments.removeRemote(id)}
+          onRemoveNew={(idx) => attachments.removeNew(idx)}
+          onChangeRemoteType={(id, t) => attachments.changeRemoteType(id, t)}
+          onChangeNewType={(idx, t) => attachments.changeNewType(idx, t)}
+          getSignedUrl={(path, name) => signedUrl(path, name)}
+        />
+      </Form.Item>
+      <Form.Item style={{ textAlign: 'right' }}>
+        {onCancel && (
+          <Button style={{ marginRight: 8 }} onClick={onCancel} disabled={update.isPending}>
+            Отмена
+          </Button>
+        )}
+        <Button type="primary" htmlType="submit" loading={update.isPending}>
+          Сохранить
+        </Button>
+      </Form.Item>
+    </Form>
+  );
+}

--- a/src/features/correspondence/LetterViewModal.tsx
+++ b/src/features/correspondence/LetterViewModal.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Modal, Skeleton, Typography } from 'antd';
+import { useLetter } from '@/entities/correspondence';
+import LetterFormAntdEdit from './LetterFormAntdEdit';
+
+interface Props {
+  open: boolean;
+  letterId: string | number | null;
+  onClose: () => void;
+}
+
+/** Модальное окно просмотра письма */
+export default function LetterViewModal({ open, letterId, onClose }: Props) {
+  const { data: letter } = useLetter(letterId ?? undefined);
+  const titleText = letter ? `Письмо №${letter.number}` : 'Письмо';
+
+  return (
+    <Modal
+      open={open}
+      onCancel={onClose}
+      footer={null}
+      width="80%"
+      title={
+        <Typography.Title level={4} style={{ margin: 0 }}>
+          {titleText}
+        </Typography.Title>
+      }
+    >
+      {letter ? (
+        <LetterFormAntdEdit
+          embedded
+          letterId={String(letterId)}
+          onCancel={onClose}
+          onSaved={onClose}
+        />
+      ) : (
+        <Skeleton active />
+      )}
+    </Modal>
+  );
+}

--- a/src/features/correspondence/model/useLetterAttachments.ts
+++ b/src/features/correspondence/model/useLetterAttachments.ts
@@ -1,0 +1,125 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { AttachmentType } from '@/shared/types/attachmentType';
+import type { CorrespondenceLetter } from '@/shared/types/correspondence';
+import type { RemoteLetterFile, NewLetterFile } from '@/shared/types/letterFile';
+
+/**
+ * Хук управления вложениями письма.
+ */
+export function useLetterAttachments(options: {
+  letter?: CorrespondenceLetter | null;
+  attachmentTypes: AttachmentType[];
+}) {
+  const { letter, attachmentTypes } = options;
+
+  const [remoteFiles, setRemoteFiles] = useState<RemoteLetterFile[]>([]);
+  const [changedTypes, setChangedTypes] = useState<Record<string, number | null>>({});
+  const [initialTypes, setInitialTypes] = useState<Record<string, number | null>>({});
+  const [newFiles, setNewFiles] = useState<NewLetterFile[]>([]);
+  const [removedIds, setRemovedIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!letter) return;
+    const withType = (letter.attachments || []).map((f) => {
+      const t = attachmentTypes.find((at) => at.id === f.attachment_type_id);
+      return {
+        id: f.id,
+        name: f.name,
+        original_name: (f as any).original_name ?? null,
+        path: f.storage_path,
+        url: f.file_url,
+        type: f.file_type,
+        attachment_type_id: f.attachment_type_id ?? null,
+        attachment_type_name: t?.name || f.file_type || '',
+      } as RemoteLetterFile;
+    });
+    setRemoteFiles(withType);
+    const map: Record<string, number | null> = {};
+    withType.forEach((f) => {
+      map[f.id] = f.attachment_type_id ?? null;
+    });
+    setChangedTypes(map);
+    setInitialTypes(map);
+  }, [letter, attachmentTypes]);
+
+  const addFiles = useCallback(
+    (files: File[]) =>
+      setNewFiles((p) => [...p, ...files.map((f) => ({ file: f, type_id: null }))]),
+    [],
+  );
+
+  const removeNew = useCallback(
+    (idx: number) => setNewFiles((p) => p.filter((_, i) => i !== idx)),
+    [],
+  );
+
+  const removeRemote = useCallback((id: string) => {
+    setRemoteFiles((p) => p.filter((f) => String(f.id) !== String(id)));
+    setRemovedIds((p) => [...p, id]);
+  }, []);
+
+  const changeRemoteType = useCallback(
+    (id: string, type: number | null) =>
+      setChangedTypes((p) => ({ ...p, [id]: type })),
+    [],
+  );
+
+  const changeNewType = useCallback(
+    (idx: number, type: number | null) =>
+      setNewFiles((p) => p.map((f, i) => (i === idx ? { ...f, type_id: type } : f))),
+    [],
+  );
+
+  const appendRemote = useCallback((files: RemoteLetterFile[]) => {
+    setRemoteFiles((p) => [...p, ...files]);
+    setChangedTypes((prev) => {
+      const copy = { ...prev };
+      files.forEach((f) => {
+        copy[f.id] = f.attachment_type_id ?? null;
+      });
+      return copy;
+    });
+    setInitialTypes((prev) => {
+      const copy = { ...prev };
+      files.forEach((f) => {
+        copy[f.id] = f.attachment_type_id ?? null;
+      });
+      return copy;
+    });
+  }, []);
+
+  const markPersisted = useCallback(() => {
+    setNewFiles([]);
+    setRemovedIds([]);
+    setInitialTypes((prev) => ({ ...prev, ...changedTypes }));
+  }, [changedTypes]);
+
+  const attachmentsChanged =
+    newFiles.length > 0 ||
+    removedIds.length > 0 ||
+    Object.keys(changedTypes).some((id) => changedTypes[id] !== initialTypes[id]);
+
+  const resetAll = useCallback(() => {
+    setNewFiles([]);
+    setRemoteFiles([]);
+    setChangedTypes({});
+    setInitialTypes({});
+    setRemovedIds([]);
+  }, []);
+
+  return {
+    remoteFiles,
+    newFiles,
+    changedTypes,
+    removedIds,
+    addFiles,
+    removeNew,
+    removeRemote,
+    changeRemoteType,
+    changeNewType,
+    appendRemote,
+    markPersisted,
+    attachmentsChanged,
+    reset: resetAll,
+  };
+}

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -24,6 +24,7 @@ import ExportLettersButton from '@/features/correspondence/ExportLettersButton';
 import CorrespondenceTable from '@/widgets/CorrespondenceTable';
 import CorrespondenceFilters from '@/widgets/CorrespondenceFilters';
 import TableColumnsDrawer from '@/widgets/TableColumnsDrawer';
+import LetterViewModal from '@/features/correspondence/LetterViewModal';
 import LetterStatusSelect from '@/features/correspondence/LetterStatusSelect';
 import type { TableColumnSetting } from '@/shared/types/tableColumnSetting';
 import type { ColumnsType } from 'antd/es/table';
@@ -117,6 +118,7 @@ export default function CorrespondencePage() {
   const [linkFor, setLinkFor] = useState<CorrespondenceLetter | null>(null);
   const [showAddForm, setShowAddForm] = useState(false);
   const hideOnScroll = useRef(false);
+  const [viewId, setViewId] = useState<number | null>(null);
   const LS_FILTERS_VISIBLE_KEY = 'correspondenceFiltersVisible';
   const LS_COLUMNS_KEY = 'correspondenceColumns';
   const [showFilters, setShowFilters] = useState(() => {
@@ -586,6 +588,7 @@ export default function CorrespondencePage() {
             onDelete={handleDelete}
             onAddChild={setLinkFor}
             onUnlink={handleUnlink}
+            onView={(id) => setViewId(Number(id))}
             users={users}
             letterTypes={letterTypes}
             projects={projects}
@@ -600,6 +603,11 @@ export default function CorrespondencePage() {
             Готовых писем к выгрузке: {readyToExport}
           </Typography.Text>
         </div>
+        <LetterViewModal
+          open={viewId !== null}
+          letterId={viewId}
+          onClose={() => setViewId(null)}
+        />
       </>
     </ConfigProvider>
   );

--- a/src/widgets/CorrespondenceTable.tsx
+++ b/src/widgets/CorrespondenceTable.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState, useEffect } from 'react';
 import dayjs from 'dayjs';
 import { Table, Space, Button, Popconfirm, Tag, Tooltip } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
-import { DeleteOutlined, PlusOutlined, MailOutlined, BranchesOutlined, LinkOutlined } from '@ant-design/icons';
+import { DeleteOutlined, PlusOutlined, MailOutlined, BranchesOutlined, LinkOutlined, EyeOutlined } from '@ant-design/icons';
 import { CorrespondenceLetter } from '@/shared/types/correspondence';
 import LetterStatusSelect from '@/features/correspondence/LetterStatusSelect';
 
@@ -13,6 +13,7 @@ interface CorrespondenceTableProps {
   onDelete: (id: string) => void;
   onAddChild: (parent: CorrespondenceLetter) => void;
   onUnlink: (letterId: string) => void; // <--- новый проп
+  onView?: (id: string) => void;
   /** Колонки таблицы. Если не переданы, используется набор по умолчанию */
   columns?: ColumnsType<any>;
   users: Option[];
@@ -31,6 +32,7 @@ export default function CorrespondenceTable({
                                               onDelete,
                                               onAddChild,
                                               onUnlink,
+                                              onView,
                                               columns: columnsProp,
                                               users,
                                               letterTypes,
@@ -232,6 +234,15 @@ export default function CorrespondenceTable({
       width: 150,
       render: (_: any, record: CorrespondenceLetter) => (
           <Space size="middle">
+            {onView && (
+              <Tooltip title="Просмотр">
+                <Button
+                  type="text"
+                  icon={<EyeOutlined />}
+                  onClick={() => onView(record.id)}
+                />
+              </Tooltip>
+            )}
             <Button type="text" icon={<PlusOutlined />} onClick={() => onAddChild(record)} />
             {/* Только для связанных писем — показать кнопку "исключить" */}
             {record.parent_id && (
@@ -263,7 +274,7 @@ export default function CorrespondenceTable({
       ),
     },
   ],
-    [onAddChild, onUnlink, onDelete],
+    [onView, onAddChild, onUnlink, onDelete],
   );
 
   const columns = columnsProp ?? defaultColumns;


### PR DESCRIPTION
## Summary
- add `LetterFormAntdEdit` and `LetterViewModal` for viewing and editing correspondence
- support attachment editing via `useLetterAttachments`
- extend correspondence table with eye icon
- show letter view modal on correspondence page
- provide signed URL helper in `attachment.js`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684d254a2850832eb16a8640eee71e6d