### PR TITLE
Add letter view modal with editing

### DIFF
--- a/src/entities/correspondence/index.ts
+++ b/src/entities/correspondence/index.ts
@@ -423,3 +423,11 @@ export function useUpdateLetter() {
     },
   });
 }
+
+export async function signedUrl(path: string, filename = ''): Promise<string> {
+  const { data, error } = await supabase.storage
+    .from(ATTACH_BUCKET)
+    .createSignedUrl(path, 60, { download: filename || undefined });
+  if (error) throw error;
+  return data.signedUrl;
+}

--- a/src/features/correspondence/LetterFormAntdEdit.tsx
+++ b/src/features/correspondence/LetterFormAntdEdit.tsx
@@ -1,0 +1,192 @@
+import React, { useEffect } from 'react';
+import dayjs, { Dayjs } from 'dayjs';
+import { Form, Input, Select, DatePicker, Row, Col, Button, Skeleton } from 'antd';
+import { useUsers } from '@/entities/user';
+import { useLetterTypes } from '@/entities/letterType';
+import { useProjects } from '@/entities/project';
+import { useUnitsByProject } from '@/entities/unit';
+import { useAttachmentTypes } from '@/entities/attachmentType';
+import { useLetter, useUpdateLetter, signedUrl } from '@/entities/correspondence';
+import FileDropZone from '@/shared/ui/FileDropZone';
+import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
+import { useLetterAttachments } from './model/useLetterAttachments';
+import { useNotify } from '@/shared/hooks/useNotify';
+
+export interface LetterFormAntdEditProps {
+  letterId: string;
+  onCancel?: () => void;
+  onSaved?: () => void;
+  embedded?: boolean;
+}
+
+export default function LetterFormAntdEdit({ letterId, onCancel, onSaved, embedded = false }: LetterFormAntdEditProps) {
+  const [form] = Form.useForm();
+  const { data: letter } = useLetter(letterId);
+  const { data: users = [] } = useUsers();
+  const { data: letterTypes = [] } = useLetterTypes();
+  const { data: projects = [] } = useProjects();
+  const projectId = Form.useWatch('project_id', form);
+  const { data: units = [] } = useUnitsByProject(projectId); 
+  const { data: attachmentTypes = [] } = useAttachmentTypes();
+  const update = useUpdateLetter();
+  const notify = useNotify();
+  const attachments = useLetterAttachments({ letter, attachmentTypes });
+
+  useEffect(() => {
+    if (!letter) return;
+    form.setFieldsValue({
+      project_id: letter.project_id,
+      unit_ids: letter.unit_ids,
+      number: letter.number,
+      date: dayjs(letter.date),
+      sender: letter.sender,
+      receiver: letter.receiver,
+      responsible_user_id: letter.responsible_user_id ?? undefined,
+      letter_type_id: letter.letter_type_id ?? undefined,
+      subject: letter.subject,
+      content: letter.content,
+    });
+  }, [letter, form]);
+
+  const handleFiles = (files: File[]) => attachments.addFiles(files);
+
+  const onFinish = async (values: any) => {
+    if (
+      attachments.newFiles.some((f) => f.type_id == null) ||
+      attachments.remoteFiles.some((f) => (attachments.changedTypes[f.id] ?? null) == null)
+    ) {
+      notify.error('Укажите тип файла для всех вложений');
+      return;
+    }
+    try {
+      const uploaded = await update.mutateAsync({
+        id: Number(letterId),
+        updates: {
+          project_id: values.project_id,
+          unit_ids: values.unit_ids,
+          number: values.number,
+          letter_type_id: values.letter_type_id,
+          letter_date: values.date ? (values.date as Dayjs).format('YYYY-MM-DD') : letter?.date,
+          sender: values.sender,
+          receiver: values.receiver,
+          subject: values.subject,
+          content: values.content,
+          responsible_user_id: values.responsible_user_id ?? null,
+        } as any,
+        newAttachments: attachments.newFiles,
+        removedAttachmentIds: attachments.removedIds.map(Number),
+        updatedAttachments: Object.entries(attachments.changedTypes).map(([id, t]) => ({
+          id: Number(id),
+          type_id: t,
+        })),
+      });
+      if (uploaded?.length) {
+        attachments.appendRemote(
+          uploaded.map((u: any) => ({
+            id: u.id,
+            name: u.original_name || u.storage_path.split('/').pop() || 'file',
+            original_name: u.original_name ?? null,
+            path: u.storage_path,
+            url: u.file_url,
+            type: u.file_type,
+            attachment_type_id: u.attachment_type_id ?? null,
+          }))
+        );
+      }
+      attachments.markPersisted();
+      notify.success('Письмо обновлено');
+      onSaved?.();
+    } catch (e: any) {
+      notify.error(e.message);
+    }
+  };
+
+  if (!letter) return <Skeleton active />;
+
+  return (
+    <Form form={form} layout="vertical" onFinish={onFinish} style={{ maxWidth: embedded ? 'none' : 640 }} autoComplete="off">
+      <Row gutter={16}>
+        <Col span={8}>
+          <Form.Item name="project_id" label="Проект" rules={[{ required: true }]}> 
+            <Select options={projects.map((p) => ({ value: p.id, label: p.name }))} />
+          </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item name="unit_ids" label="Объекты">
+            <Select mode="multiple" options={units.map((u) => ({ value: u.id, label: u.name }))} disabled={!projectId} />
+          </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item name="responsible_user_id" label="Ответственный">
+            <Select allowClear options={users.map((u) => ({ value: u.id, label: u.name }))} />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={8}>
+          <Form.Item name="number" label="Номер" rules={[{ required: true }]}> 
+            <Input />
+          </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item name="date" label="Дата" rules={[{ required: true }]}> 
+            <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+          </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item name="letter_type_id" label="Категория">
+            <Select allowClear options={letterTypes.map((t) => ({ value: t.id, label: t.name }))} />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={12}>
+          <Form.Item name="sender" label="Отправитель">
+            <Input />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item name="receiver" label="Получатель">
+            <Input />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Form.Item name="subject" label="Тема">
+        <Input />
+      </Form.Item>
+      <Form.Item name="content" label="Содержание">
+        <Input.TextArea rows={2} />
+      </Form.Item>
+      <Form.Item label="Файлы">
+        <FileDropZone onFiles={handleFiles} />
+        <AttachmentEditorTable
+          remoteFiles={attachments.remoteFiles.map((f) => ({
+            id: String(f.id),
+            name: f.original_name ?? f.name,
+            path: f.path,
+            typeId: attachments.changedTypes[f.id] ?? f.attachment_type_id,
+            typeName: f.attachment_type_name,
+            mime: f.type,
+          }))}
+          newFiles={attachments.newFiles.map((f) => ({ file: f.file, typeId: f.type_id, mime: f.file.type }))}
+          attachmentTypes={attachmentTypes}
+          onRemoveRemote={attachments.removeRemote}
+          onRemoveNew={attachments.removeNew}
+          onChangeRemoteType={attachments.changeRemoteType}
+          onChangeNewType={attachments.changeNewType}
+          getSignedUrl={(path, name) => signedUrl(path, name)}
+        />
+      </Form.Item>
+      <Form.Item style={{ textAlign: 'right' }}>
+        {onCancel && (
+          <Button style={{ marginRight: 8 }} onClick={onCancel} disabled={update.isPending}>
+            Отмена
+          </Button>
+        )}
+        <Button type="primary" htmlType="submit" loading={update.isPending}>
+          Сохранить
+        </Button>
+      </Form.Item>
+    </Form>
+  );
+}

--- a/src/features/correspondence/LetterViewModal.tsx
+++ b/src/features/correspondence/LetterViewModal.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Modal, Typography, Skeleton } from 'antd';
+import { useLetter } from '@/entities/correspondence';
+import LetterFormAntdEdit from './LetterFormAntdEdit';
+
+interface Props {
+  open: boolean;
+  letterId: string | number | null;
+  onClose: () => void;
+}
+
+/** Модальное окно просмотра письма */
+export default function LetterViewModal({ open, letterId, onClose }: Props) {
+  if (!letterId) return null;
+  const { data: letter } = useLetter(letterId);
+  const titleText = letter ? `Письмо №${letter.number}` : 'Письмо';
+
+  return (
+    <Modal
+      open={open}
+      onCancel={onClose}
+      footer={null}
+      width="80%"
+      destroyOnClose
+      title={<Typography.Title level={4} style={{ margin: 0 }}>{titleText}</Typography.Title>}
+    >
+      {letter ? (
+        <LetterFormAntdEdit embedded letterId={String(letterId)} onCancel={onClose} onSaved={onClose} />
+      ) : (
+        <Skeleton active />
+      )}
+    </Modal>
+  );
+}

--- a/src/features/correspondence/model/useLetterAttachments.ts
+++ b/src/features/correspondence/model/useLetterAttachments.ts
@@ -1,0 +1,116 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { AttachmentType } from '@/shared/types/attachmentType';
+import type { CorrespondenceLetter } from '@/shared/types/correspondence';
+import type { RemoteLetterFile, NewLetterFile } from '@/shared/types/letterFile';
+
+/** Хук управления вложениями письма */
+export function useLetterAttachments(options: {
+  letter?: CorrespondenceLetter | null;
+  attachmentTypes: AttachmentType[];
+}) {
+  const { letter, attachmentTypes } = options;
+
+  const [remoteFiles, setRemoteFiles] = useState<RemoteLetterFile[]>([]);
+  const [changedTypes, setChangedTypes] = useState<Record<string, number | null>>({});
+  const [initialTypes, setInitialTypes] = useState<Record<string, number | null>>({});
+  const [newFiles, setNewFiles] = useState<NewLetterFile[]>([]);
+  const [removedIds, setRemovedIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!letter) return;
+    const attachments = (letter.attachments || []).map((file: any) => {
+      const typeObj = attachmentTypes.find((t) => t.id === file.attachment_type_id);
+      const storagePath = file.storage_path ?? file.path;
+      const fileUrl = file.file_url ?? file.url ?? '';
+      const fileType = file.file_type ?? file.type ?? '';
+      const originalName = file.original_name ?? null;
+      const name =
+        originalName ||
+        (storagePath ? storagePath.split('/').pop() : file.name) ||
+        'file';
+      return {
+        id: file.id,
+        name,
+        original_name: originalName,
+        path: storagePath ?? '',
+        url: fileUrl,
+        type: fileType,
+        attachment_type_id: file.attachment_type_id ?? null,
+        attachment_type_name: typeObj?.name || fileType || '',
+      } as RemoteLetterFile;
+    });
+    setRemoteFiles(attachments);
+    const map: Record<string, number | null> = {};
+    attachments.forEach((f) => {
+      map[String(f.id)] = f.attachment_type_id ?? null;
+    });
+    setChangedTypes(map);
+    setInitialTypes(map);
+  }, [letter, attachmentTypes]);
+
+  const addFiles = useCallback((files: File[]) => {
+    setNewFiles((p) => [...p, ...files.map((f) => ({ file: f, type_id: null }))]);
+  }, []);
+  const removeNew = useCallback((idx: number) => {
+    setNewFiles((p) => p.filter((_, i) => i !== idx));
+  }, []);
+  const removeRemote = useCallback((id: string) => {
+    setRemoteFiles((p) => p.filter((f) => String(f.id) !== String(id)));
+    setRemovedIds((p) => [...p, id]);
+  }, []);
+  const changeRemoteType = useCallback((id: string, type: number | null) => {
+    setChangedTypes((p) => ({ ...p, [id]: type }));
+  }, []);
+  const changeNewType = useCallback((idx: number, type: number | null) => {
+    setNewFiles((p) => p.map((f, i) => (i === idx ? { ...f, type_id: type } : f)));
+  }, []);
+  const appendRemote = useCallback((files: RemoteLetterFile[]) => {
+    setRemoteFiles((p) => [...p, ...files]);
+    setChangedTypes((prev) => {
+      const copy = { ...prev };
+      files.forEach((f) => {
+        copy[String(f.id)] = f.attachment_type_id ?? null;
+      });
+      return copy;
+    });
+    setInitialTypes((prev) => {
+      const copy = { ...prev };
+      files.forEach((f) => {
+        copy[String(f.id)] = f.attachment_type_id ?? null;
+      });
+      return copy;
+    });
+  }, []);
+  const markPersisted = useCallback(() => {
+    setNewFiles([]);
+    setRemovedIds([]);
+    setInitialTypes((prev) => ({ ...prev, ...changedTypes }));
+  }, [changedTypes]);
+  const attachmentsChanged =
+    newFiles.length > 0 ||
+    removedIds.length > 0 ||
+    Object.keys(changedTypes).some((id) => changedTypes[id] !== initialTypes[id]);
+  const resetAll = useCallback(() => {
+    setNewFiles([]);
+    setRemoteFiles([]);
+    setChangedTypes({});
+    setInitialTypes({});
+    setRemovedIds([]);
+  }, []);
+
+  return {
+    remoteFiles,
+    newFiles,
+    changedTypes,
+    removedIds,
+    addFiles,
+    removeNew,
+    removeRemote,
+    changeRemoteType,
+    changeNewType,
+    appendRemote,
+    markPersisted,
+    attachmentsChanged,
+    reset: resetAll,
+  };
+}

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -25,6 +25,7 @@ import CorrespondenceTable from '@/widgets/CorrespondenceTable';
 import CorrespondenceFilters from '@/widgets/CorrespondenceFilters';
 import TableColumnsDrawer from '@/widgets/TableColumnsDrawer';
 import LetterStatusSelect from '@/features/correspondence/LetterStatusSelect';
+import LetterViewModal from '@/features/correspondence/LetterViewModal';
 import type { TableColumnSetting } from '@/shared/types/tableColumnSetting';
 import type { ColumnsType } from 'antd/es/table';
 import {
@@ -128,6 +129,7 @@ export default function CorrespondencePage() {
     }
   });
   const [showColumnsDrawer, setShowColumnsDrawer] = useState(false);
+  const [viewId, setViewId] = useState<string | null>(null);
 
   React.useEffect(() => {
     const handler = (e: StorageEvent) => {
@@ -586,6 +588,7 @@ export default function CorrespondencePage() {
             onDelete={handleDelete}
             onAddChild={setLinkFor}
             onUnlink={handleUnlink}
+            onView={(id) => setViewId(id)}
             users={users}
             letterTypes={letterTypes}
             projects={projects}
@@ -600,6 +603,7 @@ export default function CorrespondencePage() {
             Готовых писем к выгрузке: {readyToExport}
           </Typography.Text>
         </div>
+        <LetterViewModal open={viewId !== null} letterId={viewId} onClose={() => setViewId(null)} />
       </>
     </ConfigProvider>
   );

--- a/src/widgets/CorrespondenceTable.tsx
+++ b/src/widgets/CorrespondenceTable.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState, useEffect } from 'react';
 import dayjs from 'dayjs';
 import { Table, Space, Button, Popconfirm, Tag, Tooltip } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
-import { DeleteOutlined, PlusOutlined, MailOutlined, BranchesOutlined, LinkOutlined } from '@ant-design/icons';
+import { DeleteOutlined, PlusOutlined, MailOutlined, BranchesOutlined, LinkOutlined, EyeOutlined } from '@ant-design/icons';
 import { CorrespondenceLetter } from '@/shared/types/correspondence';
 import LetterStatusSelect from '@/features/correspondence/LetterStatusSelect';
 
@@ -12,7 +12,8 @@ interface CorrespondenceTableProps {
   letters: CorrespondenceLetter[];
   onDelete: (id: string) => void;
   onAddChild: (parent: CorrespondenceLetter) => void;
-  onUnlink: (letterId: string) => void; // <--- новый проп
+  onUnlink: (letterId: string) => void;
+  onView?: (id: string) => void;
   /** Колонки таблицы. Если не переданы, используется набор по умолчанию */
   columns?: ColumnsType<any>;
   users: Option[];
@@ -31,6 +32,7 @@ export default function CorrespondenceTable({
                                               onDelete,
                                               onAddChild,
                                               onUnlink,
+                                              onView,
                                               columns: columnsProp,
                                               users,
                                               letterTypes,
@@ -232,6 +234,11 @@ export default function CorrespondenceTable({
       width: 150,
       render: (_: any, record: CorrespondenceLetter) => (
           <Space size="middle">
+            {onView && (
+              <Tooltip title="Просмотр">
+                <Button type="text" icon={<EyeOutlined />} onClick={() => onView(record.id)} />
+              </Tooltip>
+            )}
             <Button type="text" icon={<PlusOutlined />} onClick={() => onAddChild(record)} />
             {/* Только для связанных писем — показать кнопку "исключить" */}
             {record.parent_id && (
@@ -263,7 +270,7 @@ export default function CorrespondenceTable({
       ),
     },
   ],
-    [onAddChild, onUnlink, onDelete],
+    [onAddChild, onUnlink, onDelete, onView],
   );
 
   const columns = columnsProp ?? defaultColumns;


### PR DESCRIPTION
## Summary
- implement `LetterViewModal` with editable form
- enable attachment editing via `useLetterAttachments`
- expose `signedUrl` helper for correspondence
- show view button in correspondence table
- integrate view modal on correspondence page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684d254a2850832eb16a8640eee71e6d