### PR TITLE
Add archive download for court cases

### DIFF
--- a/src/entities/courtCase/index.ts
+++ b/src/entities/courtCase/index.ts
@@ -363,3 +363,11 @@ export function useUpdateCourtCaseFull() {
     },
   });
 }
+
+export async function signedUrl(path: string, filename = ''): Promise<string> {
+  const { data, error } = await supabase.storage
+    .from(ATTACH_BUCKET)
+    .createSignedUrl(path, 60, { download: filename || undefined });
+  if (error) throw error;
+  return data.signedUrl;
+}

--- a/src/features/courtCase/CourtCaseViewModal.tsx
+++ b/src/features/courtCase/CourtCaseViewModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import dayjs from 'dayjs';
 import { Modal, Typography } from 'antd';
 import CourtCaseFormAntdEdit from './CourtCaseFormAntdEdit';
 import { useCourtCase } from '@/entities/courtCase';
@@ -12,7 +13,9 @@ interface Props {
 /** Модальное окно просмотра судебного дела */
 export default function CourtCaseViewModal({ open, caseId, onClose }: Props) {
   const { data: courtCase } = useCourtCase(caseId || undefined);
-  const titleText = courtCase ? `Дело №${courtCase.number}` : 'Дело';
+  const titleText = courtCase
+    ? `Дело №${courtCase.number} от ${dayjs(courtCase.date).format('DD.MM.YYYY')}`
+    : 'Дело';
 
   if (!caseId) return null;
 


### PR DESCRIPTION
## Summary
- show case number and date in `CourtCaseViewModal`
- enable attachments archive download in court case form
- pass signed URL getter to attachment table
- expose `signedUrl` helper for court cases

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d6fe7367c832e98e54562ae218617