### PR TITLE
Enhance letter viewing modal

### DIFF
--- a/src/features/correspondence/LetterFormAntdEdit.tsx
+++ b/src/features/correspondence/LetterFormAntdEdit.tsx
@@ -11,6 +11,7 @@ import FileDropZone from '@/shared/ui/FileDropZone';
 import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
 import { useLetterAttachments } from './model/useLetterAttachments';
 import { useNotify } from '@/shared/hooks/useNotify';
+import { downloadZip } from '@/shared/utils/downloadZip';
 
 export interface LetterFormAntdEditProps {
   letterId: string;
@@ -49,6 +50,23 @@ export default function LetterFormAntdEdit({ letterId, onCancel, onSaved, embedd
   }, [letter, form]);
 
   const handleFiles = (files: File[]) => attachments.addFiles(files);
+
+  const handleDownloadArchive = async () => {
+    const files = [
+      ...attachments.remoteFiles.map((f) => ({
+        name: f.original_name ?? f.name,
+        getFile: async () => {
+          const url = await signedUrl(f.path, f.original_name ?? f.name);
+          const res = await fetch(url);
+          return res.blob();
+        },
+      })),
+      ...attachments.newFiles.map((f) => ({ name: f.file.name, getFile: async () => f.file })),
+    ];
+    if (files.length) {
+      await downloadZip(files, `letter-${letterId}-files.zip`);
+    }
+  };
 
   const onFinish = async (values: any) => {
     if (
@@ -159,6 +177,14 @@ export default function LetterFormAntdEdit({ letterId, onCancel, onSaved, embedd
       </Form.Item>
       <Form.Item label="Файлы">
         <FileDropZone onFiles={handleFiles} />
+        <Button
+          size="small"
+          style={{ marginTop: 8, marginBottom: 8 }}
+          onClick={handleDownloadArchive}
+          disabled={!attachments.remoteFiles.length && !attachments.newFiles.length}
+        >
+          Скачать архив
+        </Button>
         <AttachmentEditorTable
           remoteFiles={attachments.remoteFiles.map((f) => ({
             id: String(f.id),

--- a/src/features/correspondence/LetterViewModal.tsx
+++ b/src/features/correspondence/LetterViewModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import dayjs from 'dayjs';
 import { Modal, Typography, Skeleton } from 'antd';
 import { useLetter } from '@/entities/correspondence';
 import LetterFormAntdEdit from './LetterFormAntdEdit';
@@ -13,7 +14,11 @@ interface Props {
 export default function LetterViewModal({ open, letterId, onClose }: Props) {
   if (!letterId) return null;
   const { data: letter } = useLetter(letterId);
-  const titleText = letter ? `Письмо №${letter.number}` : 'Письмо';
+  const titleText = letter
+    ? `Письмо №${letter.number} от ${dayjs(letter.date).format('DD.MM.YYYY')} (${
+        letter.type === 'incoming' ? 'входящее' : 'исходящее'
+      })`
+    : 'Письмо';
 
   return (
     <Modal


### PR DESCRIPTION
## Summary
- show more info in letter view modal title
- allow downloading archive of letter attachments

## Testing
- `npm run lint` *(fails: Parsing error due to missing TypeScript configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684d703cdde4832e8dc4c530c078762b