### PR TITLE
Implement filtered history links

### DIFF
--- a/src/features/history/HistoryDialog.tsx
+++ b/src/features/history/HistoryDialog.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import dayjs from 'dayjs';
 import { Modal, Table, Tag, ConfigProvider, Button, Switch, Space } from 'antd';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, createSearchParams } from 'react-router-dom';
 import ruRU from 'antd/locale/ru_RU';
 import type { ColumnsType } from 'antd/es/table';
 import { useUnitHistory } from '@/entities/history';
@@ -9,9 +9,10 @@ import type { HistoryEventWithUser } from '@/shared/types/history';
 
 interface HistoryDialogProps {
   open: boolean;
-  unit: { id: number; name: string } | null;
+  unit: { id: number; name: string; project_id?: number } | null;
   onClose: () => void;
-  onOpenCourtCase?: (caseId: number) => void; // <-- добавьте если нужно открывать дело в модалке
+  /** Открыть модальное окно дела, если страница не обрабатывает case_id */
+  onOpenCourtCase?: (caseId: number) => void;
 }
 
 /** Диалог отображения истории объекта */
@@ -148,7 +149,15 @@ export default function HistoryDialog({ open, unit, onClose, onOpenCourtCase }: 
             <Button
               disabled={!ticketIds.length}
               onClick={() => {
-                navigate(`/tickets?ids=${ticketIds.join(',')}`);
+                if (unit) {
+                  const search = createSearchParams({
+                    project_id: String(unit.project_id ?? ''),
+                    unit_id: String(unit.id),
+                  }).toString();
+                  navigate(`/tickets?${search}`);
+                } else {
+                  navigate('/tickets');
+                }
                 onClose();
               }}
             >
@@ -157,7 +166,15 @@ export default function HistoryDialog({ open, unit, onClose, onOpenCourtCase }: 
             <Button
               disabled={!caseIds.length}
               onClick={() => {
-                navigate(`/court-cases?ids=${caseIds.join(',')}`);
+                if (unit) {
+                  const search = createSearchParams({
+                    project_id: String(unit.project_id ?? ''),
+                    unit_id: String(unit.id),
+                  }).toString();
+                  navigate(`/court-cases?${search}`);
+                } else {
+                  navigate('/court-cases');
+                }
                 onClose();
               }}
             >
@@ -166,7 +183,15 @@ export default function HistoryDialog({ open, unit, onClose, onOpenCourtCase }: 
             <Button
               disabled={!letterIds.length}
               onClick={() => {
-                navigate(`/correspondence?ids=${letterIds.join(',')}`);
+                if (unit) {
+                  const search = createSearchParams({
+                    project_id: String(unit.project_id ?? ''),
+                    unit_id: String(unit.id),
+                  }).toString();
+                  navigate(`/correspondence?${search}`);
+                } else {
+                  navigate('/correspondence');
+                }
                 onClose();
               }}
             >

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -83,19 +83,22 @@ export default function CorrespondencePage() {
   const linkLetters = useLinkLetters();
   const unlinkLetter = useUnlinkLetter();
   const notify = useNotify();
+  const [searchParams] = useSearchParams();
   const [filters, setFilters] = useState<Filters>(() => {
     let hideClosed = false;
     try {
       const saved = localStorage.getItem(LS_HIDE_CLOSED_KEY);
       hideClosed = saved ? JSON.parse(saved) : false;
     } catch {}
+    const prj = searchParams.get('project_id');
+    const unit = searchParams.get('unit_id');
     return {
       period: null,
       type: '',
       id: [],
       category: '',
-      project: '',
-      unit: '',
+      project: prj ? Number(prj) : '',
+      unit: unit ? Number(unit) : '',
       sender: '',
       receiver: '',
       subject: '',
@@ -103,9 +106,8 @@ export default function CorrespondencePage() {
       status: '',
       responsible: '',
       hideClosed,
-    };
+    } as Filters;
   });
-  const [searchParams] = useSearchParams();
   const [form] = Form.useForm();
   const initialValues = {
     project_id: searchParams.get('project_id')
@@ -161,6 +163,17 @@ export default function CorrespondencePage() {
       setFilters((f) => ({ ...f, id: valid }));
       form.setFieldValue('id', valid);
     }
+    const letterId = searchParams.get('letter_id');
+    if (letterId) {
+      setViewId(letterId);
+    }
+    const prj = searchParams.get('project_id');
+    const unit = searchParams.get('unit_id');
+    setFilters((f) => ({
+      ...f,
+      project: prj ? Number(prj) : f.project,
+      unit: unit ? Number(unit) : f.unit,
+    }));
   }, [searchParams, letters]);
 
 

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -72,8 +72,12 @@ export default function CourtCasesPage() {
 
   const [searchParams] = useSearchParams();
   const initialValues = {
-    project_id: searchParams.get('project_id') ? Number(searchParams.get('project_id')!) : undefined,
-    unit_ids: searchParams.get('unit_id') ? [Number(searchParams.get('unit_id')!)] : undefined,
+    project_id: searchParams.get('project_id')
+      ? Number(searchParams.get('project_id')!)
+      : undefined,
+    unit_ids: searchParams.get('unit_id')
+      ? [Number(searchParams.get('unit_id')!)]
+      : undefined,
     responsible_lawyer_id: searchParams.get('responsible_lawyer_id') || undefined,
   };
 
@@ -96,13 +100,29 @@ export default function CourtCasesPage() {
   });
 
   const [filters, setFilters] = useState<CourtCasesFiltersValues>(() => {
+    let hideClosed = false;
     try {
       const saved = localStorage.getItem(LS_KEY);
-      return { hideClosed: saved ? JSON.parse(saved) : false } as CourtCasesFiltersValues;
-    } catch {
-      return {} as CourtCasesFiltersValues;
-    }
+      hideClosed = saved ? JSON.parse(saved) : false;
+    } catch {}
+    return {
+      hideClosed,
+      projectId: initialValues.project_id,
+      objectId: initialValues.unit_ids ? initialValues.unit_ids[0] : undefined,
+    } as CourtCasesFiltersValues;
   });
+
+  useEffect(() => {
+    const caseId = searchParams.get('case_id');
+    if (caseId) setViewId(Number(caseId));
+    const prj = searchParams.get('project_id');
+    const obj = searchParams.get('unit_id');
+    setFilters((f) => ({
+      ...f,
+      projectId: prj ? Number(prj) : f.projectId,
+      objectId: obj ? Number(obj) : f.objectId,
+    }));
+  }, [searchParams]);
 
   useEffect(() => {
     const handler = (e: StorageEvent) => {

--- a/src/pages/TicketsPage/TicketsPage.tsx
+++ b/src/pages/TicketsPage/TicketsPage.tsx
@@ -94,6 +94,18 @@ export default function TicketsPage() {
     if (id) {
       setViewId(Number(id));
     }
+    const project = searchParams.get('project_id');
+    if (project) {
+      const val = Number(project);
+      setInitialFilters((f) => ({ ...f, project: val }));
+      setFilters((f) => ({ ...f, project: val }));
+    }
+    const unit = searchParams.get('unit_id');
+    if (unit) {
+      const val = Number(unit);
+      setInitialFilters((f) => ({ ...f, units: [val] }));
+      setFilters((f) => ({ ...f, units: [val] }));
+    }
     const ids = searchParams.get('ids');
     if (ids) {
       const arr = ids


### PR DESCRIPTION
## Summary
- open filters from object history by project & unit
- support opening court cases and letters via URL
- sync ticket filters with query params
- sync court case filters and open item by URL
- sync correspondence filters and open item by URL

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684d72977348832ebd248a2a564b4951