### PR TITLE
Add sender/receiver editing features

### DIFF
--- a/src/features/correspondence/LetterFormAntdEdit.tsx
+++ b/src/features/correspondence/LetterFormAntdEdit.tsx
@@ -1,17 +1,35 @@
 import React, { useEffect } from 'react';
 import dayjs, { Dayjs } from 'dayjs';
-import { Form, Input, Select, DatePicker, Row, Col, Button, Skeleton } from 'antd';
+import {
+  Form,
+  Input,
+  Select,
+  DatePicker,
+  Row,
+  Col,
+  Button,
+  Skeleton,
+  AutoComplete,
+  Radio,
+  Space,
+  Popconfirm,
+} from 'antd';
+import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
 import { useUsers } from '@/entities/user';
 import { useLetterTypes } from '@/entities/letterType';
 import { useProjects } from '@/entities/project';
 import { useUnitsByProject } from '@/entities/unit';
 import { useAttachmentTypes } from '@/entities/attachmentType';
+import { useContractors, useDeleteContractor } from '@/entities/contractor';
+import { usePersons, useDeletePerson } from '@/entities/person';
 import { useLetter, useUpdateLetter, signedUrl } from '@/entities/correspondence';
 import FileDropZone from '@/shared/ui/FileDropZone';
 import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
 import { useLetterAttachments } from './model/useLetterAttachments';
 import { useNotify } from '@/shared/hooks/useNotify';
 import { downloadZip } from '@/shared/utils/downloadZip';
+import PersonModal from '@/features/person/PersonModal';
+import ContractorModal from '@/features/contractor/ContractorModal';
 
 export interface LetterFormAntdEditProps {
   letterId: string;
@@ -29,9 +47,43 @@ export default function LetterFormAntdEdit({ letterId, onCancel, onSaved, embedd
   const projectId = Form.useWatch('project_id', form);
   const { data: units = [] } = useUnitsByProject(projectId); 
   const { data: attachmentTypes = [] } = useAttachmentTypes();
+  const { data: contractors = [] } = useContractors();
+  const { data: persons = [] } = usePersons();
+  const deletePerson = useDeletePerson();
+  const deleteContractor = useDeleteContractor();
   const update = useUpdateLetter();
   const notify = useNotify();
   const attachments = useLetterAttachments({ letter, attachmentTypes });
+
+  const senderValue = Form.useWatch('sender', form);
+  const receiverValue = Form.useWatch('receiver', form);
+  const [senderType, setSenderType] = React.useState<'person' | 'contractor'>('person');
+  const [receiverType, setReceiverType] = React.useState<'person' | 'contractor'>('contractor');
+  const [personModal, setPersonModal] = React.useState<{ target: 'sender' | 'receiver'; data?: any } | null>(null);
+  const [contractorModal, setContractorModal] = React.useState<{ target: 'sender' | 'receiver'; data?: any } | null>(null);
+
+  const personOptions = React.useMemo(
+    () => persons.map((p) => ({ value: p.full_name })),
+    [persons],
+  );
+  const contractorOptions = React.useMemo(
+    () => contractors.map((c) => ({ value: c.name })),
+    [contractors],
+  );
+
+  useEffect(() => {
+    if (!letter) return;
+    if (persons.some((p) => p.full_name === letter.sender)) {
+      setSenderType('person');
+    } else if (contractors.some((c) => c.name === letter.sender)) {
+      setSenderType('contractor');
+    }
+    if (persons.some((p) => p.full_name === letter.receiver)) {
+      setReceiverType('person');
+    } else if (contractors.some((c) => c.name === letter.receiver)) {
+      setReceiverType('contractor');
+    }
+  }, [letter, persons, contractors]);
 
   useEffect(() => {
     if (!letter) return;
@@ -159,13 +211,145 @@ export default function LetterFormAntdEdit({ letterId, onCancel, onSaved, embedd
       </Row>
       <Row gutter={16}>
         <Col span={12}>
-          <Form.Item name="sender" label="Отправитель">
-            <Input />
+          <Form.Item label="Отправитель" style={{ marginBottom: 0 }}>
+            <Space direction="vertical" style={{ width: '100%' }}>
+              <Radio.Group value={senderType} onChange={(e) => setSenderType(e.target.value)}>
+                <Radio.Button value="person">Физлицо</Radio.Button>
+                <Radio.Button value="contractor">Контрагент</Radio.Button>
+              </Radio.Group>
+              <Space.Compact style={{ width: '100%' }}>
+                <Form.Item name="sender" noStyle>
+                  <AutoComplete
+                    options={senderType === 'person' ? personOptions : contractorOptions}
+                    allowClear
+                    placeholder="Укажите отправителя"
+                    filterOption={(input, option) =>
+                      String(option?.value ?? '')
+                        .toLowerCase()
+                        .includes(input.toLowerCase())
+                    }
+                  />
+                </Form.Item>
+                <Button
+                  icon={<PlusOutlined />}
+                  onClick={() => setPersonModal({ target: 'sender' })}
+                  style={{ display: senderType === 'person' ? 'inline-block' : 'none' }}
+                />
+                <Button
+                  icon={<PlusOutlined />}
+                  onClick={() => setContractorModal({ target: 'sender' })}
+                  style={{ display: senderType === 'contractor' ? 'inline-block' : 'none' }}
+                />
+                <Button
+                  icon={<EditOutlined />}
+                  disabled={!senderValue}
+                  onClick={() => {
+                    const val = form.getFieldValue('sender');
+                    const data = senderType === 'person'
+                      ? persons.find((p) => p.full_name === val)
+                      : contractors.find((c) => c.name === val);
+                    senderType === 'person'
+                      ? setPersonModal({ target: 'sender', data })
+                      : setContractorModal({ target: 'sender', data });
+                  }}
+                />
+                <Popconfirm
+                  title="Удалить?"
+                  okText="Да"
+                  cancelText="Нет"
+                  onConfirm={() => {
+                    const val = form.getFieldValue('sender');
+                    if (!val) return;
+                    if (senderType === 'person') {
+                      const p = persons.find((pr) => pr.full_name === val);
+                      if (p) {
+                        deletePerson.mutate(p.id);
+                        form.setFieldValue('sender', '');
+                      }
+                    } else {
+                      const c = contractors.find((co) => co.name === val);
+                      if (c) {
+                        deleteContractor.mutate(c.id);
+                        form.setFieldValue('sender', '');
+                      }
+                    }
+                  }}
+                >
+                  <Button danger icon={<DeleteOutlined />} disabled={!senderValue} />
+                </Popconfirm>
+              </Space.Compact>
+            </Space>
           </Form.Item>
         </Col>
         <Col span={12}>
-          <Form.Item name="receiver" label="Получатель">
-            <Input />
+          <Form.Item label="Получатель" style={{ marginBottom: 0 }}>
+            <Space direction="vertical" style={{ width: '100%' }}>
+              <Radio.Group value={receiverType} onChange={(e) => setReceiverType(e.target.value)}>
+                <Radio.Button value="person">Физлицо</Radio.Button>
+                <Radio.Button value="contractor">Контрагент</Radio.Button>
+              </Radio.Group>
+              <Space.Compact style={{ width: '100%' }}>
+                <Form.Item name="receiver" noStyle>
+                  <AutoComplete
+                    options={receiverType === 'person' ? personOptions : contractorOptions}
+                    allowClear
+                    placeholder="Укажите получателя"
+                    filterOption={(input, option) =>
+                      String(option?.value ?? '')
+                        .toLowerCase()
+                        .includes(input.toLowerCase())
+                    }
+                  />
+                </Form.Item>
+                <Button
+                  icon={<PlusOutlined />}
+                  onClick={() => setPersonModal({ target: 'receiver' })}
+                  style={{ display: receiverType === 'person' ? 'inline-block' : 'none' }}
+                />
+                <Button
+                  icon={<PlusOutlined />}
+                  onClick={() => setContractorModal({ target: 'receiver' })}
+                  style={{ display: receiverType === 'contractor' ? 'inline-block' : 'none' }}
+                />
+                <Button
+                  icon={<EditOutlined />}
+                  disabled={!receiverValue}
+                  onClick={() => {
+                    const val = form.getFieldValue('receiver');
+                    const data = receiverType === 'person'
+                      ? persons.find((p) => p.full_name === val)
+                      : contractors.find((c) => c.name === val);
+                    receiverType === 'person'
+                      ? setPersonModal({ target: 'receiver', data })
+                      : setContractorModal({ target: 'receiver', data });
+                  }}
+                />
+                <Popconfirm
+                  title="Удалить?"
+                  okText="Да"
+                  cancelText="Нет"
+                  onConfirm={() => {
+                    const val = form.getFieldValue('receiver');
+                    if (!val) return;
+                    if (receiverType === 'person') {
+                      const p = persons.find((pr) => pr.full_name === val);
+                      if (p) {
+                        deletePerson.mutate(p.id);
+                        form.setFieldValue('receiver', '');
+                      }
+                    } else {
+                      const c = contractors.find((co) => co.name === val);
+                      if (c) {
+                        deleteContractor.mutate(c.id);
+                        form.setFieldValue('receiver', '');
+                      }
+                    }
+                  }}
+                >
+                  <Button danger icon={<DeleteOutlined />} disabled={!receiverValue} />
+                </Popconfirm>
+              </Space.Compact>
+            </Space>
           </Form.Item>
         </Col>
       </Row>
@@ -213,6 +397,23 @@ export default function LetterFormAntdEdit({ letterId, onCancel, onSaved, embedd
           Сохранить
         </Button>
       </Form.Item>
+      {personModal && (
+        <PersonModal
+          open
+          onClose={() => setPersonModal(null)}
+          unitId={null}
+          onSelect={(name) => form.setFieldValue(personModal.target, name)}
+          initialData={personModal.data}
+        />
+      )}
+      {contractorModal && (
+        <ContractorModal
+          open
+          onClose={() => setContractorModal(null)}
+          onSelect={(name) => form.setFieldValue(contractorModal.target, name)}
+          initialData={contractorModal.data}
+        />
+      )}
     </Form>
   );
 }


### PR DESCRIPTION
## Summary
- support person/contractor selection when editing correspondence
- allow creating, editing and deleting persons and contractors from edit form

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d7f5bc200832e9241756575d776a2