### PR TITLE
Highlight edited fields in view forms

### DIFF
--- a/src/features/correspondence/LetterFormAntdEdit.tsx
+++ b/src/features/correspondence/LetterFormAntdEdit.tsx
@@ -30,6 +30,7 @@ import { useNotify } from '@/shared/hooks/useNotify';
 import { downloadZip } from '@/shared/utils/downloadZip';
 import PersonModal from '@/features/person/PersonModal';
 import ContractorModal from '@/features/contractor/ContractorModal';
+import { useChangedFields } from '@/shared/hooks/useChangedFields';
 
 export interface LetterFormAntdEditProps {
   letterId: string;
@@ -54,6 +55,15 @@ export default function LetterFormAntdEdit({ letterId, onCancel, onSaved, embedd
   const update = useUpdateLetter();
   const notify = useNotify();
   const attachments = useLetterAttachments({ letter, attachmentTypes });
+  const { changedFields, handleValuesChange: handleChanged } = useChangedFields(
+    form,
+    [letter],
+  );
+
+  const highlight = (name: string) =>
+    changedFields[name]
+      ? { background: '#fffbe6', padding: 4, borderRadius: 2 }
+      : {};
 
   const senderValue = Form.useWatch('sender', form);
   const receiverValue = Form.useWatch('receiver', form);
@@ -174,44 +184,61 @@ export default function LetterFormAntdEdit({ letterId, onCancel, onSaved, embedd
   if (!letter) return <Skeleton active />;
 
   return (
-    <Form form={form} layout="vertical" onFinish={onFinish} style={{ maxWidth: embedded ? 'none' : 640 }} autoComplete="off">
+    <Form
+      form={form}
+      layout="vertical"
+      onFinish={onFinish}
+      onValuesChange={handleChanged}
+      style={{ maxWidth: embedded ? 'none' : 640 }}
+      autoComplete="off"
+    >
       <Row gutter={16}>
         <Col span={8}>
-          <Form.Item name="project_id" label="Проект" rules={[{ required: true }]}> 
+          <Form.Item
+            name="project_id"
+            label="Проект"
+            rules={[{ required: true }]}
+            style={highlight('project_id')}
+          >
             <Select options={projects.map((p) => ({ value: p.id, label: p.name }))} />
           </Form.Item>
         </Col>
         <Col span={8}>
-          <Form.Item name="unit_ids" label="Объекты">
+          <Form.Item name="unit_ids" label="Объекты" style={highlight('unit_ids')}>
             <Select mode="multiple" options={units.map((u) => ({ value: u.id, label: u.name }))} disabled={!projectId} />
           </Form.Item>
         </Col>
         <Col span={8}>
-          <Form.Item name="responsible_user_id" label="Ответственный">
+          <Form.Item name="responsible_user_id" label="Ответственный" style={highlight('responsible_user_id')}>
             <Select allowClear options={users.map((u) => ({ value: u.id, label: u.name }))} />
           </Form.Item>
         </Col>
       </Row>
       <Row gutter={16}>
         <Col span={8}>
-          <Form.Item name="number" label="Номер" rules={[{ required: true }]}> 
+          <Form.Item
+            name="number"
+            label="Номер"
+            rules={[{ required: true }]}
+            style={highlight('number')}
+          >
             <Input />
           </Form.Item>
         </Col>
         <Col span={8}>
-          <Form.Item name="date" label="Дата" rules={[{ required: true }]}> 
+          <Form.Item name="date" label="Дата" rules={[{ required: true }]} style={highlight('date')}>
             <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
           </Form.Item>
         </Col>
         <Col span={8}>
-          <Form.Item name="letter_type_id" label="Категория">
+          <Form.Item name="letter_type_id" label="Категория" style={highlight('letter_type_id')}>
             <Select allowClear options={letterTypes.map((t) => ({ value: t.id, label: t.name }))} />
           </Form.Item>
         </Col>
       </Row>
       <Row gutter={16}>
         <Col span={12}>
-          <Form.Item label="Отправитель" style={{ marginBottom: 0 }}>
+          <Form.Item label="Отправитель" style={{ marginBottom: 0, ...highlight('sender') }}>
             <Space direction="vertical" style={{ width: '100%' }}>
               <Radio.Group value={senderType} onChange={(e) => setSenderType(e.target.value)}>
                 <Radio.Button value="person">Физлицо</Radio.Button>
@@ -282,7 +309,7 @@ export default function LetterFormAntdEdit({ letterId, onCancel, onSaved, embedd
           </Form.Item>
         </Col>
         <Col span={12}>
-          <Form.Item label="Получатель" style={{ marginBottom: 0 }}>
+          <Form.Item label="Получатель" style={{ marginBottom: 0, ...highlight('receiver') }}>
             <Space direction="vertical" style={{ width: '100%' }}>
               <Radio.Group value={receiverType} onChange={(e) => setReceiverType(e.target.value)}>
                 <Radio.Button value="person">Физлицо</Radio.Button>
@@ -353,13 +380,13 @@ export default function LetterFormAntdEdit({ letterId, onCancel, onSaved, embedd
           </Form.Item>
         </Col>
       </Row>
-      <Form.Item name="subject" label="Тема">
+      <Form.Item name="subject" label="Тема" style={highlight('subject')}>
         <Input />
       </Form.Item>
-      <Form.Item name="content" label="Содержание">
+      <Form.Item name="content" label="Содержание" style={highlight('content')}>
         <Input.TextArea rows={2} />
       </Form.Item>
-      <Form.Item label="Файлы">
+      <Form.Item label="Файлы" style={attachments.attachmentsChanged ? { background: '#fffbe6', padding: 4, borderRadius: 2 } : {}}>
         <FileDropZone onFiles={handleFiles} />
         <Button
           size="small"

--- a/src/features/courtCase/CourtCaseFormAntdEdit.tsx
+++ b/src/features/courtCase/CourtCaseFormAntdEdit.tsx
@@ -15,6 +15,7 @@ import { useCaseAttachments } from './model/useCaseAttachments';
 import { useNotify } from '@/shared/hooks/useNotify';
 import { downloadZip } from '@/shared/utils/downloadZip';
 import { signedUrl } from '@/entities/courtCase';
+import { useChangedFields } from '@/shared/hooks/useChangedFields';
 
 export interface CourtCaseFormAntdEditProps {
   caseId: string;
@@ -42,6 +43,15 @@ export default function CourtCaseFormAntdEdit({
   const update = useUpdateCourtCaseFull();
   const notify = useNotify();
   const attachments = useCaseAttachments({ courtCase, attachmentTypes });
+  const { changedFields, handleValuesChange: handleChanged } = useChangedFields(
+    form,
+    [courtCase],
+  );
+
+  const highlight = (name: string) =>
+    changedFields[name]
+      ? { background: '#fffbe6', padding: 4, borderRadius: 2 }
+      : {};
 
   useEffect(() => {
     if (!courtCase) return;
@@ -141,46 +151,82 @@ export default function CourtCaseFormAntdEdit({
       form={form}
       layout="vertical"
       onFinish={onFinish}
+      onValuesChange={handleChanged}
       style={{ maxWidth: embedded ? 'none' : 640 }}
       autoComplete="off"
     >
       <Row gutter={16}>
         <Col span={8}>
-          <Form.Item name="project_id" label="Проект" rules={[{ required: true }]}> 
+          <Form.Item
+            name="project_id"
+            label="Проект"
+            rules={[{ required: true }]}
+            style={highlight('project_id')}
+          >
             <Select options={projects.map((p) => ({ value: p.id, label: p.name }))} />
           </Form.Item>
         </Col>
         <Col span={8}>
-          <Form.Item name="unit_ids" label="Объекты" rules={[{ required: true }]}> 
+          <Form.Item
+            name="unit_ids"
+            label="Объекты"
+            rules={[{ required: true }]}
+            style={highlight('unit_ids')}
+          >
             <Select mode="multiple" options={units.map((u) => ({ value: u.id, label: u.name }))} disabled={!projectId} />
           </Form.Item>
         </Col>
         <Col span={8}>
-          <Form.Item name="responsible_lawyer_id" label="Ответственный юрист" rules={[{ required: true }]}> 
+          <Form.Item
+            name="responsible_lawyer_id"
+            label="Ответственный юрист"
+            rules={[{ required: true }]}
+            style={highlight('responsible_lawyer_id')}
+          >
             <Select options={users.map((u) => ({ value: u.id, label: u.name }))} />
           </Form.Item>
         </Col>
       </Row>
       <Row gutter={16}>
         <Col span={8}>
-          <Form.Item name="number" label="Номер дела" rules={[{ required: true }]}> 
+          <Form.Item
+            name="number"
+            label="Номер дела"
+            rules={[{ required: true }]}
+            style={highlight('number')}
+          >
             <Input />
           </Form.Item>
         </Col>
         <Col span={8}>
-          <Form.Item name="date" label="Дата" rules={[{ required: true }]}> 
+          <Form.Item
+            name="date"
+            label="Дата"
+            rules={[{ required: true }]}
+            style={highlight('date')}
+          >
             <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
           </Form.Item>
         </Col>
         <Col span={8}>
-          <Form.Item name="status" label="Статус" rules={[{ required: true }]}> 
+          <Form.Item
+            name="status"
+            label="Статус"
+            rules={[{ required: true }]}
+            style={highlight('status')}
+          >
             <Select options={stages.map((s) => ({ value: s.id, label: s.name }))} />
           </Form.Item>
         </Col>
       </Row>
       <Row gutter={16}>
         <Col span={12}>
-          <Form.Item name="plaintiff_id" label="Истец" rules={[{ required: true }]}> 
+          <Form.Item
+            name="plaintiff_id"
+            label="Истец"
+            rules={[{ required: true }]}
+            style={highlight('plaintiff_id')}
+          >
             <Select
               showSearch
               optionFilterProp="label"
@@ -192,7 +238,12 @@ export default function CourtCaseFormAntdEdit({
           </Form.Item>
         </Col>
         <Col span={12}>
-          <Form.Item name="defendant_id" label="Ответчик" rules={[{ required: true }]}> 
+          <Form.Item
+            name="defendant_id"
+            label="Ответчик"
+            rules={[{ required: true }]}
+            style={highlight('defendant_id')}
+          >
             <Select
               showSearch
               optionFilterProp="label"
@@ -206,7 +257,11 @@ export default function CourtCaseFormAntdEdit({
       </Row>
       <Row gutter={16}>
         <Col span={12}>
-          <Form.Item name="fix_start_date" label="Дата начала устранения">
+          <Form.Item
+            name="fix_start_date"
+            label="Дата начала устранения"
+            style={highlight('fix_start_date')}
+          >
             <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
           </Form.Item>
         </Col>
@@ -226,6 +281,7 @@ export default function CourtCaseFormAntdEdit({
                 },
               }),
             ]}
+            style={highlight('fix_end_date')}
           >
             <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
           </Form.Item>
@@ -233,12 +289,12 @@ export default function CourtCaseFormAntdEdit({
       </Row>
       <Row gutter={16}>
         <Col span={24}>
-          <Form.Item name="description" label="Описание">
+          <Form.Item name="description" label="Описание" style={highlight('description')}>
             <Input.TextArea rows={1} />
           </Form.Item>
         </Col>
       </Row>
-      <Form.Item label="Файлы">
+      <Form.Item label="Файлы" style={attachments.attachmentsChanged ? { background: '#fffbe6', padding: 4, borderRadius: 2 } : {}}>
         <FileDropZone onFiles={handleFiles} />
         <Button
           size="small"

--- a/src/features/ticket/TicketFormAntdEdit.tsx
+++ b/src/features/ticket/TicketFormAntdEdit.tsx
@@ -28,6 +28,7 @@ import { useTicketAttachments } from './model/useTicketAttachments';
 import { useUnsavedChangesWarning } from '@/shared/hooks/useUnsavedChangesWarning';
 import { downloadZip } from '@/shared/utils/downloadZip';
 import { signedUrl } from '@/entities/ticket';
+import { useChangedFields } from '@/shared/hooks/useChangedFields';
 
 export interface TicketFormAntdEditProps {
   ticketId?: string;
@@ -77,6 +78,10 @@ export default function TicketFormAntdEdit({
   const profileId = useAuthStore((s) => s.profile?.id);
 
   const [formTouched, setFormTouched] = useState(false);
+  const { changedFields, handleValuesChange: handleChanged } = useChangedFields(
+    form,
+    [ticket],
+  );
 
   const {
     remoteFiles,
@@ -93,6 +98,11 @@ export default function TicketFormAntdEdit({
     attachmentsChanged,
     reset: resetAttachments,
   } = useTicketAttachments({ ticket, attachmentTypes });
+
+  const highlight = (name: keyof TicketFormAntdEditValues) =>
+    changedFields[name as string]
+      ? { background: '#fffbe6', padding: 4, borderRadius: 2 }
+      : {};
 
   const typeId = Form.useWatch('type_id', form);
   const deadlineDays = React.useMemo(() => {
@@ -132,7 +142,10 @@ export default function TicketFormAntdEdit({
   }, [ticket, form, globalProjectId, profileId, initialUnitId]);
 
   const handleFiles = (files: File[]) => addFiles(files);
-  const handleValuesChange = () => setFormTouched(true);
+  const handleValuesChange = () => {
+    setFormTouched(true);
+    handleChanged();
+  };
 
   const handleDownloadArchive = async () => {
     const files = [
@@ -245,12 +258,22 @@ export default function TicketFormAntdEdit({
     >
       <Row gutter={16}>
         <Col span={12}>
-          <Form.Item name="project_id" label="Проект" rules={[{ required: true }]}>
-            <Select allowClear options={projects.map((p) => ({ value: p.id, label: p.name }))} />
-          </Form.Item>
+      <Form.Item
+        name="project_id"
+        label="Проект"
+        rules={[{ required: true }]}
+        style={highlight('project_id')}
+      >
+        <Select allowClear options={projects.map((p) => ({ value: p.id, label: p.name }))} />
+      </Form.Item>
         </Col>
         <Col span={12}>
-          <Form.Item name="unit_ids" label="Объекты" rules={[{ required: true }]}>
+          <Form.Item
+            name="unit_ids"
+            label="Объекты"
+            rules={[{ required: true }]}
+            style={highlight('unit_ids')}
+          >
             <Select
               mode="multiple"
               disabled={!projectId}
@@ -261,48 +284,85 @@ export default function TicketFormAntdEdit({
       </Row>
       <Row gutter={16}>
         <Col span={12}>
-          <Form.Item name="responsible_engineer_id" label="Ответственный инженер" rules={[{ required: true }]}>
+          <Form.Item
+            name="responsible_engineer_id"
+            label="Ответственный инженер"
+            rules={[{ required: true }]}
+            style={highlight('responsible_engineer_id')}
+          >
             <Select allowClear options={users.map((u) => ({ value: u.id, label: u.name }))} />
           </Form.Item>
         </Col>
         <Col span={12}>
-          <Form.Item name="status_id" label="Статус" rules={[{ required: true }]}>
+          <Form.Item
+            name="status_id"
+            label="Статус"
+            rules={[{ required: true }]}
+            style={highlight('status_id')}
+          >
             <Select options={statuses.map((s) => ({ value: s.id, label: s.name }))} />
           </Form.Item>
         </Col>
       </Row>
       <Row gutter={16}>
         <Col span={12}>
-          <Form.Item name="type_id" label={`Тип${deadlineDays ? ` (${deadlineDays} дн.)` : ''}`} rules={[{ required: true }]}>
+          <Form.Item
+            name="type_id"
+            label={`Тип${deadlineDays ? ` (${deadlineDays} дн.)` : ''}`}
+            rules={[{ required: true }]}
+            style={highlight('type_id')}
+          >
             <Select options={types.map((t) => ({ value: t.id, label: t.name }))} />
           </Form.Item>
         </Col>
         <Col span={12}>
-          <Form.Item name="is_warranty" label="Гарантия" valuePropName="checked">
+          <Form.Item
+            name="is_warranty"
+            label="Гарантия"
+            valuePropName="checked"
+            style={highlight('is_warranty')}
+          >
             <Switch />
           </Form.Item>
         </Col>
       </Row>
       <Row gutter={16}>
         <Col span={12}>
-          <Form.Item name="customer_request_no" label="№ заявки от Заказчика">
+          <Form.Item
+            name="customer_request_no"
+            label="№ заявки от Заказчика"
+            style={highlight('customer_request_no')}
+          >
             <Input />
           </Form.Item>
         </Col>
         <Col span={12}>
-          <Form.Item name="customer_request_date" label="Дата заявки Заказчика">
+          <Form.Item
+            name="customer_request_date"
+            label="Дата заявки Заказчика"
+            style={highlight('customer_request_date')}
+          >
             <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
           </Form.Item>
         </Col>
       </Row>
       <Row gutter={16}>
         <Col span={12}>
-          <Form.Item name="received_at" label="Дата получения" rules={[{ required: true }]}>
+          <Form.Item
+            name="received_at"
+            label="Дата получения"
+            rules={[{ required: true }]}
+            style={highlight('received_at')}
+          >
             <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
           </Form.Item>
         </Col>
         <Col span={12}>
-          <Form.Item name="fixed_at" label="Дата устранения">
+          <Form.Item
+            name="fixed_at"
+            label="Дата устранения"
+            style={highlight('fixed_at')}
+          >
             <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
           </Form.Item>
         </Col>
@@ -336,13 +396,22 @@ export default function TicketFormAntdEdit({
           </Col>
         )}
       </Row>
-      <Form.Item name="title" label="Краткое описание" rules={[{ required: true }]}> 
+      <Form.Item
+        name="title"
+        label="Краткое описание"
+        rules={[{ required: true }]}
+        style={highlight('title')}
+      >
         <Input />
       </Form.Item>
-      <Form.Item name="description" label="Подробное описание">
+      <Form.Item
+        name="description"
+        label="Подробное описание"
+        style={highlight('description')}
+      >
         <Input.TextArea rows={2} />
       </Form.Item>
-      <Form.Item label="Файлы">
+      <Form.Item label="Файлы" style={attachmentsChanged ? { background: '#fffbe6', padding: 4, borderRadius: 2 } : {}}>
         <FileDropZone onFiles={handleFiles} />
         <Button
           size="small"

--- a/src/index.css
+++ b/src/index.css
@@ -76,3 +76,8 @@ body {
     border-left: 3px solid #722ed1;
 }
 /* Skeleton эффекты были выше (оставил без изменений) */
+.changed-field {
+    background-color: #fffbe6;
+    padding: 4px;
+    border-radius: 2px;
+}

--- a/src/shared/hooks/useChangedFields.ts
+++ b/src/shared/hooks/useChangedFields.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef, useState } from 'react';
+import type { FormInstance } from 'antd';
+
+/**
+ * Простое глубокое сравнение значений формы
+ * @param a Первое значение
+ * @param b Второе значение
+ */
+function deepEqual(a: any, b: any): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export interface ChangedFieldsResult {
+  /** Карта изменённых полей */
+  changedFields: Record<string, boolean>;
+  /** Обработчик для события onValuesChange */
+  handleValuesChange: () => void;
+}
+
+/**
+ * Отслеживает изменения значений формы и возвращает карту изменённых полей.
+ * @param form экземпляр Ant Design формы
+ * @param deps зависимости для переинициализации начальных значений
+ */
+export function useChangedFields<T>(
+  form: FormInstance<T>,
+  deps: any[] = [],
+): ChangedFieldsResult {
+  const initialRef = useRef<Record<string, any>>({});
+  const [changed, setChanged] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    initialRef.current = form.getFieldsValue(true);
+    setChanged({});
+  }, deps);
+
+  const handleValuesChange = () => {
+    const current = form.getFieldsValue(true);
+    const diff: Record<string, boolean> = {};
+    Object.keys(current).forEach((key) => {
+      if (!deepEqual(current[key], initialRef.current[key])) diff[key] = true;
+    });
+    setChanged(diff);
+  };
+
+  return { changedFields: changed, handleValuesChange };
+}


### PR DESCRIPTION
## Summary
- track changed fields with `useChangedFields` hook
- highlight updated inputs across Ticket, CourtCase and Letter forms
- mark attachments section when files are modified
- add global CSS style for changed fields

## Testing
- `npm run lint` *(fails: Parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_684d863a2bf0832e95816038353847ac