### PR TITLE
Improve court case form defaults

### DIFF
--- a/src/features/courtCase/AddCourtCaseFormAntd.tsx
+++ b/src/features/courtCase/AddCourtCaseFormAntd.tsx
@@ -36,12 +36,18 @@ import ContractorModalId from '@/features/contractor/ContractorModalId';
 import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
 import { useCaseFiles } from './model/useCaseFiles';
 
+/**
+ * Props for {@link AddCourtCaseFormAntd} component.
+ */
 export interface AddCourtCaseFormAntdProps {
+  /** Callback when case created successfully */
   onCreated?: () => void;
+  /** Initial field values */
   initialValues?: Partial<{
     project_id: number;
     unit_ids: number[];
     responsible_lawyer_id: string;
+    status: number;
   }>;
 }
 
@@ -72,6 +78,9 @@ export default function AddCourtCaseFormAntd({
     } else if (profileId) {
       form.setFieldValue('responsible_lawyer_id', profileId);
     }
+    if (initialValues.status) {
+      form.setFieldValue('status', initialValues.status);
+    }
   }, [initialValues, globalProjectId, profileId, form]);
 
   useEffect(() => {
@@ -95,6 +104,13 @@ export default function AddCourtCaseFormAntd({
   const deleteContractorMutation = useDeleteContractor();
   const notify = useNotify();
   const qc = useQueryClient();
+
+  // Set default litigation stage when loaded
+  useEffect(() => {
+    if (stages.length && !form.getFieldValue('status')) {
+      form.setFieldValue('status', stages[0].id);
+    }
+  }, [stages, form]);
 
   const [personModal, setPersonModal] = useState<any | null>(null);
   const [contractorModal, setContractorModal] = useState<any | null>(null);

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -79,7 +79,14 @@ export default function CourtCasesPage() {
       ? [Number(searchParams.get('unit_id')!)]
       : undefined,
     responsible_lawyer_id: searchParams.get('responsible_lawyer_id') || undefined,
+    status: searchParams.get('status') ? Number(searchParams.get('status')!) : undefined,
   };
+
+  React.useEffect(() => {
+    if (searchParams.get('open_form') === '1') {
+      setShowAddForm(true);
+    }
+  }, [searchParams]);
 
   const { data: projects = [] } = useProjects();
   const { data: contractors = [] } = useContractors();

--- a/src/widgets/UnitsMatrix/UnitsMatrix.tsx
+++ b/src/widgets/UnitsMatrix/UnitsMatrix.tsx
@@ -348,6 +348,7 @@ export default function UnitsMatrix({
                   project_id: String(projectId),
                   unit_id: String(id ?? ''),
                   responsible_lawyer_id: String(profileId ?? ''),
+                  open_form: '1',
                 }).toString();
                 navigate(`/court-cases?${search}`);
                 setActionDialog({ open: false, unit: null, action: '' });


### PR DESCRIPTION
## Summary
- prefill Ant Design form with default stage
- auto-open court case form from query param
- pass `open_form` when adding a court case from structure

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d8bb8c9b8832e8667f949a09ef53e