### PR TITLE
Add open_form query param for correspondence form

### DIFF
--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -121,6 +121,12 @@ export default function CorrespondencePage() {
   const [linkFor, setLinkFor] = useState<CorrespondenceLetter | null>(null);
   const [showAddForm, setShowAddForm] = useState(false);
   const hideOnScroll = useRef(false);
+  // Показываем форму автоматически, если передан параметр ?open_form=1
+  React.useEffect(() => {
+    if (searchParams.get('open_form') === '1') {
+      setShowAddForm(true);
+    }
+  }, [searchParams]);
   const LS_FILTERS_VISIBLE_KEY = 'correspondenceFiltersVisible';
   const LS_COLUMNS_KEY = 'correspondenceColumns';
   const [showFilters, setShowFilters] = useState(() => {

--- a/src/widgets/UnitsMatrix/UnitsMatrix.tsx
+++ b/src/widgets/UnitsMatrix/UnitsMatrix.tsx
@@ -361,9 +361,13 @@ export default function UnitsMatrix({
               fullWidth
               onClick={() => {
                 const id = actionDialog.unit?.id;
-                navigate(
-                  `/correspondence?project_id=${projectId}&unit_id=${id}&responsible_user_id=${profileId ?? ''}`,
-                );
+                const search = createSearchParams({
+                  project_id: String(projectId),
+                  unit_id: String(id ?? ''),
+                  responsible_user_id: String(profileId ?? ''),
+                  open_form: '1',
+                }).toString();
+                navigate(`/correspondence?${search}`);
                 setActionDialog({ open: false, unit: null, action: '' });
               }}
             >


### PR DESCRIPTION
## Summary
- open correspondence add form automatically when `open_form=1`
- pass `open_form=1` when navigating from structure page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684d8c37b44c832eb52caa875120c551