### PR TITLE
Add defect types and table for ticket defects

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -323,7 +323,7 @@
   },
   {
     "table_name": "defect_deadlines",
-    "column_name": "ticket_type_id",
+    "column_name": "defect_type_id",
     "data_type": "integer",
     "is_nullable": "NO",
     "column_default": null
@@ -714,14 +714,14 @@
     "column_default": null
   },
   {
-    "table_name": "ticket_types",
+    "table_name": "defect_types",
     "column_name": "id",
     "data_type": "integer",
     "is_nullable": "NO",
-    "column_default": "nextval('ticket_types_id_seq'::regclass)"
+    "column_default": "nextval('defect_types_id_seq'::regclass)"
   },
   {
-    "table_name": "ticket_types",
+    "table_name": "defect_types",
     "column_name": "name",
     "data_type": "text",
     "is_nullable": "NO",
@@ -757,8 +757,8 @@
   },
   {
     "table_name": "tickets",
-    "column_name": "type_id",
-    "data_type": "integer",
+    "column_name": "defect_ids",
+    "data_type": "ARRAY",
     "is_nullable": "YES",
     "column_default": null
   },

--- a/sql/update_defect_types.sql
+++ b/sql/update_defect_types.sql
@@ -1,0 +1,10 @@
+-- Rename ticket_types to defect_types
+ALTER TABLE ticket_types RENAME TO defect_types;
+ALTER SEQUENCE ticket_types_id_seq RENAME TO defect_types_id_seq;
+
+-- Update related foreign keys
+ALTER TABLE defect_deadlines RENAME COLUMN ticket_type_id TO defect_type_id;
+
+-- Remove type_id from tickets and add defect_ids array
+ALTER TABLE tickets DROP COLUMN IF EXISTS type_id;
+ALTER TABLE tickets ADD COLUMN defect_ids integer[] DEFAULT ARRAY[]::integer[];

--- a/src/entities/defectDeadline.ts
+++ b/src/entities/defectDeadline.ts
@@ -4,9 +4,9 @@ import type { DefectDeadline } from '@/shared/types/defectDeadline';
 
 const TABLE = 'defect_deadlines';
 const SELECT = `
-  id, project_id, ticket_type_id, fix_days,
+  id, project_id, defect_type_id, fix_days,
   project:projects ( id, name ),
-  ticket_type:ticket_types ( id, name )
+  defect_type:defect_types ( id, name )
 `;
 
 export const useDefectDeadlines = () =>
@@ -25,9 +25,9 @@ export const useDefectDeadlines = () =>
 
 export const useAddDefectDeadline = () => {
   const qc = useQueryClient();
-  return useMutation<DefectDeadline, Error, Omit<DefectDeadline, 'id' | 'project' | 'ticket_type'>>({
+  return useMutation<DefectDeadline, Error, Omit<DefectDeadline, 'id' | 'project' | 'defect_type'>>({
     mutationFn: async (
-      payload: Omit<DefectDeadline, 'id' | 'project' | 'ticket_type'>,
+      payload: Omit<DefectDeadline, 'id' | 'project' | 'defect_type'>,
     ): Promise<DefectDeadline> => {
       const { data, error } = await supabase
         .from(TABLE)
@@ -43,7 +43,7 @@ export const useAddDefectDeadline = () => {
 
 export const useUpdateDefectDeadline = () => {
   const qc = useQueryClient();
-  return useMutation<DefectDeadline, Error, { id: number; updates: Partial<Omit<DefectDeadline, 'id' | 'project' | 'ticket_type'>> }>({
+  return useMutation<DefectDeadline, Error, { id: number; updates: Partial<Omit<DefectDeadline, 'id' | 'project' | 'defect_type'>> }>({
     mutationFn: async ({
       id,
       updates,

--- a/src/entities/defectType.d.ts
+++ b/src/entities/defectType.d.ts
@@ -1,0 +1,8 @@
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+export interface DefectType { id: number; name: string }
+
+export const useDefectTypes: () => UseQueryResult<DefectType[]>;
+export const useAddDefectType: () => UseMutationResult<DefectType, Error, string>;
+export const useUpdateDefectType: () => UseMutationResult<DefectType, Error, { id: number; name: string }>;
+export const useDeleteDefectType: () => UseMutationResult<void, Error, number>;

--- a/src/entities/defectType.js
+++ b/src/entities/defectType.js
@@ -1,14 +1,14 @@
-// src/entities/ticketType.js
+// src/entities/defectType.js
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/shared/api/supabaseClient';
 
 // ---------------- select ----------------
-export const useTicketTypes = () => {
+export const useDefectTypes = () => {
     return useQuery({
-        queryKey: ['ticket_types'],
+        queryKey: ['defect_types'],
         queryFn: async () => {
             const { data, error } = await supabase
-                .from('ticket_types')
+                .from('defect_types')
                 .select('id, name')
                 .order('id');
             if (error) throw error;
@@ -19,29 +19,29 @@ export const useTicketTypes = () => {
 };
 
 // ---------------- insert ----------------
-export const useAddTicketType = () => {
+export const useAddDefectType = () => {
     const qc = useQueryClient();
     return useMutation({
         mutationFn: async (name) => {
             const { data, error } = await supabase
-                .from('ticket_types')
+                .from('defect_types')
                 .insert({ name })
                 .select('id, name')
                 .single();
             if (error) throw error;
             return data;
         },
-        onSuccess: () => qc.invalidateQueries({ queryKey: ['ticket_types'] }),
+        onSuccess: () => qc.invalidateQueries({ queryKey: ['defect_types'] }),
     });
 };
 
 // ---------------- update ----------------
-export const useUpdateTicketType = () => {
+export const useUpdateDefectType = () => {
     const qc = useQueryClient();
     return useMutation({
         mutationFn: async ({ id, name }) => {
             const { data, error } = await supabase
-                .from('ticket_types')
+                .from('defect_types')
                 .update({ name })
                 .eq('id', id)
                 .select('id, name')
@@ -49,21 +49,21 @@ export const useUpdateTicketType = () => {
             if (error) throw error;
             return data;
         },
-        onSuccess: () => qc.invalidateQueries({ queryKey: ['ticket_types'] }),
+        onSuccess: () => qc.invalidateQueries({ queryKey: ['defect_types'] }),
     });
 };
 
 // ---------------- delete ----------------
-export const useDeleteTicketType = () => {
+export const useDeleteDefectType = () => {
     const qc = useQueryClient();
     return useMutation({
         mutationFn: async (id) => {
             const { error } = await supabase
-                .from('ticket_types')
+                .from('defect_types')
                 .delete()
                 .eq('id', id);
             if (error) throw error;
         },
-        onSuccess: () => qc.invalidateQueries({ queryKey: ['ticket_types'] }),
+        onSuccess: () => qc.invalidateQueries({ queryKey: ['defect_types'] }),
     });
 };

--- a/src/entities/ticket.d.ts
+++ b/src/entities/ticket.d.ts
@@ -24,11 +24,10 @@ export interface Ticket {
   parentId: number | null;
   projectId: number;
   unitIds: number[];
-  typeId: number | null;
   statusId: number | null;
   projectName: string;
   unitNames: string;
-  typeName: string;
+  defectIds: number[];
   statusName: string;
   statusColor: string | null;
   title: string;

--- a/src/entities/ticket.js
+++ b/src/entities/ticket.js
@@ -150,11 +150,10 @@ function mapTicket(r) {
     parentId: r.parent_id ?? null,
     projectId: r.project_id,
     unitIds: r.unit_ids || [],
-    typeId: r.type_id,
     statusId: r.status_id,
     projectName: r.projects?.name ?? "—",
     unitNames: [],
-    typeName: r.ticket_types?.name ?? "—",
+    defectIds: r.defect_ids || [],
     statusName: r.ticket_statuses?.name ?? "—",
     statusColor: r.ticket_statuses?.color ?? null,
     title: r.title,
@@ -184,12 +183,12 @@ export function useTickets() {
         .from("tickets")
         .select(
           `
-          id, project_id, unit_ids, type_id, status_id, title, description,
+          id, project_id, unit_ids, defect_ids, status_id, title, description,
           customer_request_no, customer_request_date, responsible_engineer_id,
           created_by, is_warranty, is_closed, created_at, received_at, fixed_at,
           attachment_ids,
           projects (id, name),
-          ticket_types (id, name), ticket_statuses (id, name, color)
+          ticket_statuses (id, name, color)
         `,
         )
         .eq("project_id", projectId)
@@ -320,12 +319,12 @@ export function useTicket(ticketId) {
         .from("tickets")
         .select(
           `
-          id, project_id, unit_ids, type_id, status_id, title, description,
+          id, project_id, unit_ids, defect_ids, status_id, title, description,
           customer_request_no, customer_request_date, responsible_engineer_id,
           created_by, is_warranty, is_closed, created_at, received_at, fixed_at,
           attachment_ids,
           projects (id, name),
-          ticket_types (id, name), ticket_statuses (id, name, color)
+          ticket_statuses (id, name, color)
         `,
         )
         .eq("id", id)

--- a/src/entities/ticketType.d.ts
+++ b/src/entities/ticketType.d.ts
@@ -1,8 +1,0 @@
-import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
-
-export interface TicketType { id: number; name: string }
-
-export const useTicketTypes: () => UseQueryResult<TicketType[]>;
-export const useAddTicketType: () => UseMutationResult<TicketType, Error, string>;
-export const useUpdateTicketType: () => UseMutationResult<TicketType, Error, { id: number; name: string }>;
-export const useDeleteTicketType: () => UseMutationResult<void, Error, number>;

--- a/src/features/defectDeadline/DefectDeadlineForm.tsx
+++ b/src/features/defectDeadline/DefectDeadlineForm.tsx
@@ -9,17 +9,17 @@ import {
   MenuItem,
 } from '@mui/material';
 import { useProjects } from '@/entities/project';
-import { useTicketTypes } from '@/entities/ticketType';
+import { useDefectTypes } from '@/entities/defectType';
 
 interface FormValues {
   project_id: number | '';
-  ticket_type_id: number | '';
+  defect_type_id: number | '';
   fix_days: number | '';
 }
 
 interface Props {
-  initialData?: { project_id?: number; ticket_type_id?: number; fix_days?: number };
-  onSubmit: (values: { project_id: number; ticket_type_id: number; fix_days: number }) => void;
+  initialData?: { project_id?: number; defect_type_id?: number; fix_days?: number };
+  onSubmit: (values: { project_id: number; defect_type_id: number; fix_days: number }) => void;
   onCancel: () => void;
 }
 
@@ -27,18 +27,18 @@ export default function DefectDeadlineForm({ initialData, onSubmit, onCancel }: 
   const { control, handleSubmit, formState: { isSubmitting } } = useForm<FormValues>({
     defaultValues: {
       project_id: initialData?.project_id ?? '',
-      ticket_type_id: initialData?.ticket_type_id ?? '',
+      defect_type_id: initialData?.defect_type_id ?? '',
       fix_days: initialData?.fix_days ?? '',
     },
   });
 
   const { data: projects = [] } = useProjects();
-  const { data: types = [] } = useTicketTypes();
+  const { data: types = [] } = useDefectTypes();
 
   return (
     <form onSubmit={handleSubmit((v) => onSubmit({
       project_id: Number(v.project_id),
-      ticket_type_id: Number(v.ticket_type_id),
+      defect_type_id: Number(v.defect_type_id),
       fix_days: Number(v.fix_days),
     }))} noValidate>
       <Stack spacing={2} sx={{ minWidth: 320 }}>
@@ -55,7 +55,7 @@ export default function DefectDeadlineForm({ initialData, onSubmit, onCancel }: 
           )}
         />
         <Controller
-          name="ticket_type_id"
+          name="defect_type_id"
           control={control}
           rules={{ required: 'Тип дефекта обязателен' }}
           render={({ field, fieldState }) => (

--- a/src/features/defectType/DefectTypeForm.tsx
+++ b/src/features/defectType/DefectTypeForm.tsx
@@ -15,7 +15,7 @@ import {
  *   onCancel: () => void
  * }} props
  */
-export default function TicketTypeForm({ initialData, onSubmit, onCancel }) {
+export default function DefectTypeForm({ initialData, onSubmit, onCancel }) {
   const {
     control,
     handleSubmit,

--- a/src/features/ticket/ExportTicketsButton.tsx
+++ b/src/features/ticket/ExportTicketsButton.tsx
@@ -30,7 +30,6 @@ export default function ExportTicketsButton({
       Гарантия: t.isWarranty ? 'Да' : 'Нет',
       Статус: t.statusName,
       'Замечание закрыто': t.isClosed ? 'Да' : 'Нет',
-      'Тип замечания': t.typeName,
       'Дата получения': t.receivedAt ? t.receivedAt.format('DD.MM.YYYY') : '',
       'Прошло дней с Даты получения': t.receivedAt
         ? today.diff(t.receivedAt, 'day') + 1

--- a/src/features/ticket/TicketForm.tsx
+++ b/src/features/ticket/TicketForm.tsx
@@ -18,7 +18,7 @@ import {
 import { DatePicker } from "@mui/x-date-pickers";
 import dayjs, { Dayjs } from "dayjs";
 
-import { useTicketTypes } from "@/entities/ticketType";
+import { useDefectTypes } from "@/entities/defectType";
 import { useTicketStatuses } from "@/entities/ticketStatus";
 import { useUnitsByProject } from "@/entities/unit";
 import { useUsers } from "@/entities/user";
@@ -113,7 +113,7 @@ export default function TicketForm({
   });
 
   const { data: projects = [] } = useProjects();
-  const { data: types = [] } = useTicketTypes();
+  const { data: types = [] } = useDefectTypes();
   const { data: statuses = [] } = useTicketStatuses();
   const { data: users = [] } = useUsers();
   const { data: attachmentTypes = [] } = useAttachmentTypes();
@@ -127,7 +127,7 @@ export default function TicketForm({
     const rec = deadlines.find(
       (d) =>
         d.project_id === projectIdWatch &&
-        d.ticket_type_id === typeIdWatch,
+        d.defect_type_id === typeIdWatch,
     );
     return rec?.fix_days ?? null;
   }, [deadlines, projectIdWatch, typeIdWatch]);
@@ -160,7 +160,6 @@ export default function TicketForm({
         unit_ids: ticket.unitIds,
         responsible_engineer_id: ticket.responsibleEngineerId,
         status_id: ticket.statusId,
-        type_id: ticket.typeId,
         is_warranty: ticket.isWarranty,
         customer_request_no: ticket.customerRequestNo || "",
         customer_request_date: ticket.customerRequestDate,

--- a/src/features/ticket/TicketFormAntd.tsx
+++ b/src/features/ticket/TicketFormAntd.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import dayjs, { Dayjs } from 'dayjs';
 import { Form, Input, Select, DatePicker, Switch, Button, Row, Col } from 'antd';
-import { useTicketTypes } from '@/entities/ticketType';
+import { PlusOutlined } from '@ant-design/icons';
+import { useDefectTypes } from '@/entities/defectType';
 import { useTicketStatuses } from '@/entities/ticketStatus';
 import { useUnitsByProject } from '@/entities/unit';
 import { useUsers } from '@/entities/user';
 import { useProjects } from '@/entities/project';
 import { useCreateTicket } from '@/entities/ticket';
-import { useDefectDeadlines } from '@/entities/defectDeadline';
 import { useAttachmentTypes } from '@/entities/attachmentType';
 import { useProjectId } from '@/shared/hooks/useProjectId';
 import { useAuthStore } from '@/shared/store/authStore';
@@ -31,7 +31,6 @@ export interface TicketFormAntdProps {
 export interface TicketFormAntdValues {
   project_id: number | null;
   unit_ids: number[];
-  type_id: number | null;
   status_id: number | null;
   title: string;
   description: string | null;
@@ -41,6 +40,7 @@ export interface TicketFormAntdValues {
   is_warranty: boolean;
   received_at: Dayjs;
   fixed_at: Dayjs | null;
+  defects?: Array<{ type_id: number | null; fixed_at: Dayjs | null; fix_by: string }>;
   /** Дополнительные данные разметки, не отправляются на сервер */
   pins?: unknown;
 }
@@ -50,25 +50,16 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
   const globalProjectId = useProjectId();
   const projectId = Form.useWatch('project_id', form) ?? globalProjectId;
 
-  const { data: types = [] } = useTicketTypes();
+  const { data: defectTypes = [] } = useDefectTypes();
   const { data: statuses = [] } = useTicketStatuses();
   const { data: projects = [] } = useProjects();
   const { data: units = [] } = useUnitsByProject(projectId);
   const { data: users = [] } = useUsers();
   const { data: attachmentTypes = [] } = useAttachmentTypes();
-  const { data: deadlines = [] } = useDefectDeadlines();
   const create = useCreateTicket();
   const notify = useNotify();
   const [files, setFiles] = useState<{ file: File; type_id: number | null }[]>([]);
   const profileId = useAuthStore((s) => s.profile?.id);
-  const typeId = Form.useWatch('type_id', form);
-  const deadlineDays = React.useMemo(() => {
-    if (!projectId || !typeId) return null;
-    const rec = deadlines.find(
-      (d) => d.project_id === projectId && d.ticket_type_id === typeId,
-    );
-    return rec?.fix_days ?? null;
-  }, [projectId, typeId, deadlines]);
 
   useEffect(() => {
     if (initialValues.project_id != null) {
@@ -122,6 +113,9 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
         ...rest,
         project_id: values.project_id ?? globalProjectId,
         attachments: files,
+        defect_ids: (values.defects || [])
+          .map((d) => d.type_id ?? null)
+          .filter((id): id is number => id != null),
         received_at: values.received_at.format('YYYY-MM-DD'),
         fixed_at: values.fixed_at ? values.fixed_at.format('YYYY-MM-DD') : null,
         customer_request_date: values.customer_request_date
@@ -179,15 +173,6 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
           </Form.Item>
         </Col>
         <Col span={8}>
-          <Form.Item
-            name="type_id"
-            label={`Тип${deadlineDays ? ` (${deadlineDays} дн.)` : ''}`}
-            rules={[{ required: true }]}
-          >
-            <Select options={types.map((t) => ({ value: t.id, label: t.name }))} />
-          </Form.Item>
-        </Col>
-        <Col span={8}>
           <Form.Item name="is_warranty" label="Гарантия" valuePropName="checked">
             <Switch />
           </Form.Item>
@@ -205,6 +190,60 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
           </Form.Item>
         </Col>
       </Row>
+      <Form.List name="defects">
+        {(fields, { add, remove }) => (
+          <>
+            <table style={{ width: '100%', marginBottom: 16 }}>
+              <thead>
+                <tr>
+                  <th style={{ width: 40 }}>#</th>
+                  <th>Наименование дефекта</th>
+                  <th style={{ width: 160 }}>Дата устранения</th>
+                  <th style={{ width: 180 }}>Кем устраняется</th>
+                  <th style={{ width: 40 }}></th>
+                </tr>
+              </thead>
+              <tbody>
+                {fields.map((field, index) => (
+                  <tr key={field.key}>
+                    <td>{index + 1}</td>
+                    <td>
+                      <Form.Item name={[field.name, 'type_id']} noStyle>
+                        <Select
+                          placeholder="Тип дефекта"
+                          options={defectTypes.map((d) => ({ value: d.id, label: d.name }))}
+                          style={{ width: '100%' }}
+                        />
+                      </Form.Item>
+                    </td>
+                    <td>
+                      <Form.Item name={[field.name, 'fixed_at']} noStyle>
+                        <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+                      </Form.Item>
+                    </td>
+                    <td>
+                      <Form.Item name={[field.name, 'fix_by']} noStyle initialValue="own">
+                        <Select
+                          options={[
+                            { value: 'own', label: 'Собственные силы' },
+                            { value: 'contractor', label: 'Подрядчик' },
+                          ]}
+                        />
+                      </Form.Item>
+                    </td>
+                    <td>
+                      <Button type="text" danger onClick={() => remove(field.name)}>
+                        Удалить
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <Button type="dashed" onClick={() => add()} icon={<PlusOutlined />}>Добавить дефект</Button>
+          </>
+        )}
+      </Form.List>
       <Row gutter={16}>
         <Col span={8}>
           <Form.Item name="received_at" label="Дата получения" rules={[{ required: true }]}>
@@ -233,22 +272,6 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
             </Button>
           </Col>
         ))}
-        {deadlineDays && (
-          <Col>
-            <Button
-              size="small"
-              style={{ background: '#2e7d32', color: '#fff' }}
-              onClick={() => {
-                const rec = form.getFieldValue('received_at');
-                if (rec) {
-                  form.setFieldValue('fixed_at', dayjs(rec).add(deadlineDays, 'day'));
-                }
-              }}
-            >
-              +{deadlineDays} дней
-            </Button>
-          </Col>
-        )}
       </Row>
       <Form.Item name="title" label="Краткое описание" rules={[{ required: true }]}> 
         <Input />

--- a/src/pages/TicketsPage/TicketsPage.tsx
+++ b/src/pages/TicketsPage/TicketsPage.tsx
@@ -180,7 +180,6 @@ export default function TicketsPage() {
       projects: uniq(ticketsWithNames, "projectName"),
       units: uniq(ticketsWithNames, "unitNames"),
       statuses: uniq(ticketsWithNames, "statusName"),
-      types: uniq(ticketsWithNames, "typeName"),
       responsibleEngineers: uniq(ticketsWithNames, "responsibleEngineerName"),
       ids: uniq(ticketsWithNames, "id"),
     };
@@ -276,12 +275,6 @@ export default function TicketsPage() {
         width: 160,
         sorter: (a: any, b: any) => Number(a.isClosed) - Number(b.isClosed),
         render: (_: any, row: any) => <TicketClosedSelect ticketId={row.id} isClosed={row.isClosed} />,
-      },
-      typeName: {
-        title: 'Тип замечания',
-        dataIndex: 'typeName',
-        width: 160,
-        sorter: (a: any, b: any) => a.typeName.localeCompare(b.typeName),
       },
       days: {
         title: 'Прошло дней с Даты получения',

--- a/src/pages/UnitsPage/AdminPage.tsx
+++ b/src/pages/UnitsPage/AdminPage.tsx
@@ -4,7 +4,7 @@ import { Container, Stack } from "@mui/material";
 import ProjectsTable from "../../widgets/ProjectsTable";
 import ContractorAdmin from "../../widgets/ContractorAdmin";
 import TicketStatusesAdmin from "../../widgets/TicketStatusesAdmin";
-import TicketTypesAdmin from "../../widgets/TicketTypesAdmin";
+import DefectTypesAdmin from "../../widgets/DefectTypesAdmin";
 import DefectDeadlinesAdmin from "../../widgets/DefectDeadlinesAdmin";
 import UsersTable from "../../widgets/UsersTable";
 import LitigationStagesAdmin from "../../widgets/LitigationStagesAdmin";
@@ -25,7 +25,7 @@ export default function AdminPage() {
           rowsPerPageOptions={[10, 25, 50, 100]}
         />
 
-        <TicketTypesAdmin
+        <DefectTypesAdmin
           pageSize={25}
           rowsPerPageOptions={[10, 25, 50, 100]}
         />

--- a/src/shared/types/defectDeadline.ts
+++ b/src/shared/types/defectDeadline.ts
@@ -1,8 +1,8 @@
 export interface DefectDeadline {
   id: number;
   project_id: number;
-  ticket_type_id: number;
+  defect_type_id: number;
   fix_days: number;
   project?: { id: number; name: string } | null;
-  ticket_type?: { id: number; name: string } | null;
+  defect_type?: { id: number; name: string } | null;
 }

--- a/src/shared/types/ticket.ts
+++ b/src/shared/types/ticket.ts
@@ -5,7 +5,6 @@ export interface Ticket {
   project_id: number;
   /** массив ID объектов, к которым относится замечание */
   unit_ids: number[];
-  type_id: number | null;
   status_id: number | null;
   title: string;
   description: string | null;
@@ -18,6 +17,7 @@ export interface Ticket {
   received_at: string;
   fixed_at: string | null;
   attachment_ids?: number[];
+  defect_ids?: number[];
 }
 
 /** Связь замечаний: parent_id - родительское замечание, child_id - дочернее */

--- a/src/shared/types/ticketFilters.ts
+++ b/src/shared/types/ticketFilters.ts
@@ -11,6 +11,5 @@ export interface TicketFilters {
   units?: string[];
   warranty?: 'yes' | 'no';
   status?: string;
-  type?: string;
   responsible?: string;
 }

--- a/src/shared/utils/ticketFilter.ts
+++ b/src/shared/utils/ticketFilter.ts
@@ -20,7 +20,7 @@ export function filterTickets<T extends {
   unitNames?: string;
   isWarranty?: boolean;
   statusName?: string;
-  typeName?: string;
+  defectIds?: number[];
   responsibleEngineerName?: string | null;
 }>(rows: T[], f: TicketFilters): T[] {
   const pass = (r: T): boolean => {
@@ -57,7 +57,6 @@ export function filterTickets<T extends {
       if (r.isWarranty !== want) return false;
     }
     if (f.status && r.statusName !== f.status) return false;
-    if (f.type && r.typeName !== f.type) return false;
     if (f.responsible && r.responsibleEngineerName !== f.responsible) {
       return false;
     }

--- a/src/widgets/DefectDeadlinesAdmin.tsx
+++ b/src/widgets/DefectDeadlinesAdmin.tsx
@@ -13,7 +13,7 @@ import AdminDataGrid from '@/shared/ui/AdminDataGrid';
 import { Dialog, DialogTitle, DialogContent } from '@mui/material';
 import { useNotify } from '@/shared/hooks/useNotify';
 import { useProjects } from '@/entities/project';
-import { useTicketTypes } from '@/entities/ticketType';
+import { useDefectTypes } from '@/entities/defectType';
 
 /** Props for {@link DefectDeadlinesAdmin} */
 interface Props {
@@ -35,7 +35,7 @@ export default function DefectDeadlinesAdmin({
   const notify = useNotify();
   const { data = [], isPending } = useDefectDeadlines();
   const { data: projects = [] } = useProjects();
-  const { data: ticketTypes = [] } = useTicketTypes();
+  const { data: defectTypes = [] } = useDefectTypes();
 
   const rows = useMemo(
     () =>
@@ -45,9 +45,9 @@ export default function DefectDeadlinesAdmin({
           row.project?.name || projects.find((p) => p.id === row.project_id)?.name || '',
         ticket_type_name:
           row.ticket_type?.name ||
-          ticketTypes.find((t) => t.id === row.ticket_type_id)?.name || '',
+          defectTypes.find((t) => t.id === row.ticket_type_id)?.name || '',
       })),
-    [data, projects, ticketTypes]
+    [data, projects, defectTypes]
   );
   const add = useAddDefectDeadline();
   const update = useUpdateDefectDeadline();

--- a/src/widgets/DefectTypesAdmin.tsx
+++ b/src/widgets/DefectTypesAdmin.tsx
@@ -1,29 +1,29 @@
-// src/widgets/TicketTypesAdmin.js
+// src/widgets/DefectTypesAdmin.tsx
 import React from 'react';
 import {
-    useTicketTypes,
-    useAddTicketType,
-    useUpdateTicketType,
-    useDeleteTicketType,
-} from '@/entities/ticketType';
+    useDefectTypes,
+    useAddDefectType,
+    useUpdateDefectType,
+    useDeleteDefectType,
+} from '@/entities/defectType';
 import { Button, Stack, Dialog, DialogTitle, DialogContent, IconButton } from '@mui/material';
 import AdminDataGrid from '@/shared/ui/AdminDataGrid';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
-import TicketTypeForm from '@/features/ticketType/TicketTypeForm'; // без ProjectForm!
+import DefectTypeForm from '@/features/defectType/DefectTypeForm';
 
-interface TicketTypesAdminProps {
+interface DefectTypesAdminProps {
     pageSize?: number;
     rowsPerPageOptions?: number[];
 }
-export default function TicketTypesAdmin({
+export default function DefectTypesAdmin({
     pageSize = 25,
     rowsPerPageOptions = [10, 25, 50, 100],
-}: TicketTypesAdminProps) {
-    const { data = [], isLoading } = useTicketTypes();
-    const addMutation = useAddTicketType();
-    const updateMutation = useUpdateTicketType();
-    const deleteMutation = useDeleteTicketType();
+}: DefectTypesAdminProps) {
+    const { data = [], isLoading } = useDefectTypes();
+    const addMutation = useAddDefectType();
+    const updateMutation = useUpdateDefectType();
+    const deleteMutation = useDeleteDefectType();
 
     const [open, setOpen] = React.useState(false);
     const [editRow, setEditRow] = React.useState(null);
@@ -79,7 +79,7 @@ export default function TicketTypesAdmin({
             <Dialog open={open} onClose={() => setOpen(false)} maxWidth="xs" fullWidth>
                 <DialogTitle>{editRow ? 'Редактировать тип' : 'Добавить тип'}</DialogTitle>
                 <DialogContent>
-                    <TicketTypeForm
+                    <DefectTypeForm
                         initialData={editRow}
                         onSubmit={(values) => handleSubmit(values)}
                         onCancel={() => setOpen(false)}
@@ -88,7 +88,7 @@ export default function TicketTypesAdmin({
             </Dialog>
 
             <AdminDataGrid
-                title="Типы замечаний"
+                title="Типы дефектов"
                 rows={data}
                 columns={columns}
                 loading={isLoading}

--- a/src/widgets/TicketsFilters.tsx
+++ b/src/widgets/TicketsFilters.tsx
@@ -108,9 +108,6 @@ export default function TicketsFilters({ options, onChange, initialValues = {} }
       <Form.Item name="status" label="Статусы">
         <Select allowClear options={options.statuses} />
       </Form.Item>
-      <Form.Item name="type" label="Тип замечания">
-        <Select allowClear options={options.types} />
-      </Form.Item>
       <Form.Item name="requestNo" label="№ заявки от Заказчика">
         <Input />
       </Form.Item>

--- a/src/widgets/TicketsTable.tsx
+++ b/src/widgets/TicketsTable.tsx
@@ -156,12 +156,6 @@ export default function TicketsTable({
         ),
       },
       {
-        title: "Тип замечания",
-        dataIndex: "typeName",
-        width: 160,
-        sorter: (a, b) => a.typeName.localeCompare(b.typeName),
-      },
-      {
         title: "Прошло дней с Даты получения",
         dataIndex: "days",
         width: 120,


### PR DESCRIPTION
## Summary
- rename ticket types to defect types across app
- update ticket creation form with defect table
- adjust admin page and widgets for defect types
- update defect deadlines & types
- provide SQL migration script
- refactor tickets to use defect types
- fix ticket creation payload

## Testing
- `npm run lint` *(fails: Parsing error because of missing eslint plugins)*

------
https://chatgpt.com/codex/tasks/task_e_684d930b7edc832ea861710a683f1183