### PR TITLE
Add defects page

### DIFF
--- a/src/app/Router.tsx
+++ b/src/app/Router.tsx
@@ -12,6 +12,7 @@ import TicketsPage from "@/pages/TicketsPage/TicketsPage";
 import TicketFormPage from "@/pages/TicketsPage/TicketFormPage";
 import CourtCasesPage from "@/pages/CourtCasesPage/CourtCasesPage";
 import CorrespondencePage from "@/pages/CorrespondencePage/CorrespondencePage";
+import DefectsPage from "@/pages/DefectsPage/DefectsPage";
 import LoginPage from "@/pages/UnitsPage/LoginPage"; // ← CHANGE
 import RegisterPage from "@/pages/UnitsPage/RegisterPage"; // ← CHANGE
 import AdminPage from "@/pages/UnitsPage/AdminPage";
@@ -76,6 +77,15 @@ export default function AppRouter() {
           </RequireAuth>
         }
         data-oid="41m4r4h"
+      />
+
+      <Route
+        path="/defects"
+        element={
+          <RequireAuth>
+            <DefectsPage />
+          </RequireAuth>
+        }
       />
 
       <Route

--- a/src/entities/defect.ts
+++ b/src/entities/defect.ts
@@ -1,0 +1,45 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/shared/api/supabaseClient';
+import { useProjectId } from '@/shared/hooks/useProjectId';
+import type { DefectRecord } from '@/shared/types/defect';
+
+const TABLE = 'defects';
+
+/** Получить все дефекты проекта */
+export function useDefects() {
+  const projectId = useProjectId();
+  return useQuery<DefectRecord[]>({
+    queryKey: [TABLE, projectId],
+    enabled: !!projectId,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select('id, project_id, description, fix_cost, created_at')
+        .eq('project_id', projectId)
+        .order('id');
+      if (error) throw error;
+      return data as DefectRecord[];
+    },
+    staleTime: 5 * 60_000,
+  });
+}
+
+/** Получить дефект по ID */
+export function useDefect(id?: number) {
+  const projectId = useProjectId();
+  return useQuery<DefectRecord | null>({
+    queryKey: ['defect', id],
+    enabled: !!id && !!projectId,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select('id, project_id, description, fix_cost, created_at')
+        .eq('id', id as number)
+        .eq('project_id', projectId)
+        .single();
+      if (error) throw error;
+      return data as DefectRecord;
+    },
+    staleTime: 5 * 60_000,
+  });
+}

--- a/src/entities/ticket.js
+++ b/src/entities/ticket.js
@@ -520,6 +520,26 @@ export function useAllTicketsSimple() {
 }
 
 // -----------------------------------------------------------------------------
+// Получить список замечаний текущего проекта (минимальный набор полей)
+// -----------------------------------------------------------------------------
+export function useTicketsSimple() {
+  const projectId = useProjectId();
+  return useQuery({
+    queryKey: ["tickets-simple", projectId],
+    enabled: !!projectId,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("tickets")
+        .select("id, project_id, unit_ids, defect_ids")
+        .eq("project_id", projectId);
+      if (error) throw error;
+      return data ?? [];
+    },
+    staleTime: 5 * 60_000,
+  });
+}
+
+// -----------------------------------------------------------------------------
 // Обновить статус замечания
 // -----------------------------------------------------------------------------
 export function useUpdateTicketStatus() {

--- a/src/features/defect/DefectViewModal.tsx
+++ b/src/features/defect/DefectViewModal.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import { Modal, Typography, Skeleton } from 'antd';
+import { useDefect } from '@/entities/defect';
+
+interface Props {
+  open: boolean;
+  defectId: number | null;
+  onClose: () => void;
+}
+
+/** Модальное окно просмотра дефекта */
+export default function DefectViewModal({ open, defectId, onClose }: Props) {
+  const { data: defect, isLoading } = useDefect(defectId ?? undefined);
+  if (!defectId) return null;
+  const title = defect ? `Дефект №${defect.id}` : 'Дефект';
+  return (
+    <Modal open={open} onCancel={onClose} footer={null} width="60%"
+      title={<Typography.Title level={4} style={{ margin: 0 }}>{title}</Typography.Title>}>
+      {isLoading || !defect ? (
+        <Skeleton active />
+      ) : (
+        <div style={{ display: 'grid', gap: 8 }}>
+          <Typography.Text><b>Описание:</b> {defect.description}</Typography.Text>
+          <Typography.Text>
+            <b>Стоимость устранения:</b> {defect.fix_cost ?? '—'}
+          </Typography.Text>
+          <Typography.Text>
+            <b>Дата создания:</b>{' '}
+            {defect.created_at ? dayjs(defect.created_at).format('DD.MM.YYYY') : '—'}
+          </Typography.Text>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -1,0 +1,78 @@
+import React, { useMemo, useState } from 'react';
+import { ConfigProvider, Card } from 'antd';
+import ruRU from 'antd/locale/ru_RU';
+import { useDefects } from '@/entities/defect';
+import { useTicketsSimple } from '@/entities/ticket';
+import { useProjects } from '@/entities/project';
+import { useUnitsByIds } from '@/entities/unit';
+import DefectsTable from '@/widgets/DefectsTable';
+import DefectsFilters from '@/widgets/DefectsFilters';
+import DefectViewModal from '@/features/defect/DefectViewModal';
+import type { DefectWithInfo } from '@/shared/types/defect';
+import type { DefectFilters } from '@/shared/types/defectFilters';
+
+export default function DefectsPage() {
+  const { data: defects = [], isPending } = useDefects();
+  const { data: tickets = [] } = useTicketsSimple();
+  const { data: projects = [] } = useProjects();
+  const unitIds = useMemo(
+    () => Array.from(new Set(tickets.flatMap((t) => t.unit_ids || []))),
+    [tickets],
+  );
+  const { data: units = [] } = useUnitsByIds(unitIds);
+
+  const data: DefectWithInfo[] = useMemo(() => {
+    const projectMap = new Map(projects.map((p) => [p.id, p.name]));
+    const unitMap = new Map(units.map((u) => [u.id, u.name]));
+    const ticketsMap = new Map<number, { id: number; unit_ids: number[] }[]>();
+    tickets.forEach((t: any) => {
+      (t.defect_ids || []).forEach((id: number) => {
+        const arr = ticketsMap.get(id) || [];
+        arr.push({ id: t.id, unit_ids: t.unit_ids || [] });
+        ticketsMap.set(id, arr);
+      });
+    });
+    return defects.map((d) => {
+      const linked = ticketsMap.get(d.id) || [];
+      const unitIds = Array.from(new Set(linked.flatMap((l) => l.unit_ids)));
+      const unitNames = unitIds
+        .map((id) => unitMap.get(id))
+        .filter(Boolean)
+        .join(', ');
+      return {
+        ...d,
+        ticketIds: linked.map((l) => l.id),
+        unitIds,
+        projectName: projectMap.get(d.project_id) || '',
+        unitNames,
+      } as DefectWithInfo;
+    });
+  }, [defects, tickets, projects, units]);
+
+  const options = useMemo(() => {
+    const uniq = (arr: any[], key: string) =>
+      Array.from(new Set(arr.map((i) => i[key]).filter(Boolean))).map((v) => ({
+        label: String(v),
+        value: v,
+      }));
+    return {
+      ids: uniq(data, 'id'),
+      tickets: uniq(data.flatMap((d) => d.ticketIds.map((t) => ({ ticket: t }))), 'ticket').map((o) => ({ label: o.label, value: Number(o.label) })),
+      projects: projects.map((p) => ({ label: p.name, value: p.id })),
+      units: units.map((u) => ({ label: u.name, value: u.id })),
+    };
+  }, [data, projects, units]);
+
+  const [filters, setFilters] = useState<DefectFilters>({});
+  const [viewId, setViewId] = useState<number | null>(null);
+
+  return (
+    <ConfigProvider locale={ruRU}>
+      <Card style={{ marginBottom: 24 }}>
+        <DefectsFilters options={options} onChange={setFilters} />
+      </Card>
+      <DefectsTable defects={data} filters={filters} loading={isPending} onView={setViewId} />
+      <DefectViewModal open={viewId !== null} defectId={viewId} onClose={() => setViewId(null)} />
+    </ConfigProvider>
+  );
+}

--- a/src/shared/types/defect.ts
+++ b/src/shared/types/defect.ts
@@ -1,0 +1,25 @@
+/** Запись дефекта в базе данных */
+export interface DefectRecord {
+  /** Уникальный идентификатор */
+  id: number;
+  /** Проект, к которому относится дефект */
+  project_id: number;
+  /** Описание дефекта */
+  description: string;
+  /** Стоимость устранения */
+  fix_cost: number | null;
+  /** Дата создания */
+  created_at: string | null;
+}
+
+/** Дефект с дополнительной информацией для отображения */
+export interface DefectWithInfo extends DefectRecord {
+  /** ID замечаний, содержащих данный дефект */
+  ticketIds: number[];
+  /** Идентификаторы объектов, связанные с замечаниями */
+  unitIds: number[];
+  /** Название проекта */
+  projectName?: string;
+  /** Названия объектов, объединённые в строку */
+  unitNames?: string;
+}

--- a/src/shared/types/defectFilters.ts
+++ b/src/shared/types/defectFilters.ts
@@ -1,0 +1,10 @@
+import { Dayjs } from 'dayjs';
+
+/** Набор фильтров для списка дефектов */
+export interface DefectFilters {
+  id?: number[];
+  ticketId?: number[];
+  project?: number;
+  units?: number[];
+  period?: [Dayjs, Dayjs];
+}

--- a/src/widgets/DefectsFilters.tsx
+++ b/src/widgets/DefectsFilters.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect } from 'react';
+import { Form, Select, Button, DatePicker } from 'antd';
+import type { DefectFilters } from '@/shared/types/defectFilters';
+
+const { RangePicker } = DatePicker;
+
+interface Options {
+  ids: { label: string; value: number }[];
+  tickets: { label: string; value: number }[];
+  projects: { label: string; value: number }[];
+  units: { label: string; value: number }[];
+}
+
+/** Форма фильтров дефектов */
+export default function DefectsFilters({
+  options,
+  onChange,
+  initialValues = {},
+}: {
+  options: Options;
+  onChange: (v: DefectFilters) => void;
+  initialValues?: Partial<DefectFilters>;
+}) {
+  const [form] = Form.useForm();
+  useEffect(() => {
+    form.setFieldsValue(initialValues);
+  }, [initialValues, form]);
+
+  const handleValuesChange = (_: any, values: DefectFilters) => onChange(values);
+
+  const reset = () => {
+    form.resetFields();
+    onChange({});
+  };
+
+  return (
+    <Form form={form} layout="vertical" onValuesChange={handleValuesChange} className="filter-grid">
+      <Form.Item name="id" label="ID">
+        <Select mode="multiple" allowClear options={options.ids} />
+      </Form.Item>
+      <Form.Item name="ticketId" label="№ замечания">
+        <Select mode="multiple" allowClear options={options.tickets} />
+      </Form.Item>
+      <Form.Item name="project" label="Проект">
+        <Select allowClear options={options.projects} />
+      </Form.Item>
+      <Form.Item name="units" label="Объекты">
+        <Select mode="multiple" allowClear options={options.units} />
+      </Form.Item>
+      <Form.Item name="period" label="Дата создания">
+        <RangePicker style={{ width: '100%' }} format="DD.MM.YYYY" />
+      </Form.Item>
+      <Form.Item>
+        <Button onClick={reset} block>
+          Сброс
+        </Button>
+      </Form.Item>
+    </Form>
+  );
+}

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -1,0 +1,58 @@
+import React, { useMemo } from 'react';
+import dayjs from 'dayjs';
+import { Table, Button, Tooltip, Skeleton } from 'antd';
+import { EyeOutlined } from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import type { DefectWithInfo } from '@/shared/types/defect';
+import type { DefectFilters } from '@/shared/types/defectFilters';
+
+const fmt = (v: string | null) =>
+  v ? dayjs(v).format('DD.MM.YYYY') : '—';
+
+interface Props {
+  defects: DefectWithInfo[];
+  filters: DefectFilters;
+  loading?: boolean;
+  onView?: (id: number) => void;
+}
+
+export default function DefectsTable({ defects, filters, loading, onView }: Props) {
+  const filtered = useMemo(() => {
+    return defects.filter((d) => {
+      if (filters.id && !filters.id.includes(d.id)) return false;
+      if (filters.ticketId && !d.ticketIds.some((t) => filters.ticketId!.includes(t))) return false;
+      if (filters.project && d.project_id !== filters.project) return false;
+      if (filters.units && filters.units.length && !d.unitIds.some((u) => filters.units!.includes(u))) return false;
+      if (filters.period) {
+        const [from, to] = filters.period;
+        const created = dayjs(d.created_at);
+        if (!created.isSameOrAfter(from, 'day') || !created.isSameOrBefore(to, 'day')) return false;
+      }
+      return true;
+    });
+  }, [defects, filters]);
+
+  const columns: ColumnsType<DefectWithInfo> = [
+    { title: 'ID', dataIndex: 'id', width: 80 },
+    { title: '№ замечания', dataIndex: 'ticketIds', render: (v) => v.join(', ') },
+    { title: 'Проект', dataIndex: 'projectName' },
+    { title: 'Объекты', dataIndex: 'unitNames' },
+    { title: 'Описание', dataIndex: 'description' },
+    { title: 'Стоимость', dataIndex: 'fix_cost' },
+    { title: 'Дата создания', dataIndex: 'created_at', render: fmt },
+    {
+      title: 'Действия',
+      key: 'actions',
+      width: 80,
+      render: (_, row) => (
+        <Tooltip title="Просмотр">
+          <Button size="small" type="text" icon={<EyeOutlined />} onClick={() => onView && onView(row.id)} />
+        </Tooltip>
+      ),
+    },
+  ];
+
+  if (loading) return <Skeleton active paragraph={{ rows: 6 }} />;
+
+  return <Table rowKey="id" columns={columns} dataSource={filtered} pagination={{ pageSize: 25 }} />;
+}

--- a/src/widgets/NavBar.tsx
+++ b/src/widgets/NavBar.tsx
@@ -67,6 +67,14 @@ const NavBar = () => {
           <Button
             color="inherit"
             component={RouterLink}
+            to="/defects"
+            sx={{ whiteSpace: "normal" }}
+          >
+            Дефекты
+          </Button>
+          <Button
+            color="inherit"
+            component={RouterLink}
             to="/court-cases"
             sx={{ whiteSpace: "normal" }}
           >


### PR DESCRIPTION
## Summary
- add DefectsPage with table and filters
- support fetching defects from DB
- add simple ticket list query for cross links
- add modal view for defect
- link new page in Router and NavBar

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684da99b7b20832e96223a2ae604abac