### PR TITLE
Add defect creation flow

### DIFF
--- a/src/features/ticket/TicketFormAntd.tsx
+++ b/src/features/ticket/TicketFormAntd.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import dayjs, { Dayjs } from 'dayjs';
-import { Form, Input, Select, DatePicker, Switch, Button, Row, Col } from 'antd';
+import { Form, Input, Select, DatePicker, Switch, Button, Row, Col, Table } from 'antd';
 import { PlusOutlined } from '@ant-design/icons';
 import { useDefectTypes } from '@/entities/defectType';
 import { useDefectStatuses } from '@/entities/defectStatus';
@@ -9,6 +9,7 @@ import { useUnitsByProject } from '@/entities/unit';
 import { useUsers } from '@/entities/user';
 import { useProjects } from '@/entities/project';
 import { useCreateTicket } from '@/entities/ticket';
+import { useCreateDefects, type NewDefect } from '@/entities/defect';
 import { useAttachmentTypes } from '@/entities/attachmentType';
 import { useProjectId } from '@/shared/hooks/useProjectId';
 import { useAuthStore } from '@/shared/store/authStore';
@@ -59,6 +60,7 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
   const { data: users = [] } = useUsers();
   const { data: attachmentTypes = [] } = useAttachmentTypes();
   const create = useCreateTicket();
+  const createDefects = useCreateDefects();
   const notify = useNotify();
   const [files, setFiles] = useState<{ file: File; type_id: number | null }[]>([]);
   const profileId = useAuthStore((s) => s.profile?.id);
@@ -111,13 +113,18 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
     }
     try {
       const { pins, defects: _defects, ...rest } = values;
+      const newDefs: NewDefect[] = (_defects || []).map((d) => ({
+        description: d.description || '',
+        defect_type_id: d.type_id ?? null,
+        defect_status_id: d.status_id ?? null,
+        received_at: d.received_at ? d.received_at.format('YYYY-MM-DD') : null,
+      }));
+      const defectIds = await createDefects.mutateAsync(newDefs);
       const payload = {
         ...rest,
         project_id: values.project_id ?? globalProjectId,
         attachments: files,
-        defect_ids: (_defects || [])
-          .map((d) => d.type_id ?? null)
-          .filter((id): id is number => id != null),
+        defect_ids: defectIds,
         received_at: values.received_at.format('YYYY-MM-DD'),
         fixed_at: values.fixed_at ? values.fixed_at.format('YYYY-MM-DD') : null,
         customer_request_date: values.customer_request_date
@@ -194,76 +201,107 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
       </Row>
       <Form.List name="defects">
         {(fields, { add, remove }) => (
-          <>
-            <table style={{ width: '100%', marginBottom: 16 }}>
-              <thead>
-                <tr>
-                  <th style={{ width: 40 }}>ID</th>
-                  <th>Описание дефекта</th>
-                  <th style={{ width: 140 }}>Статус</th>
-                  <th style={{ width: 140 }}>Тип</th>
-                  <th style={{ width: 140 }}>Дата получения</th>
-                  <th style={{ width: 140 }}>Дата устранения</th>
-                  <th style={{ width: 180 }}>Кем устраняется</th>
-                  <th style={{ width: 40 }}></th>
-                </tr>
-              </thead>
-              <tbody>
-                {fields.map((field, index) => (
-                  <tr key={field.key}>
-                    <td>{index + 1}</td>
-                    <td>
-                      <Form.Item name={[field.name, 'description']} noStyle>
-                        <Input placeholder="Описание" />
-                      </Form.Item>
-                    </td>
-                    <td>
-                      <Form.Item name={[field.name, 'status_id']} noStyle initialValue={defectStatuses[0]?.id}>
-                        <Select
-                          placeholder="Статус"
-                          options={defectStatuses.map((s) => ({ value: s.id, label: s.name }))}
-                        />
-                      </Form.Item>
-                    </td>
-                    <td>
-                      <Form.Item name={[field.name, 'type_id']} noStyle>
-                        <Select
-                          placeholder="Тип"
-                          options={defectTypes.map((d) => ({ value: d.id, label: d.name }))}
-                        />
-                      </Form.Item>
-                    </td>
-                    <td>
-                      <Form.Item name={[field.name, 'received_at']} noStyle initialValue={dayjs()}>
-                        <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
-                      </Form.Item>
-                    </td>
-                    <td>
-                      <Form.Item name={[field.name, 'fixed_at']} noStyle>
-                        <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
-                      </Form.Item>
-                    </td>
-                    <td>
-                      <Form.Item name={[field.name, 'fix_by']} noStyle initialValue="own">
-                        <Select
-                          options={[
-                            { value: 'own', label: 'Собственные силы' },
-                            { value: 'contractor', label: 'Подрядчик' },
-                          ]}
-                        />
-                      </Form.Item>
-                    </td>
-                    <td>
-                      <Button type="text" danger onClick={() => remove(field.name)}>
-                        Удалить
-                      </Button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-            <Button type="dashed" onClick={() => add()} icon={<PlusOutlined />}>Добавить дефект</Button>
-          </>
+          <div style={{ maxWidth: '50%' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
+              <span style={{ fontWeight: 500 }}>Дефекты</span>
+              <Button type="dashed" icon={<PlusOutlined />} onClick={() => add()}>
+                Добавить дефект
+              </Button>
+            </div>
+            <Table
+              size="small"
+              pagination={false}
+              rowKey="key"
+              columns={[
+                {
+                  title: '#',
+                  dataIndex: 'index',
+                  width: 40,
+                  render: (_: any, __: any, i: number) => i + 1,
+                },
+                {
+                  title: 'Описание дефекта',
+                  dataIndex: 'description',
+                  render: (_: any, field: any) => (
+                    <Form.Item name={[field.name, 'description']} noStyle>
+                      <Input placeholder="Описание" />
+                    </Form.Item>
+                  ),
+                },
+                {
+                  title: 'Статус',
+                  dataIndex: 'status_id',
+                  render: (_: any, field: any) => (
+                    <Form.Item
+                      name={[field.name, 'status_id']}
+                      noStyle
+                      initialValue={defectStatuses[0]?.id}
+                    >
+                      <Select
+                        placeholder="Статус"
+                        options={defectStatuses.map((s) => ({ value: s.id, label: s.name }))}
+                      />
+                    </Form.Item>
+                  ),
+                },
+                {
+                  title: 'Тип',
+                  dataIndex: 'type_id',
+                  render: (_: any, field: any) => (
+                    <Form.Item name={[field.name, 'type_id']} noStyle>
+                      <Select
+                        placeholder="Тип"
+                        options={defectTypes.map((d) => ({ value: d.id, label: d.name }))}
+                      />
+                    </Form.Item>
+                  ),
+                },
+                {
+                  title: 'Дата получения',
+                  dataIndex: 'received_at',
+                  render: (_: any, field: any) => (
+                    <Form.Item name={[field.name, 'received_at']} noStyle initialValue={dayjs()}>
+                      <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+                    </Form.Item>
+                  ),
+                },
+                {
+                  title: 'Дата устранения',
+                  dataIndex: 'fixed_at',
+                  render: (_: any, field: any) => (
+                    <Form.Item name={[field.name, 'fixed_at']} noStyle>
+                      <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+                    </Form.Item>
+                  ),
+                },
+                {
+                  title: 'Кем устраняется',
+                  dataIndex: 'fix_by',
+                  render: (_: any, field: any) => (
+                    <Form.Item name={[field.name, 'fix_by']} noStyle initialValue="own">
+                      <Select
+                        options={[
+                          { value: 'own', label: 'Собственные силы' },
+                          { value: 'contractor', label: 'Подрядчик' },
+                        ]}
+                      />
+                    </Form.Item>
+                  ),
+                },
+                {
+                  title: '',
+                  dataIndex: 'actions',
+                  width: 80,
+                  render: (_: any, field: any) => (
+                    <Button type="text" danger onClick={() => remove(field.name)}>
+                      Удалить
+                    </Button>
+                  ),
+                },
+              ]}
+              dataSource={fields}
+            />
+          </div>
         )}
       </Form.List>
       <Row gutter={16}>

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -3,7 +3,6 @@ import { ConfigProvider, Card } from 'antd';
 import ruRU from 'antd/locale/ru_RU';
 import { useDefects } from '@/entities/defect';
 import { useTicketsSimple } from '@/entities/ticket';
-import { useProjects } from '@/entities/project';
 import { useUnitsByIds } from '@/entities/unit';
 import DefectsTable from '@/widgets/DefectsTable';
 import DefectsFilters from '@/widgets/DefectsFilters';
@@ -14,7 +13,6 @@ import type { DefectFilters } from '@/shared/types/defectFilters';
 export default function DefectsPage() {
   const { data: defects = [], isPending } = useDefects();
   const { data: tickets = [] } = useTicketsSimple();
-  const { data: projects = [] } = useProjects();
   const unitIds = useMemo(
     () => Array.from(new Set(tickets.flatMap((t) => t.unit_ids || []))),
     [tickets],
@@ -22,7 +20,6 @@ export default function DefectsPage() {
   const { data: units = [] } = useUnitsByIds(unitIds);
 
   const data: DefectWithInfo[] = useMemo(() => {
-    const projectMap = new Map(projects.map((p) => [p.id, p.name]));
     const unitMap = new Map(units.map((u) => [u.id, u.name]));
     const ticketsMap = new Map<number, { id: number; unit_ids: number[] }[]>();
     tickets.forEach((t: any) => {
@@ -43,11 +40,10 @@ export default function DefectsPage() {
         ...d,
         ticketIds: linked.map((l) => l.id),
         unitIds,
-        projectName: projectMap.get(d.project_id) || '',
         unitNames,
       } as DefectWithInfo;
     });
-  }, [defects, tickets, projects, units]);
+  }, [defects, tickets, units]);
 
   const options = useMemo(() => {
     const uniq = (arr: any[], key: string) =>
@@ -58,10 +54,9 @@ export default function DefectsPage() {
     return {
       ids: uniq(data, 'id'),
       tickets: uniq(data.flatMap((d) => d.ticketIds.map((t) => ({ ticket: t }))), 'ticket').map((o) => ({ label: o.label, value: Number(o.label) })),
-      projects: projects.map((p) => ({ label: p.name, value: p.id })),
       units: units.map((u) => ({ label: u.name, value: u.id })),
     };
-  }, [data, projects, units]);
+  }, [data, units]);
 
   const [filters, setFilters] = useState<DefectFilters>({});
   const [viewId, setViewId] = useState<number | null>(null);

--- a/src/shared/types/defect.ts
+++ b/src/shared/types/defect.ts
@@ -2,8 +2,6 @@
 export interface DefectRecord {
   /** Уникальный идентификатор */
   id: number;
-  /** Проект, к которому относится дефект */
-  project_id: number;
   /** Описание дефекта */
   description: string;
   /** Тип дефекта */
@@ -22,8 +20,6 @@ export interface DefectWithInfo extends DefectRecord {
   ticketIds: number[];
   /** Идентификаторы объектов, связанные с замечаниями */
   unitIds: number[];
-  /** Название проекта */
-  projectName?: string;
   /** Названия объектов, объединённые в строку */
   unitNames?: string;
   /** Название типа дефекта */

--- a/src/shared/types/defectFilters.ts
+++ b/src/shared/types/defectFilters.ts
@@ -4,7 +4,6 @@ import { Dayjs } from 'dayjs';
 export interface DefectFilters {
   id?: number[];
   ticketId?: number[];
-  project?: number;
   units?: number[];
   period?: [Dayjs, Dayjs];
 }

--- a/src/widgets/DefectsFilters.tsx
+++ b/src/widgets/DefectsFilters.tsx
@@ -7,7 +7,6 @@ const { RangePicker } = DatePicker;
 interface Options {
   ids: { label: string; value: number }[];
   tickets: { label: string; value: number }[];
-  projects: { label: string; value: number }[];
   units: { label: string; value: number }[];
 }
 
@@ -40,9 +39,6 @@ export default function DefectsFilters({
       </Form.Item>
       <Form.Item name="ticketId" label="№ замечания">
         <Select mode="multiple" allowClear options={options.tickets} />
-      </Form.Item>
-      <Form.Item name="project" label="Проект">
-        <Select allowClear options={options.projects} />
       </Form.Item>
       <Form.Item name="units" label="Объекты">
         <Select mode="multiple" allowClear options={options.units} />

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -21,7 +21,6 @@ export default function DefectsTable({ defects, filters, loading, onView }: Prop
     return defects.filter((d) => {
       if (filters.id && !filters.id.includes(d.id)) return false;
       if (filters.ticketId && !d.ticketIds.some((t) => filters.ticketId!.includes(t))) return false;
-      if (filters.project && d.project_id !== filters.project) return false;
       if (filters.units && filters.units.length && !d.unitIds.some((u) => filters.units!.includes(u))) return false;
       if (filters.period) {
         const [from, to] = filters.period;
@@ -35,7 +34,6 @@ export default function DefectsTable({ defects, filters, loading, onView }: Prop
   const columns: ColumnsType<DefectWithInfo> = [
     { title: 'ID', dataIndex: 'id', width: 80 },
     { title: '№ замечания', dataIndex: 'ticketIds', render: (v) => v.join(', ') },
-    { title: 'Проект', dataIndex: 'projectName' },
     { title: 'Объекты', dataIndex: 'unitNames' },
     { title: 'Описание', dataIndex: 'description' },
     { title: 'Тип', dataIndex: 'defectTypeName' },


### PR DESCRIPTION
## Summary
- allow creating defects from ticket form
- adapt data fetching without project_id
- show defects filters & table without project column
- render defect list in ticket form via Ant Design table
- add helper hook for bulk defect creation

## Testing
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_684db446ab54832e9728d627506dd3e3