### PR TITLE
Fix defects table UI and DB integration

### DIFF
--- a/sql/remove_project_id_from_defects.sql
+++ b/sql/remove_project_id_from_defects.sql
@@ -1,0 +1,2 @@
+-- Удаление колонки project_id из таблицы defects
+ALTER TABLE defects DROP COLUMN IF EXISTS project_id;

--- a/src/entities/courtCase/index.ts
+++ b/src/entities/courtCase/index.ts
@@ -139,15 +139,13 @@ export function useAddDefect() {
   return useMutation({
     /**
      * Creates a defect record and links it to a court case.
-     * `project_id` is required by DB constraints, so it must be provided.
      */
     mutationFn: async (
-      payload: { case_id: number; project_id: number } & Omit<Defect, 'id' | 'case_id'>,
+      payload: { case_id: number } & Omit<Defect, 'id' | 'case_id'>,
     ) => {
       const { data, error } = await supabase
         .from(DEFECTS_TABLE)
         .insert({
-          project_id: payload.project_id,
           description: payload.description,
           defect_type_id: payload.defect_type_id,
           defect_status_id: payload.defect_status_id,

--- a/src/entities/defect.ts
+++ b/src/entities/defect.ts
@@ -1,24 +1,20 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/shared/api/supabaseClient';
-import { useProjectId } from '@/shared/hooks/useProjectId';
-import type { DefectRecord } from '@/shared/types/defect';
+import type { DefectRecord, NewDefect } from '@/shared/types/defect';
 
 const TABLE = 'defects';
 
 /** Получить все дефекты проекта */
 export function useDefects() {
-  const projectId = useProjectId();
   return useQuery<DefectRecord[]>({
-    queryKey: [TABLE, projectId],
-    enabled: !!projectId,
+    queryKey: [TABLE],
     queryFn: async () => {
       const { data, error } = await supabase
         .from(TABLE)
         .select(
-          'id, project_id, description, defect_type_id, defect_status_id, received_at, created_at,' +
+          'id, description, defect_type_id, defect_status_id, received_at, created_at,' +
           ' defect_type:defect_types(id,name), defect_status:defect_statuses(id,name)'
         )
-        .eq('project_id', projectId)
         .order('id');
       if (error) throw error;
       return data as DefectRecord[];
@@ -29,23 +25,41 @@ export function useDefects() {
 
 /** Получить дефект по ID */
 export function useDefect(id?: number) {
-  const projectId = useProjectId();
   return useQuery<DefectRecord | null>({
     queryKey: ['defect', id],
-    enabled: !!id && !!projectId,
+    enabled: !!id,
     queryFn: async () => {
       const { data, error } = await supabase
         .from(TABLE)
         .select(
-          'id, project_id, description, defect_type_id, defect_status_id, received_at, created_at,' +
+          'id, description, defect_type_id, defect_status_id, received_at, created_at,' +
           ' defect_type:defect_types(id,name), defect_status:defect_statuses(id,name)'
         )
         .eq('id', id as number)
-        .eq('project_id', projectId)
         .single();
       if (error) throw error;
       return data as DefectRecord;
     },
     staleTime: 5 * 60_000,
+  });
+}
+
+/**
+ * Создать несколько дефектов.
+ * Возвращает массив идентификаторов созданных записей.
+ */
+export function useAddDefects() {
+  const qc = useQueryClient();
+  return useMutation<number[], Error, NewDefect[]>({
+    mutationFn: async (rows) => {
+      if (!rows.length) return [];
+      const { data, error } = await supabase
+        .from(TABLE)
+        .insert(rows)
+        .select('id');
+      if (error) throw error;
+      return (data ?? []).map((r) => r.id as number);
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: [TABLE] }),
   });
 }

--- a/src/features/ticket/TicketFormAntd.tsx
+++ b/src/features/ticket/TicketFormAntd.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import dayjs, { Dayjs } from 'dayjs';
-import { Form, Input, Select, DatePicker, Switch, Button, Row, Col } from 'antd';
+import { Form, Input, Select, DatePicker, Switch, Button, Row, Col, Table } from 'antd';
 import { PlusOutlined } from '@ant-design/icons';
 import { useDefectTypes } from '@/entities/defectType';
 import { useDefectStatuses } from '@/entities/defectStatus';
@@ -9,6 +9,7 @@ import { useUnitsByProject } from '@/entities/unit';
 import { useUsers } from '@/entities/user';
 import { useProjects } from '@/entities/project';
 import { useCreateTicket } from '@/entities/ticket';
+import { useAddDefects } from '@/entities/defect';
 import { useAttachmentTypes } from '@/entities/attachmentType';
 import { useProjectId } from '@/shared/hooks/useProjectId';
 import { useAuthStore } from '@/shared/store/authStore';
@@ -41,7 +42,14 @@ export interface TicketFormAntdValues {
   is_warranty: boolean;
   received_at: Dayjs;
   fixed_at: Dayjs | null;
-  defects?: Array<{ type_id: number | null; fixed_at: Dayjs | null; fix_by: string }>;
+  defects?: Array<{
+    description?: string;
+    status_id: number | null;
+    type_id: number | null;
+    received_at: Dayjs;
+    fixed_at: Dayjs | null;
+    fix_by: string;
+  }>;
   /** Дополнительные данные разметки, не отправляются на сервер */
   pins?: unknown;
 }
@@ -58,6 +66,7 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
   const { data: units = [] } = useUnitsByProject(projectId);
   const { data: users = [] } = useUsers();
   const { data: attachmentTypes = [] } = useAttachmentTypes();
+  const addDefects = useAddDefects();
   const create = useCreateTicket();
   const notify = useNotify();
   const [files, setFiles] = useState<{ file: File; type_id: number | null }[]>([]);
@@ -111,13 +120,19 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
     }
     try {
       const { pins, defects: _defects, ...rest } = values;
+      const defectsPayload = (_defects || []).map((d) => ({
+        description: d.description || '',
+        defect_type_id: d.type_id ?? null,
+        defect_status_id: d.status_id ?? null,
+        received_at: d.received_at?.format('YYYY-MM-DD') ?? null,
+        fixed_at: d.fixed_at?.format('YYYY-MM-DD') ?? null,
+      }));
+      const defectIds = await addDefects.mutateAsync(defectsPayload);
       const payload = {
         ...rest,
         project_id: values.project_id ?? globalProjectId,
         attachments: files,
-        defect_ids: (_defects || [])
-          .map((d) => d.type_id ?? null)
-          .filter((id): id is number => id != null),
+        defect_ids: defectIds,
         received_at: values.received_at.format('YYYY-MM-DD'),
         fixed_at: values.fixed_at ? values.fixed_at.format('YYYY-MM-DD') : null,
         customer_request_date: values.customer_request_date
@@ -193,78 +208,109 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
         </Col>
       </Row>
       <Form.List name="defects">
-        {(fields, { add, remove }) => (
-          <>
-            <table style={{ width: '100%', marginBottom: 16 }}>
-              <thead>
-                <tr>
-                  <th style={{ width: 40 }}>ID</th>
-                  <th>Описание дефекта</th>
-                  <th style={{ width: 140 }}>Статус</th>
-                  <th style={{ width: 140 }}>Тип</th>
-                  <th style={{ width: 140 }}>Дата получения</th>
-                  <th style={{ width: 140 }}>Дата устранения</th>
-                  <th style={{ width: 180 }}>Кем устраняется</th>
-                  <th style={{ width: 40 }}></th>
-                </tr>
-              </thead>
-              <tbody>
-                {fields.map((field, index) => (
-                  <tr key={field.key}>
-                    <td>{index + 1}</td>
-                    <td>
-                      <Form.Item name={[field.name, 'description']} noStyle>
-                        <Input placeholder="Описание" />
-                      </Form.Item>
-                    </td>
-                    <td>
-                      <Form.Item name={[field.name, 'status_id']} noStyle initialValue={defectStatuses[0]?.id}>
-                        <Select
-                          placeholder="Статус"
-                          options={defectStatuses.map((s) => ({ value: s.id, label: s.name }))}
-                        />
-                      </Form.Item>
-                    </td>
-                    <td>
-                      <Form.Item name={[field.name, 'type_id']} noStyle>
-                        <Select
-                          placeholder="Тип"
-                          options={defectTypes.map((d) => ({ value: d.id, label: d.name }))}
-                        />
-                      </Form.Item>
-                    </td>
-                    <td>
-                      <Form.Item name={[field.name, 'received_at']} noStyle initialValue={dayjs()}>
-                        <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
-                      </Form.Item>
-                    </td>
-                    <td>
-                      <Form.Item name={[field.name, 'fixed_at']} noStyle>
-                        <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
-                      </Form.Item>
-                    </td>
-                    <td>
-                      <Form.Item name={[field.name, 'fix_by']} noStyle initialValue="own">
-                        <Select
-                          options={[
-                            { value: 'own', label: 'Собственные силы' },
-                            { value: 'contractor', label: 'Подрядчик' },
-                          ]}
-                        />
-                      </Form.Item>
-                    </td>
-                    <td>
-                      <Button type="text" danger onClick={() => remove(field.name)}>
-                        Удалить
-                      </Button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-            <Button type="dashed" onClick={() => add()} icon={<PlusOutlined />}>Добавить дефект</Button>
-          </>
-        )}
+        {(fields, { add, remove }) => {
+          const columns = [
+            {
+              title: 'ID',
+              dataIndex: 'index',
+              width: 40,
+              render: (_: any, __: any, idx: number) => idx + 1,
+            },
+            {
+              title: 'Описание дефекта',
+              dataIndex: 'description',
+              render: (_: any, field: any) => (
+                <Form.Item name={[field.name, 'description']} noStyle>
+                  <Input placeholder="Описание" />
+                </Form.Item>
+              ),
+            },
+            {
+              title: 'Статус',
+              dataIndex: 'status',
+              width: 140,
+              render: (_: any, field: any) => (
+                <Form.Item name={[field.name, 'status_id']} noStyle initialValue={defectStatuses[0]?.id}>
+                  <Select placeholder="Статус" options={defectStatuses.map((s) => ({ value: s.id, label: s.name }))} />
+                </Form.Item>
+              ),
+            },
+            {
+              title: 'Тип',
+              dataIndex: 'type',
+              width: 140,
+              render: (_: any, field: any) => (
+                <Form.Item name={[field.name, 'type_id']} noStyle>
+                  <Select placeholder="Тип" options={defectTypes.map((d) => ({ value: d.id, label: d.name }))} />
+                </Form.Item>
+              ),
+            },
+            {
+              title: 'Дата получения',
+              dataIndex: 'received',
+              width: 140,
+              render: (_: any, field: any) => (
+                <Form.Item name={[field.name, 'received_at']} noStyle initialValue={dayjs()}>
+                  <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+                </Form.Item>
+              ),
+            },
+            {
+              title: 'Дата устранения',
+              dataIndex: 'fixed',
+              width: 140,
+              render: (_: any, field: any) => (
+                <Form.Item name={[field.name, 'fixed_at']} noStyle>
+                  <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+                </Form.Item>
+              ),
+            },
+            {
+              title: 'Кем устраняется',
+              dataIndex: 'fix_by',
+              width: 180,
+              render: (_: any, field: any) => (
+                <Form.Item name={[field.name, 'fix_by']} noStyle initialValue="own">
+                  <Select
+                    options={[
+                      { value: 'own', label: 'Собственные силы' },
+                      { value: 'contractor', label: 'Подрядчик' },
+                    ]}
+                  />
+                </Form.Item>
+              ),
+            },
+            {
+              title: '',
+              dataIndex: 'actions',
+              width: 40,
+              render: (_: any, field: any) => (
+                <Button type="text" danger onClick={() => remove(field.name)}>
+                  Удалить
+                </Button>
+              ),
+            },
+          ];
+          const data = fields.map((f) => ({ ...f, key: f.key }));
+          return (
+            <Table
+              columns={columns as any}
+              dataSource={data}
+              pagination={false}
+              rowKey="key"
+              size="middle"
+              style={{ maxWidth: '50%', marginBottom: 16 }}
+              title={() => (
+                <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                  <span>Дефекты</span>
+                  <Button type="dashed" onClick={() => add()} icon={<PlusOutlined />}>
+                    Добавить дефект
+                  </Button>
+                </div>
+              )}
+            />
+          );
+        }}
       </Form.List>
       <Row gutter={16}>
         <Col span={8}>

--- a/src/shared/types/defect.ts
+++ b/src/shared/types/defect.ts
@@ -2,8 +2,6 @@
 export interface DefectRecord {
   /** Уникальный идентификатор */
   id: number;
-  /** Проект, к которому относится дефект */
-  project_id: number;
   /** Описание дефекта */
   description: string;
   /** Тип дефекта */
@@ -30,4 +28,13 @@ export interface DefectWithInfo extends DefectRecord {
   defectTypeName?: string;
   /** Название статуса дефекта */
   defectStatusName?: string;
+}
+
+/** Данные для создания нового дефекта */
+export interface NewDefect {
+  description: string;
+  defect_type_id: number | null;
+  defect_status_id: number | null;
+  received_at: string | null;
+  fixed_at: string | null;
 }


### PR DESCRIPTION
## Summary
- adjust `DefectRecord` type and add `NewDefect`
- fetch defects without project filtering and add `useAddDefects`
- update court case defect creation
- enhance ticket form: create defects in DB and display editable table via Ant Design
- provide SQL script to drop `project_id` column from `defects`

## Testing
- `npm run lint` *(fails: Parsing error and missing eslint plugins)*

------
https://chatgpt.com/codex/tasks/task_e_684db446ab54832e9728d627506dd3e3