### PR TITLE
Refactor defect input table

### DIFF
--- a/src/features/ticket/TicketFormAntd.tsx
+++ b/src/features/ticket/TicketFormAntd.tsx
@@ -1,9 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import dayjs, { Dayjs } from 'dayjs';
-import { Form, Input, Select, DatePicker, Switch, Button, Row, Col, Table } from 'antd';
-import { PlusOutlined } from '@ant-design/icons';
-import { useDefectTypes } from '@/entities/defectType';
-import { useDefectStatuses } from '@/entities/defectStatus';
+import { Form, Input, Select, DatePicker, Switch, Button, Row, Col } from 'antd';
 import { useTicketStatuses } from '@/entities/ticketStatus';
 import { useUnitsByProject } from '@/entities/unit';
 import { useUsers } from '@/entities/user';
@@ -15,6 +12,7 @@ import { useProjectId } from '@/shared/hooks/useProjectId';
 import { useAuthStore } from '@/shared/store/authStore';
 import FileDropZone from '@/shared/ui/FileDropZone';
 import { useNotify } from '@/shared/hooks/useNotify';
+import DefectEditableTable from '@/widgets/DefectEditableTable';
 
 /**
  * Форма создания замечания на основе Ant Design.
@@ -52,8 +50,6 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
   const globalProjectId = useProjectId();
   const projectId = Form.useWatch('project_id', form) ?? globalProjectId;
 
-  const { data: defectTypes = [] } = useDefectTypes();
-  const { data: defectStatuses = [] } = useDefectStatuses();
   const { data: statuses = [] } = useTicketStatuses();
   const { data: projects = [] } = useProjects();
   const { data: units = [] } = useUnitsByProject(projectId);
@@ -201,107 +197,7 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
       </Row>
       <Form.List name="defects">
         {(fields, { add, remove }) => (
-          <div style={{ maxWidth: '50%' }}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
-              <span style={{ fontWeight: 500 }}>Дефекты</span>
-              <Button type="dashed" icon={<PlusOutlined />} onClick={() => add()}>
-                Добавить дефект
-              </Button>
-            </div>
-            <Table
-              size="small"
-              pagination={false}
-              rowKey="key"
-              columns={[
-                {
-                  title: '#',
-                  dataIndex: 'index',
-                  width: 40,
-                  render: (_: any, __: any, i: number) => i + 1,
-                },
-                {
-                  title: 'Описание дефекта',
-                  dataIndex: 'description',
-                  render: (_: any, field: any) => (
-                    <Form.Item name={[field.name, 'description']} noStyle>
-                      <Input placeholder="Описание" />
-                    </Form.Item>
-                  ),
-                },
-                {
-                  title: 'Статус',
-                  dataIndex: 'status_id',
-                  render: (_: any, field: any) => (
-                    <Form.Item
-                      name={[field.name, 'status_id']}
-                      noStyle
-                      initialValue={defectStatuses[0]?.id}
-                    >
-                      <Select
-                        placeholder="Статус"
-                        options={defectStatuses.map((s) => ({ value: s.id, label: s.name }))}
-                      />
-                    </Form.Item>
-                  ),
-                },
-                {
-                  title: 'Тип',
-                  dataIndex: 'type_id',
-                  render: (_: any, field: any) => (
-                    <Form.Item name={[field.name, 'type_id']} noStyle>
-                      <Select
-                        placeholder="Тип"
-                        options={defectTypes.map((d) => ({ value: d.id, label: d.name }))}
-                      />
-                    </Form.Item>
-                  ),
-                },
-                {
-                  title: 'Дата получения',
-                  dataIndex: 'received_at',
-                  render: (_: any, field: any) => (
-                    <Form.Item name={[field.name, 'received_at']} noStyle initialValue={dayjs()}>
-                      <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
-                    </Form.Item>
-                  ),
-                },
-                {
-                  title: 'Дата устранения',
-                  dataIndex: 'fixed_at',
-                  render: (_: any, field: any) => (
-                    <Form.Item name={[field.name, 'fixed_at']} noStyle>
-                      <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
-                    </Form.Item>
-                  ),
-                },
-                {
-                  title: 'Кем устраняется',
-                  dataIndex: 'fix_by',
-                  render: (_: any, field: any) => (
-                    <Form.Item name={[field.name, 'fix_by']} noStyle initialValue="own">
-                      <Select
-                        options={[
-                          { value: 'own', label: 'Собственные силы' },
-                          { value: 'contractor', label: 'Подрядчик' },
-                        ]}
-                      />
-                    </Form.Item>
-                  ),
-                },
-                {
-                  title: '',
-                  dataIndex: 'actions',
-                  width: 80,
-                  render: (_: any, field: any) => (
-                    <Button type="text" danger onClick={() => remove(field.name)}>
-                      Удалить
-                    </Button>
-                  ),
-                },
-              ]}
-              dataSource={fields}
-            />
-          </div>
+          <DefectEditableTable fields={fields} add={add} remove={remove} />
         )}
       </Form.List>
       <Row gutter={16}>

--- a/src/widgets/DefectEditableTable.tsx
+++ b/src/widgets/DefectEditableTable.tsx
@@ -1,0 +1,158 @@
+import React, { useMemo } from 'react';
+import dayjs from 'dayjs';
+import {
+  Table,
+  Button,
+  Form,
+  Input,
+  Select,
+  DatePicker,
+  Skeleton,
+  Tooltip,
+} from 'antd';
+import { PlusOutlined, DeleteOutlined } from '@ant-design/icons';
+import { useDefectTypes } from '@/entities/defectType';
+import { useDefectStatuses } from '@/entities/defectStatus';
+import type { ColumnsType } from 'antd/es/table';
+
+/**
+ * Props for {@link DefectEditableTable}
+ */
+interface Props {
+  fields: any[];
+  add: () => void;
+  remove: (index: number) => void;
+}
+
+/**
+ * Editable table for adding defects inside ticket form.
+ * Shows skeleton until defect types and statuses are loaded.
+ */
+export default function DefectEditableTable({ fields, add, remove }: Props) {
+  const { data: defectTypes = [], isPending: loadingTypes } = useDefectTypes();
+  const { data: defectStatuses = [], isPending: loadingStatuses } = useDefectStatuses();
+
+  const columns: ColumnsType<any> = useMemo(
+    () => [
+      {
+        title: '#',
+        dataIndex: 'index',
+        width: 40,
+        render: (_: any, __: any, i: number) => i + 1,
+      },
+      {
+        title: 'Описание дефекта',
+        dataIndex: 'description',
+        ellipsis: true,
+        render: (_: any, field: any) => (
+          <Form.Item name={[field.name, 'description']} noStyle>
+            <Input.TextArea size="small" autoSize placeholder="Описание" />
+          </Form.Item>
+        ),
+      },
+      {
+        title: 'Статус',
+        dataIndex: 'status_id',
+        ellipsis: true,
+        render: (_: any, field: any) => (
+          <Form.Item name={[field.name, 'status_id']} noStyle initialValue={defectStatuses[0]?.id}>
+            <Select
+              size="small"
+              placeholder="Статус"
+              options={defectStatuses.map((s) => ({ value: s.id, label: s.name }))}
+            />
+          </Form.Item>
+        ),
+      },
+      {
+        title: 'Тип',
+        dataIndex: 'type_id',
+        ellipsis: true,
+        render: (_: any, field: any) => (
+          <Form.Item name={[field.name, 'type_id']} noStyle>
+            <Select
+              size="small"
+              placeholder="Тип"
+              options={defectTypes.map((d) => ({ value: d.id, label: d.name }))}
+            />
+          </Form.Item>
+        ),
+      },
+      {
+        title: 'Дата получения',
+        dataIndex: 'received_at',
+        ellipsis: true,
+        render: (_: any, field: any) => (
+          <Form.Item name={[field.name, 'received_at']} noStyle initialValue={dayjs()}>
+            <DatePicker size="small" format="DD.MM.YYYY" style={{ width: '100%' }} />
+          </Form.Item>
+        ),
+      },
+      {
+        title: 'Дата устранения',
+        dataIndex: 'fixed_at',
+        ellipsis: true,
+        render: (_: any, field: any) => (
+          <Form.Item name={[field.name, 'fixed_at']} noStyle>
+            <DatePicker size="small" format="DD.MM.YYYY" style={{ width: '100%' }} />
+          </Form.Item>
+        ),
+      },
+      {
+        title: 'Кем устраняется',
+        dataIndex: 'fix_by',
+        ellipsis: true,
+        render: (_: any, field: any) => (
+          <Form.Item name={[field.name, 'fix_by']} noStyle initialValue="own">
+            <Select
+              size="small"
+              options={[
+                { value: 'own', label: 'Собственные силы' },
+                { value: 'contractor', label: 'Подрядчик' },
+              ]}
+            />
+          </Form.Item>
+        ),
+      },
+      {
+        title: '',
+        dataIndex: 'actions',
+        width: 60,
+        render: (_: any, field: any) => (
+          <Tooltip title="Удалить">
+            <Button
+              size="small"
+              type="text"
+              danger
+              icon={<DeleteOutlined />}
+              onClick={() => remove(field.name)}
+            />
+          </Tooltip>
+        ),
+      },
+    ],
+    [defectTypes, defectStatuses, remove],
+  );
+
+  if (loadingTypes || loadingStatuses) {
+    return <Skeleton active paragraph={{ rows: 4 }} />;
+  }
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
+        <span style={{ fontWeight: 500 }}>Дефекты</span>
+        <Button type="dashed" icon={<PlusOutlined />} onClick={() => add()}>
+          Добавить дефект
+        </Button>
+      </div>
+      <Table
+        size="small"
+        pagination={false}
+        rowKey="key"
+        columns={columns}
+        dataSource={fields}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- refactor ticket form to use `DefectEditableTable`
- create new widget `DefectEditableTable` with ellipsis and skeleton loading

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684dbec9cb9c832e87c58b758bb6e2fe