### PR TITLE
Fix defects columns and add column settings

### DIFF
--- a/src/entities/defect.ts
+++ b/src/entities/defect.ts
@@ -70,3 +70,18 @@ export function useCreateDefects() {
     onError: (e) => notify.error(e.message),
   });
 }
+
+/** Удалить дефект */
+export function useDeleteDefect() {
+  const qc = useQueryClient();
+  const notify = useNotify();
+  return useMutation<number, Error, number>({
+    mutationFn: async (id: number) => {
+      const { error } = await supabase.from(TABLE).delete().eq('id', id);
+      if (error) throw error;
+      return id;
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: [TABLE] }),
+    onError: (e) => notify.error(e.message),
+  });
+}

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -1,14 +1,20 @@
 import React, { useMemo, useState } from 'react';
-import { ConfigProvider, Card } from 'antd';
+import dayjs from 'dayjs';
+import { ConfigProvider, Card, Button } from 'antd';
+import { SettingOutlined } from '@ant-design/icons';
 import ruRU from 'antd/locale/ru_RU';
 import { useDefects } from '@/entities/defect';
 import { useTicketsSimple } from '@/entities/ticket';
 import { useUnitsByIds } from '@/entities/unit';
 import DefectsTable from '@/widgets/DefectsTable';
 import DefectsFilters from '@/widgets/DefectsFilters';
+import TableColumnsDrawer from '@/widgets/TableColumnsDrawer';
+import type { TableColumnSetting } from '@/shared/types/tableColumnSetting';
 import DefectViewModal from '@/features/defect/DefectViewModal';
 import type { DefectWithInfo } from '@/shared/types/defect';
 import type { DefectFilters } from '@/shared/types/defectFilters';
+
+const fmt = (v: string | null) => (v ? dayjs(v).format('DD.MM.YYYY') : '—');
 
 export default function DefectsPage() {
   const { data: defects = [], isPending } = useDefects();
@@ -29,7 +35,7 @@ export default function DefectsPage() {
         ticketsMap.set(id, arr);
       });
     });
-    return defects.map((d) => {
+    return defects.map((d: any) => {
       const linked = ticketsMap.get(d.id) || [];
       const unitIds = Array.from(new Set(linked.flatMap((l) => l.unit_ids)));
       const unitNames = unitIds
@@ -41,6 +47,8 @@ export default function DefectsPage() {
         ticketIds: linked.map((l) => l.id),
         unitIds,
         unitNames,
+        defectTypeName: d.defect_type?.name ?? '',
+        defectStatusName: d.defect_status?.name ?? '',
       } as DefectWithInfo;
     });
   }, [defects, tickets, units]);
@@ -61,13 +69,131 @@ export default function DefectsPage() {
   const [filters, setFilters] = useState<DefectFilters>({});
   const [viewId, setViewId] = useState<number | null>(null);
 
+  const LS_FILTERS_VISIBLE_KEY = 'defectsFiltersVisible';
+  const LS_COLUMNS_KEY = 'defectsColumns';
+
+  const [showFilters, setShowFilters] = useState(() => {
+    try {
+      const saved = localStorage.getItem(LS_FILTERS_VISIBLE_KEY);
+      return saved ? JSON.parse(saved) : true;
+    } catch {
+      return true;
+    }
+  });
+
+  const baseColumns = useMemo(() => {
+    return {
+      id: { title: 'ID', dataIndex: 'id', width: 80 },
+      tickets: {
+        title: '№ замечания',
+        dataIndex: 'ticketIds',
+        render: (v: number[]) => v.join(', '),
+      },
+      units: { title: 'Объекты', dataIndex: 'unitNames' },
+      description: { title: 'Описание', dataIndex: 'description' },
+      type: { title: 'Тип', dataIndex: 'defectTypeName' },
+      status: { title: 'Статус', dataIndex: 'defectStatusName' },
+      received: {
+        title: 'Дата получения',
+        dataIndex: 'received_at',
+        render: fmt,
+      },
+      created: {
+        title: 'Дата создания',
+        dataIndex: 'created_at',
+        render: fmt,
+      },
+      actions: {
+        title: 'Действия',
+        key: 'actions',
+      } as any,
+    } as Record<string, ColumnsType<DefectWithInfo>[number]>;
+  }, []);
+
+  const [columnsState, setColumnsState] = useState<TableColumnSetting[]>(() => {
+    const base = baseColumns;
+    const defaults = Object.keys(base).map((key) => ({
+      key,
+      title: base[key].title as string,
+      visible: true,
+    }));
+    try {
+      const saved = localStorage.getItem(LS_COLUMNS_KEY);
+      if (saved) {
+        const parsed = JSON.parse(saved) as TableColumnSetting[];
+        return parsed.filter((c) => base[c.key]);
+      }
+    } catch {}
+    return defaults;
+  });
+
+  const handleResetColumns = () => {
+    const base = baseColumns;
+    const defaults = Object.keys(base).map((key) => ({
+      key,
+      title: base[key].title as string,
+      visible: true,
+    }));
+    setColumnsState(defaults);
+  };
+
+  React.useEffect(() => {
+    try {
+      localStorage.setItem(LS_COLUMNS_KEY, JSON.stringify(columnsState));
+    } catch {}
+  }, [columnsState]);
+
+  React.useEffect(() => {
+    try {
+      localStorage.setItem(LS_FILTERS_VISIBLE_KEY, JSON.stringify(showFilters));
+    } catch {}
+  }, [showFilters]);
+
+  const columns = useMemo(() => {
+    const base = baseColumns;
+    return columnsState
+      .filter((c) => c.visible)
+      .map((c) => base[c.key]);
+  }, [columnsState, baseColumns]);
+
+  const [showColumnsDrawer, setShowColumnsDrawer] = useState(false);
+
   return (
     <ConfigProvider locale={ruRU}>
-      <Card style={{ marginBottom: 24 }}>
-        <DefectsFilters options={options} onChange={setFilters} />
-      </Card>
-      <DefectsTable defects={data} filters={filters} loading={isPending} onView={setViewId} />
-      <DefectViewModal open={viewId !== null} defectId={viewId} onClose={() => setViewId(null)} />
+      <>
+        <Button onClick={() => setShowFilters((p) => !p)} style={{ marginTop: 16 }}>
+          {showFilters ? 'Скрыть фильтры' : 'Показать фильтры'}
+        </Button>
+        <Button
+          icon={<SettingOutlined />}
+          style={{ marginTop: 16, marginLeft: 8 }}
+          onClick={() => setShowColumnsDrawer(true)}
+        />
+        {showFilters && (
+          <Card style={{ marginTop: 16, marginBottom: 24 }}>
+            <DefectsFilters options={options} onChange={setFilters} />
+          </Card>
+        )}
+        <DefectsTable
+          defects={data}
+          filters={filters}
+          loading={isPending}
+          onView={setViewId}
+          columns={columns}
+        />
+        <TableColumnsDrawer
+          open={showColumnsDrawer}
+          columns={columnsState}
+          onChange={setColumnsState}
+          onClose={() => setShowColumnsDrawer(false)}
+          onReset={handleResetColumns}
+        />
+        <DefectViewModal
+          open={viewId !== null}
+          defectId={viewId}
+          onClose={() => setViewId(null)}
+        />
+      </>
     </ConfigProvider>
   );
 }


### PR DESCRIPTION
## Summary
- show defect type and status names
- allow hiding filters and configuring columns
- add delete action for defects

## Testing
- `npm run lint` *(fails: missing eslint plugins)*
- `npm run build` *(fails: vite not installed)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684dd1c47de8832ea3a7756e18cddd70