### PR TITLE
fix dayjs max usage

### DIFF
--- a/src/features/ticket/TicketFormAntd.tsx
+++ b/src/features/ticket/TicketFormAntd.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import dayjs, { Dayjs } from 'dayjs';
+import minMax from 'dayjs/plugin/minMax';
+
+dayjs.extend(minMax);
 import { Form, Input, Select, DatePicker, Switch, Button, Row, Col } from 'antd';
 import { useTicketStatuses } from '@/entities/ticketStatus';
 import { useUnitsByProject } from '@/entities/unit';


### PR DESCRIPTION
## Summary
- extend dayjs with `minMax` plugin for ticket form

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684dd26a8f08832ebe2b00cc0c7da1e4