### PR TITLE
Implement export and stats for defects

### DIFF
--- a/src/features/defect/ExportDefectsButton.tsx
+++ b/src/features/defect/ExportDefectsButton.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Button, Tooltip } from 'antd';
+import { DownloadOutlined } from '@ant-design/icons';
+import ExcelJS from 'exceljs';
+import { saveAs } from 'file-saver';
+import dayjs from 'dayjs';
+import type { DefectWithInfo } from '@/shared/types/defect';
+import type { DefectFilters } from '@/shared/types/defectFilters';
+import { filterDefects } from '@/shared/utils/defectFilter';
+
+export interface ExportDefectsButtonProps {
+  /** Список дефектов */
+  defects: DefectWithInfo[];
+  /** Активные фильтры */
+  filters: DefectFilters;
+}
+
+/** Кнопка выгрузки дефектов в Excel */
+export default function ExportDefectsButton({
+  defects,
+  filters,
+}: ExportDefectsButtonProps) {
+  const handleClick = React.useCallback(async () => {
+    const rows = filterDefects(defects, filters).map((d) => ({
+      ID: d.id,
+      '№ замечания': d.ticketIds.join(', '),
+      Объекты: d.unitNames ?? '',
+      Описание: d.description,
+      Тип: d.defectTypeName ?? '',
+      Статус: d.defectStatusName ?? '',
+      'Дата получения': d.received_at ? dayjs(d.received_at).format('DD.MM.YYYY') : '',
+      'Дата создания': d.created_at ? dayjs(d.created_at).format('DD.MM.YYYY') : '',
+    }));
+    const wb = new ExcelJS.Workbook();
+    const ws = wb.addWorksheet('Defects');
+    if (rows.length) {
+      ws.columns = Object.keys(rows[0]).map((key) => ({ header: key, key }));
+      rows.forEach((r) => ws.addRow(r));
+    }
+    const buffer = await wb.xlsx.writeBuffer();
+    saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'defects.xlsx');
+  }, [defects, filters]);
+
+  return (
+    <Tooltip title="Выгрузить в Excel">
+      <Button icon={<DownloadOutlined />} onClick={handleClick} />
+    </Tooltip>
+  );
+}

--- a/src/shared/utils/defectFilter.ts
+++ b/src/shared/utils/defectFilter.ts
@@ -1,0 +1,41 @@
+import dayjs from 'dayjs';
+import type { DefectFilters } from '@/shared/types/defectFilters';
+
+/**
+ * Фильтрация массива дефектов согласно активным фильтрам.
+ * Возвращает только те записи, которые удовлетворяют условиям.
+ */
+export function filterDefects<T extends {
+  id: number;
+  ticketIds: number[];
+  unitIds: number[];
+  created_at: string | null;
+}>(rows: T[], f: DefectFilters): T[] {
+  return rows.filter((d) => {
+    if (Array.isArray(f.id) && f.id.length > 0 && !f.id.includes(d.id)) {
+      return false;
+    }
+    if (
+      Array.isArray(f.ticketId) &&
+      f.ticketId.length > 0 &&
+      !d.ticketIds.some((t) => f.ticketId!.includes(t))
+    ) {
+      return false;
+    }
+    if (
+      Array.isArray(f.units) &&
+      f.units.length > 0 &&
+      !d.unitIds.some((u) => f.units!.includes(u))
+    ) {
+      return false;
+    }
+    if (f.period && f.period.length === 2) {
+      const [from, to] = f.period;
+      const created = dayjs(d.created_at);
+      if (!created.isSameOrAfter(from, 'day') || !created.isSameOrBefore(to, 'day')) {
+        return false;
+      }
+    }
+    return true;
+  });
+}

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -36,14 +36,57 @@ export default function DefectsTable({ defects, filters, loading, columns: colum
   }, [defects, filters]);
 
   const defaultColumns: ColumnsType<DefectWithInfo> = [
-    { title: 'ID', dataIndex: 'id', width: 80 },
-    { title: '№ замечания', dataIndex: 'ticketIds', render: (v) => v.join(', ') },
-    { title: 'Объекты', dataIndex: 'unitNames' },
-    { title: 'Описание', dataIndex: 'description' },
-    { title: 'Тип', dataIndex: 'defectTypeName' },
-    { title: 'Статус', dataIndex: 'defectStatusName' },
-    { title: 'Дата получения', dataIndex: 'received_at', render: fmt },
-    { title: 'Дата создания', dataIndex: 'created_at', render: fmt },
+    {
+      title: 'ID',
+      dataIndex: 'id',
+      width: 80,
+      sorter: (a, b) => a.id - b.id,
+    },
+    {
+      title: '№ замечания',
+      dataIndex: 'ticketIds',
+      sorter: (a, b) =>
+        a.ticketIds.join(',').localeCompare(b.ticketIds.join(',')),
+      render: (v: number[]) => v.join(', '),
+    },
+    {
+      title: 'Объекты',
+      dataIndex: 'unitNames',
+      sorter: (a, b) => (a.unitNames || '').localeCompare(b.unitNames || ''),
+    },
+    {
+      title: 'Описание',
+      dataIndex: 'description',
+      sorter: (a, b) => a.description.localeCompare(b.description),
+    },
+    {
+      title: 'Тип',
+      dataIndex: 'defectTypeName',
+      sorter: (a, b) =>
+        (a.defectTypeName || '').localeCompare(b.defectTypeName || ''),
+    },
+    {
+      title: 'Статус',
+      dataIndex: 'defectStatusName',
+      sorter: (a, b) =>
+        (a.defectStatusName || '').localeCompare(b.defectStatusName || ''),
+    },
+    {
+      title: 'Дата получения',
+      dataIndex: 'received_at',
+      sorter: (a, b) =>
+        (a.received_at ? dayjs(a.received_at).valueOf() : 0) -
+        (b.received_at ? dayjs(b.received_at).valueOf() : 0),
+      render: fmt,
+    },
+    {
+      title: 'Дата создания',
+      dataIndex: 'created_at',
+      sorter: (a, b) =>
+        (a.created_at ? dayjs(a.created_at).valueOf() : 0) -
+        (b.created_at ? dayjs(b.created_at).valueOf() : 0),
+      render: fmt,
+    },
     {
       title: 'Действия',
       key: 'actions',
@@ -74,5 +117,13 @@ export default function DefectsTable({ defects, filters, loading, columns: colum
 
   if (loading) return <Skeleton active paragraph={{ rows: 6 }} />;
 
-  return <Table rowKey="id" columns={columns} dataSource={filtered} pagination={{ pageSize: 25 }} />;
+  return (
+    <Table
+      rowKey="id"
+      columns={columns}
+      dataSource={filtered}
+      pagination={{ pageSize: 25 }}
+      style={{ background: '#fff' }}
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- add Excel export and filters for defects
- enable sorting in defects table
- provide stats on DefectsPage and export button

## Testing
- `npm run lint` *(fails: Parsing error due to missing eslint packages)*

------
https://chatgpt.com/codex/tasks/task_e_684dd480eed4832eb66641c0e1bf4daa