### PR TITLE
Add fixed_at to defects

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -406,6 +406,13 @@
     "column_default": null
   },
   {
+    "table_name": "defects",
+    "column_name": "fixed_at",
+    "data_type": "date",
+    "is_nullable": "YES",
+    "column_default": null
+  },
+  {
     "table_name": "letter_links",
     "column_name": "parent_id",
     "data_type": "bigint",

--- a/sql/add_fixed_at_to_defects.sql
+++ b/sql/add_fixed_at_to_defects.sql
@@ -1,0 +1,2 @@
+-- Add fixed_at column to defects table
+ALTER TABLE defects ADD COLUMN IF NOT EXISTS fixed_at date;

--- a/src/entities/defect.ts
+++ b/src/entities/defect.ts
@@ -8,6 +8,7 @@ export interface NewDefect {
   defect_type_id: number | null;
   defect_status_id: number | null;
   received_at: string | null;
+  fixed_at: string | null;
 }
 
 const TABLE = 'defects';
@@ -20,7 +21,7 @@ export function useDefects() {
       const { data, error } = await supabase
         .from(TABLE)
         .select(
-          'id, description, defect_type_id, defect_status_id, received_at, created_at,' +
+          'id, description, defect_type_id, defect_status_id, received_at, fixed_at, created_at,' +
           ' defect_type:defect_types(id,name), defect_status:defect_statuses(id,name)'
         )
         .order('id');
@@ -40,7 +41,7 @@ export function useDefect(id?: number) {
       const { data, error } = await supabase
         .from(TABLE)
         .select(
-          'id, description, defect_type_id, defect_status_id, received_at, created_at,' +
+          'id, description, defect_type_id, defect_status_id, received_at, fixed_at, created_at,' +
           ' defect_type:defect_types(id,name), defect_status:defect_statuses(id,name)'
         )
         .eq('id', id as number)

--- a/src/features/ticket/TicketFormAntd.tsx
+++ b/src/features/ticket/TicketFormAntd.tsx
@@ -132,6 +132,7 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
         defect_type_id: d.type_id ?? null,
         defect_status_id: d.status_id ?? null,
         received_at: d.received_at ? d.received_at.format('YYYY-MM-DD') : null,
+        fixed_at: d.fixed_at ? d.fixed_at.format('YYYY-MM-DD') : null,
       }));
       const defectIds = await createDefects.mutateAsync(newDefs);
       const payload = {

--- a/src/shared/types/defect.ts
+++ b/src/shared/types/defect.ts
@@ -10,6 +10,8 @@ export interface DefectRecord {
   defect_status_id: number | null;
   /** Дата получения */
   received_at: string | null;
+  /** Дата устранения */
+  fixed_at: string | null;
   /** Дата создания */
   created_at: string | null;
 }


### PR DESCRIPTION
## Summary
- support defect completion date
- set defect fixed date when creating ticket
- provide SQL snippet

## Testing
- `npm run lint` *(fails: eslint parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ddc4073c4832ea75ca0fb1143bccf