### PR TITLE
Unify defects table style

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -75,6 +75,11 @@ body {
     font-style: italic;
     border-left: 3px solid #722ed1;
 }
+.main-defect-row {
+    background: #eaf4ff !important;
+    font-weight: 600;
+    box-shadow: 0 1px 0 #b5d3f7;
+}
 /* Skeleton эффекты были выше (оставил без изменений) */
 .changed-field {
     background-color: #fffbe6;

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import dayjs from 'dayjs';
-import { Table, Button, Tooltip, Skeleton, Popconfirm, message } from 'antd';
+import { Table, Button, Tooltip, Skeleton, Popconfirm, message, Space } from 'antd';
 import { EyeOutlined, DeleteOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import { useDeleteDefect } from '@/entities/defect';
@@ -92,7 +92,7 @@ export default function DefectsTable({ defects, filters, loading, columns: colum
       key: 'actions',
       width: 100,
       render: (_, row) => (
-        <>
+        <Space size="middle">
           <Tooltip title="Просмотр">
             <Button size="small" type="text" icon={<EyeOutlined />} onClick={() => onView && onView(row.id)} />
           </Tooltip>
@@ -108,7 +108,7 @@ export default function DefectsTable({ defects, filters, loading, columns: colum
           >
             <Button size="small" type="text" danger icon={<DeleteOutlined />} loading={isPending} />
           </Popconfirm>
-        </>
+        </Space>
       ),
     },
   ];
@@ -117,13 +117,16 @@ export default function DefectsTable({ defects, filters, loading, columns: colum
 
   if (loading) return <Skeleton active paragraph={{ rows: 6 }} />;
 
-  return (
-    <Table
-      rowKey="id"
-      columns={columns}
-      dataSource={filtered}
-      pagination={{ pageSize: 25 }}
-      style={{ background: '#fff' }}
-    />
-  );
+    return (
+      <Table
+        rowKey="id"
+        columns={columns}
+        dataSource={filtered}
+        pagination={{ pageSize: 25, showSizeChanger: true }}
+        size="middle"
+        /** Стилизуем строки аналогично таблице писем */
+        rowClassName={() => 'main-defect-row'}
+        style={{ background: '#fff' }}
+      />
+    );
 }


### PR DESCRIPTION
## Summary
- match defects table appearance with correspondence table
- add CSS class for defect rows

## Testing
- `npm run lint` *(fails: Parsing errors)*
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684ddcf9c910832ea781d83875f7c55a