### PR TITLE
Add fix_by column and filters to defects

### DIFF
--- a/sql/add_fix_by_to_defects.sql
+++ b/sql/add_fix_by_to_defects.sql
@@ -1,0 +1,2 @@
+-- Track performer responsible for fixing defect
+ALTER TABLE defects ADD COLUMN IF NOT EXISTS fix_by text;

--- a/src/entities/defect.ts
+++ b/src/entities/defect.ts
@@ -7,6 +7,7 @@ export interface NewDefect {
   description: string;
   defect_type_id: number | null;
   defect_status_id: number | null;
+  fix_by: string | null;
   received_at: string | null;
   fixed_at: string | null;
 }
@@ -21,7 +22,7 @@ export function useDefects() {
       const { data, error } = await supabase
         .from(TABLE)
         .select(
-          'id, description, defect_type_id, defect_status_id, received_at, fixed_at, created_at,' +
+          'id, description, defect_type_id, defect_status_id, fix_by, received_at, fixed_at, created_at,' +
           ' defect_type:defect_types(id,name), defect_status:defect_statuses(id,name)'
         )
         .order('id');
@@ -41,7 +42,7 @@ export function useDefect(id?: number) {
       const { data, error } = await supabase
         .from(TABLE)
         .select(
-          'id, description, defect_type_id, defect_status_id, received_at, fixed_at, created_at,' +
+          'id, description, defect_type_id, defect_status_id, fix_by, received_at, fixed_at, created_at,' +
           ' defect_type:defect_types(id,name), defect_status:defect_statuses(id,name)'
         )
         .eq('id', id as number)

--- a/src/features/defect/ExportDefectsButton.tsx
+++ b/src/features/defect/ExportDefectsButton.tsx
@@ -23,11 +23,13 @@ export default function ExportDefectsButton({
   const handleClick = React.useCallback(async () => {
     const rows = filterDefects(defects, filters).map((d) => ({
       ID: d.id,
-      '№ замечания': d.ticketIds.join(', '),
+      'ID замечание': d.ticketIds.join(', '),
+      Проект: d.projectNames ?? '',
       Объекты: d.unitNames ?? '',
       Описание: d.description,
       Тип: d.defectTypeName ?? '',
       Статус: d.defectStatusName ?? '',
+      'Кем устраняется': d.fixByName ?? '',
       'Дата получения': d.received_at ? dayjs(d.received_at).format('DD.MM.YYYY') : '',
       'Дата создания': d.created_at ? dayjs(d.created_at).format('DD.MM.YYYY') : '',
     }));

--- a/src/features/ticket/TicketFormAntd.tsx
+++ b/src/features/ticket/TicketFormAntd.tsx
@@ -131,6 +131,7 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
         description: d.description || '',
         defect_type_id: d.type_id ?? null,
         defect_status_id: d.status_id ?? null,
+        fix_by: d.fix_by || null,
         received_at: d.received_at ? d.received_at.format('YYYY-MM-DD') : null,
         fixed_at: d.fixed_at ? d.fixed_at.format('YYYY-MM-DD') : null,
       }));

--- a/src/shared/types/defect.ts
+++ b/src/shared/types/defect.ts
@@ -8,6 +8,8 @@ export interface DefectRecord {
   defect_type_id: number | null;
   /** Статус дефекта */
   defect_status_id: number | null;
+  /** Кем устраняется (own|contractor) */
+  fix_by: string | null;
   /** Дата получения */
   received_at: string | null;
   /** Дата устранения */
@@ -28,4 +30,10 @@ export interface DefectWithInfo extends DefectRecord {
   defectTypeName?: string;
   /** Название статуса дефекта */
   defectStatusName?: string;
+  /** Текстовое значение поля fix_by */
+  fixByName?: string;
+  /** Идентификаторы проектов, связанные с замечаниями */
+  projectIds?: number[];
+  /** Названия проектов, объединённые в строку */
+  projectNames?: string;
 }

--- a/src/shared/types/defectFilters.ts
+++ b/src/shared/types/defectFilters.ts
@@ -5,5 +5,10 @@ export interface DefectFilters {
   id?: number[];
   ticketId?: number[];
   units?: number[];
+  projectId?: number[];
+  typeId?: number[];
+  statusId?: number[];
+  fixBy?: string[];
   period?: [Dayjs, Dayjs];
+  hideClosed?: boolean;
 }

--- a/src/shared/utils/defectFilter.ts
+++ b/src/shared/utils/defectFilter.ts
@@ -10,6 +10,12 @@ export function filterDefects<T extends {
   ticketIds: number[];
   unitIds: number[];
   created_at: string | null;
+  received_at: string | null;
+  projectIds?: number[];
+  defect_type_id: number | null;
+  defect_status_id: number | null;
+  fix_by: string | null;
+  defectStatusName?: string;
 }>(rows: T[], f: DefectFilters): T[] {
   return rows.filter((d) => {
     if (Array.isArray(f.id) && f.id.length > 0 && !f.id.includes(d.id)) {
@@ -29,12 +35,43 @@ export function filterDefects<T extends {
     ) {
       return false;
     }
+    if (
+      Array.isArray(f.projectId) &&
+      f.projectId.length > 0 &&
+      !(d.projectIds || []).some((p) => f.projectId!.includes(p))
+    ) {
+      return false;
+    }
+    if (
+      Array.isArray(f.typeId) &&
+      f.typeId.length > 0 &&
+      (d.defect_type_id == null || !f.typeId.includes(d.defect_type_id))
+    ) {
+      return false;
+    }
+    if (
+      Array.isArray(f.statusId) &&
+      f.statusId.length > 0 &&
+      (d.defect_status_id == null || !f.statusId.includes(d.defect_status_id))
+    ) {
+      return false;
+    }
+    if (
+      Array.isArray(f.fixBy) &&
+      f.fixBy.length > 0 &&
+      (!d.fix_by || !f.fixBy.includes(d.fix_by))
+    ) {
+      return false;
+    }
     if (f.period && f.period.length === 2) {
       const [from, to] = f.period;
-      const created = dayjs(d.created_at);
-      if (!created.isSameOrAfter(from, 'day') || !created.isSameOrBefore(to, 'day')) {
+      const rec = dayjs(d.received_at);
+      if (!rec.isSameOrAfter(from, 'day') || !rec.isSameOrBefore(to, 'day')) {
         return false;
       }
+    }
+    if (f.hideClosed && d.defectStatusName?.toLowerCase().includes('закры')) {
+      return false;
     }
     return true;
   });

--- a/src/widgets/DefectsFilters.tsx
+++ b/src/widgets/DefectsFilters.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Form, Select, Button, DatePicker } from 'antd';
+import { Form, Select, Button, DatePicker, Switch } from 'antd';
 import type { DefectFilters } from '@/shared/types/defectFilters';
 
 const { RangePicker } = DatePicker;
@@ -8,6 +8,10 @@ interface Options {
   ids: { label: string; value: number }[];
   tickets: { label: string; value: number }[];
   units: { label: string; value: number }[];
+  projects: { label: string; value: string }[];
+  types: { label: string; value: string }[];
+  statuses: { label: string; value: string }[];
+  fixBy: { label: string; value: string }[];
 }
 
 /** Форма фильтров дефектов */
@@ -35,16 +39,31 @@ export default function DefectsFilters({
   return (
     <Form form={form} layout="vertical" onValuesChange={handleValuesChange} className="filter-grid">
       <Form.Item name="id" label="ID">
-        <Select mode="multiple" allowClear options={options.ids} />
+        <Select mode="multiple" allowClear options={options.ids} showSearch optionFilterProp="label" />
       </Form.Item>
-      <Form.Item name="ticketId" label="№ замечания">
-        <Select mode="multiple" allowClear options={options.tickets} />
+      <Form.Item name="ticketId" label="ID замечание">
+        <Select mode="multiple" allowClear options={options.tickets} showSearch optionFilterProp="label" />
+      </Form.Item>
+      <Form.Item name="projectId" label="Проекты">
+        <Select mode="multiple" allowClear options={options.projects} showSearch optionFilterProp="label" />
       </Form.Item>
       <Form.Item name="units" label="Объекты">
-        <Select mode="multiple" allowClear options={options.units} />
+        <Select mode="multiple" allowClear options={options.units} showSearch optionFilterProp="label" />
       </Form.Item>
-      <Form.Item name="period" label="Дата создания">
+      <Form.Item name="typeId" label="Тип">
+        <Select mode="multiple" allowClear options={options.types} showSearch optionFilterProp="label" />
+      </Form.Item>
+      <Form.Item name="statusId" label="Статус">
+        <Select mode="multiple" allowClear options={options.statuses} showSearch optionFilterProp="label" />
+      </Form.Item>
+      <Form.Item name="fixBy" label="Кем устраняется">
+        <Select mode="multiple" allowClear options={options.fixBy} showSearch optionFilterProp="label" />
+      </Form.Item>
+      <Form.Item name="period" label="Дата получения">
         <RangePicker style={{ width: '100%' }} format="DD.MM.YYYY" />
+      </Form.Item>
+      <Form.Item name="hideClosed" label="Скрыть закрытые" valuePropName="checked">
+        <Switch />
       </Form.Item>
       <Form.Item>
         <Button onClick={reset} block>


### PR DESCRIPTION
## Summary
- track who fixes a defect
- expose `fix_by` info in tables and exports
- add filter fields for projects, types, statuses and performer
- include SQL snippet to alter DB

## Testing
- `npm run lint` *(fails: Parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e5283927c832e838c59a2d4c99455