### PR TITLE
Improve defect table and filters

### DIFF
--- a/src/entities/unit.js
+++ b/src/entities/unit.js
@@ -80,7 +80,7 @@ export const useUnitsByIds = (ids) =>
         queryFn : async () => {
             const { data, error } = await supabase
                 .from('units')
-                .select('id, name')
+                .select('id, name, building, section, floor')
                 .in('id', ids);
             if (error) throw error;
             return data ?? [];

--- a/src/features/defect/ExportDefectsButton.tsx
+++ b/src/features/defect/ExportDefectsButton.tsx
@@ -22,7 +22,7 @@ export default function ExportDefectsButton({
 }: ExportDefectsButtonProps) {
   const handleClick = React.useCallback(async () => {
     const rows = filterDefects(defects, filters).map((d) => ({
-      ID: d.id,
+      'ID дефекта': d.id,
       'ID замечание': d.ticketIds.join(', '),
       Проект: d.projectNames ?? '',
       Объекты: d.unitNames ?? '',

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -22,6 +22,7 @@ import type { TableColumnSetting } from '@/shared/types/tableColumnSetting';
 import DefectViewModal from '@/features/defect/DefectViewModal';
 import ExportDefectsButton from '@/features/defect/ExportDefectsButton';
 import { filterDefects } from '@/shared/utils/defectFilter';
+import formatUnitName from '@/shared/utils/formatUnitName';
 import type { DefectWithInfo } from '@/shared/types/defect';
 import type { DefectFilters } from '@/shared/types/defectFilters';
 import type { ColumnsType } from 'antd/es/table';
@@ -39,7 +40,7 @@ export default function DefectsPage() {
   const { data: projects = [] } = useProjects();
 
   const data: DefectWithInfo[] = useMemo(() => {
-    const unitMap = new Map(units.map((u) => [u.id, u.name]));
+    const unitMap = new Map(units.map((u) => [u.id, formatUnitName(u)]));
     const projectMap = new Map(projects.map((p) => [p.id, p.name]));
     const ticketsMap = new Map<number, { id: number; unit_ids: number[]; project_id: number }[]>();
     tickets.forEach((t: any) => {
@@ -111,6 +112,11 @@ export default function DefectsPage() {
 
   const baseColumns = useMemo(() => {
     return {
+      id: {
+        title: 'ID дефекта',
+        dataIndex: 'id',
+        sorter: (a: DefectWithInfo, b: DefectWithInfo) => a.id - b.id,
+      },
       tickets: {
         title: 'ID замечание',
         dataIndex: 'ticketIds',

--- a/src/shared/utils/formatUnitName.ts
+++ b/src/shared/utils/formatUnitName.ts
@@ -1,0 +1,24 @@
+/**
+ * Формирует человеко-читаемое название объекта.
+ * Возвращает строку вида "Корпус X, Секция Y, Этаж Z, <номер>".
+ * Пустые части пропускаются.
+ *
+ * @param unit - данные объекта
+ */
+export default function formatUnitName(
+  unit: {
+    name: string;
+    building?: string | null;
+    section?: string | null;
+    floor?: number | null;
+  },
+): string {
+  const parts: string[] = [];
+  if (unit.building) parts.push(`Корпус ${unit.building}`);
+  if (unit.section) parts.push(`Секция ${unit.section}`);
+  if (unit.floor !== undefined && unit.floor !== null) {
+    parts.push(`Этаж ${unit.floor}`);
+  }
+  parts.push(unit.name);
+  return parts.join(', ');
+}

--- a/src/widgets/DefectsFilters.tsx
+++ b/src/widgets/DefectsFilters.tsx
@@ -38,11 +38,8 @@ export default function DefectsFilters({
 
   return (
     <Form form={form} layout="vertical" onValuesChange={handleValuesChange} className="filter-grid">
-      <Form.Item name="id" label="ID">
+      <Form.Item name="id" label="ID дефекта">
         <Select mode="multiple" allowClear options={options.ids} showSearch optionFilterProp="label" />
-      </Form.Item>
-      <Form.Item name="ticketId" label="ID замечание">
-        <Select mode="multiple" allowClear options={options.tickets} showSearch optionFilterProp="label" />
       </Form.Item>
       <Form.Item name="projectId" label="Проекты">
         <Select mode="multiple" allowClear options={options.projects} showSearch optionFilterProp="label" />
@@ -50,17 +47,20 @@ export default function DefectsFilters({
       <Form.Item name="units" label="Объекты">
         <Select mode="multiple" allowClear options={options.units} showSearch optionFilterProp="label" />
       </Form.Item>
+      <Form.Item name="statusId" label="Статус">
+        <Select mode="multiple" allowClear options={options.statuses} showSearch optionFilterProp="label" />
+      </Form.Item>
       <Form.Item name="typeId" label="Тип">
         <Select mode="multiple" allowClear options={options.types} showSearch optionFilterProp="label" />
       </Form.Item>
-      <Form.Item name="statusId" label="Статус">
-        <Select mode="multiple" allowClear options={options.statuses} showSearch optionFilterProp="label" />
+      <Form.Item name="period" label="Дата получения">
+        <RangePicker style={{ width: '100%' }} format="DD.MM.YYYY" />
       </Form.Item>
       <Form.Item name="fixBy" label="Кем устраняется">
         <Select mode="multiple" allowClear options={options.fixBy} showSearch optionFilterProp="label" />
       </Form.Item>
-      <Form.Item name="period" label="Дата получения">
-        <RangePicker style={{ width: '100%' }} format="DD.MM.YYYY" />
+      <Form.Item name="ticketId" label="ID замечание">
+        <Select mode="multiple" allowClear options={options.tickets} showSearch optionFilterProp="label" />
       </Form.Item>
       <Form.Item name="hideClosed" label="Скрыть закрытые" valuePropName="checked">
         <Switch />

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -26,6 +26,11 @@ export default function DefectsTable({ defects, filters, loading, columns: colum
 
   const defaultColumns: ColumnsType<DefectWithInfo> = [
     {
+      title: 'ID дефекта',
+      dataIndex: 'id',
+      sorter: (a, b) => a.id - b.id,
+    },
+    {
       title: 'ID замечание',
       dataIndex: 'ticketIds',
       sorter: (a, b) => a.ticketIds.join(',').localeCompare(b.ticketIds.join(',')),


### PR DESCRIPTION
## Summary
- show full unit names in defects table
- add defect id column and export field
- add unit formatter helper
- rename and reorder defect filters
- query more info for units

## Testing
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_684e5adf2f78832ebe1d7336ebf0e1b7