### PR TITLE
Fix columns list in defects drawer

### DIFF
--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -225,7 +225,9 @@ export default function DefectsPage() {
       const saved = localStorage.getItem(LS_COLUMNS_KEY);
       if (saved) {
         const parsed = JSON.parse(saved) as TableColumnSetting[];
-        return parsed.filter((c) => base[c.key]);
+        const filtered = parsed.filter((c) => base[c.key]);
+        const missing = defaults.filter((d) => !filtered.some((f) => f.key === d.key));
+        return [...filtered, ...missing];
       }
     } catch {}
     return defaults;


### PR DESCRIPTION
## Summary
- ensure newly added columns show up when opening the columns drawer on defects page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e5cc46614832e9dfca816aef53a98