### PR TITLE
Add brigades admin and link to defects

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -112,6 +112,34 @@
     "column_default": "now()"
   },
   {
+    "table_name": "brigades",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('brigades_id_seq'::regclass)"
+  },
+  {
+    "table_name": "brigades",
+    "column_name": "name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": null
+  },
+  {
+    "table_name": "brigades",
+    "column_name": "description",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": null
+  },
+  {
+    "table_name": "brigades",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "now()"
+  },
+  {
     "table_name": "court_case_defects",
     "column_name": "case_id",
     "data_type": "bigint",

--- a/src/entities/brigade.ts
+++ b/src/entities/brigade.ts
@@ -1,0 +1,71 @@
+import { supabase } from '@/shared/api/supabaseClient';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { Brigade } from '@/shared/types/brigade';
+
+const TABLE = 'brigades';
+const FIELDS = 'id, name, description, created_at';
+
+const sanitize = (b: Partial<Brigade>) =>
+  Object.fromEntries(
+    Object.entries(b).map(([k, v]) => [k, typeof v === 'string' ? v.trim() : v]),
+  );
+
+const insert = async (
+  payload: Omit<Brigade, 'id' | 'created_at'>,
+): Promise<Brigade> => {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .insert(sanitize(payload))
+    .select(FIELDS)
+    .single();
+  if (error) throw error;
+  return data as Brigade;
+};
+
+const patch = async ({
+  id,
+  updates,
+}: {
+  id: number;
+  updates: Partial<Omit<Brigade, 'id' | 'created_at'>>;
+}): Promise<Brigade> => {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .update(sanitize(updates))
+    .eq('id', id)
+    .select(FIELDS)
+    .single();
+  if (error) throw error;
+  return data as Brigade;
+};
+
+const remove = async (id: number): Promise<void> => {
+  const { error } = await supabase.from(TABLE).delete().eq('id', id);
+  if (error) throw error;
+};
+
+export const useBrigades = () =>
+  useQuery<Brigade[]>({
+    queryKey: [TABLE],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select(FIELDS)
+        .order('name');
+      if (error) throw error;
+      return (data ?? []) as Brigade[];
+    },
+    staleTime: 10 * 60_000,
+  });
+
+const mutation = <TVar, TRes>(fn: (vars: TVar) => Promise<TRes>) => () => {
+  const qc = useQueryClient();
+  return useMutation<TRes, Error, TVar>({
+    mutationFn: fn,
+    onSuccess: () => qc.invalidateQueries({ queryKey: [TABLE] }),
+  });
+};
+
+export const useAddBrigade = mutation(insert);
+export const useUpdateBrigade = mutation(patch);
+export const useDeleteBrigade = mutation(remove);

--- a/src/features/brigade/BrigadeForm.tsx
+++ b/src/features/brigade/BrigadeForm.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import {
+  DialogActions,
+  Stack,
+  TextField,
+  Button,
+  CircularProgress,
+} from '@mui/material';
+import { useAddBrigade, useUpdateBrigade } from '@/entities/brigade';
+import { useNotify } from '@/shared/hooks/useNotify';
+
+interface Props {
+  initialData?: { id?: number; name?: string; description?: string | null } | null;
+  onSuccess?: () => void;
+  onCancel: () => void;
+}
+
+export default function BrigadeForm({ initialData = null, onSuccess, onCancel }: Props) {
+  const notify = useNotify();
+  const add = useAddBrigade();
+  const update = useUpdateBrigade();
+  const isEdit = !!initialData;
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { isSubmitting },
+  } = useForm({
+    defaultValues: {
+      name: initialData?.name ?? '',
+      description: initialData?.description ?? '',
+    },
+  });
+
+  const submit = async (vals: { name: string; description?: string | null }) => {
+    try {
+      if (isEdit && initialData?.id) {
+        await update.mutateAsync({ id: initialData.id, updates: vals });
+        notify.success('Бригада обновлена');
+      } else {
+        await add.mutateAsync(vals);
+        notify.success('Бригада создана');
+        reset({ name: '', description: '' });
+      }
+      onSuccess?.();
+    } catch (e: any) {
+      notify.error(e.message);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(submit)} noValidate>
+      <Stack spacing={2} sx={{ minWidth: 320 }}>
+        <Controller
+          name="name"
+          control={control}
+          rules={{ required: 'Название обязательно' }}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              label="Название бригады"
+              fullWidth
+              required
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+              autoFocus
+            />
+          )}
+        />
+        <Controller
+          name="description"
+          control={control}
+          render={({ field }) => (
+            <TextField {...field} label="Описание" fullWidth multiline rows={2} />
+          )}
+        />
+        <DialogActions sx={{ px: 0 }}>
+          <Button onClick={onCancel}>Отмена</Button>
+          <Button
+            type="submit"
+            variant="contained"
+            disabled={isSubmitting}
+            startIcon={isSubmitting && <CircularProgress size={18} color="inherit" />}
+          >
+            Сохранить
+          </Button>
+        </DialogActions>
+      </Stack>
+    </form>
+  );
+}

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -15,6 +15,8 @@ import { useDefects, useDeleteDefect } from '@/entities/defect';
 import { useTicketsSimple } from '@/entities/ticket';
 import { useUnitsByIds } from '@/entities/unit';
 import { useProjects } from '@/entities/project';
+import { useBrigades } from '@/entities/brigade';
+import { useContractors } from '@/entities/contractor';
 import DefectsTable from '@/widgets/DefectsTable';
 import DefectsFilters from '@/widgets/DefectsFilters';
 import TableColumnsDrawer from '@/widgets/TableColumnsDrawer';
@@ -38,6 +40,8 @@ export default function DefectsPage() {
   );
   const { data: units = [] } = useUnitsByIds(unitIds);
   const { data: projects = [] } = useProjects();
+  const { data: brigades = [] } = useBrigades();
+  const { data: contractors = [] } = useContractors();
 
   const data: DefectWithInfo[] = useMemo(() => {
     const unitMap = new Map(units.map((u) => [u.id, formatUnitName(u)]));
@@ -62,7 +66,16 @@ export default function DefectsPage() {
         .map((id) => projectMap.get(id))
         .filter(Boolean)
         .join(', ');
-      const fixByName = d.fix_by === 'contractor' ? 'Подрядчик' : 'Собственные силы';
+      let fixByName = '—';
+      if (d.fix_by?.startsWith('b:')) {
+        const id = Number(d.fix_by.slice(2));
+        fixByName = brigades.find((b) => b.id === id)?.name || 'Бригада';
+      } else if (d.fix_by?.startsWith('c:')) {
+        const id = Number(d.fix_by.slice(2));
+        fixByName = contractors.find((c) => c.id === id)?.name || 'Подрядчик';
+      } else if (d.fix_by) {
+        fixByName = d.fix_by === 'contractor' ? 'Подрядчик' : 'Собственные силы';
+      }
       return {
         ...d,
         ticketIds: linked.map((l) => l.id),

--- a/src/pages/UnitsPage/AdminPage.tsx
+++ b/src/pages/UnitsPage/AdminPage.tsx
@@ -3,6 +3,7 @@ import { Container, Stack } from "@mui/material";
 
 import ProjectsTable from "../../widgets/ProjectsTable";
 import ContractorAdmin from "../../widgets/ContractorAdmin";
+import BrigadesAdmin from "../../widgets/BrigadesAdmin";
 import TicketStatusesAdmin from "../../widgets/TicketStatusesAdmin";
 import DefectTypesAdmin from "../../widgets/DefectTypesAdmin";
 import DefectStatusesAdmin from "../../widgets/DefectStatusesAdmin";
@@ -20,6 +21,7 @@ export default function AdminPage() {
         <ProjectsTable pageSize={25} rowsPerPageOptions={[10, 25, 50, 100]} />
 
         <ContractorAdmin pageSize={25} rowsPerPageOptions={[10, 25, 50, 100]} />
+        <BrigadesAdmin pageSize={25} rowsPerPageOptions={[10, 25, 50, 100]} />
 
         <TicketStatusesAdmin
           pageSize={25}

--- a/src/shared/types/brigade.ts
+++ b/src/shared/types/brigade.ts
@@ -1,0 +1,9 @@
+export interface Brigade {
+  id: number;
+  /** Наименование бригады */
+  name: string;
+  /** Дополнительное описание */
+  description?: string | null;
+  /** Дата создания записи */
+  created_at?: string | null;
+}

--- a/src/widgets/BrigadesAdmin.tsx
+++ b/src/widgets/BrigadesAdmin.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useState } from 'react';
+import { GridActionsCellItem } from '@mui/x-data-grid';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { useBrigades, useDeleteBrigade } from '@/entities/brigade';
+import BrigadeForm from '@/features/brigade/BrigadeForm';
+import AdminDataGrid from '@/shared/ui/AdminDataGrid';
+import { useNotify } from '@/shared/hooks/useNotify';
+import { Dialog, DialogTitle, DialogContent } from '@mui/material';
+
+interface Props {
+  pageSize?: number;
+  rowsPerPageOptions?: number[];
+}
+
+export default function BrigadesAdmin({
+  pageSize = 25,
+  rowsPerPageOptions = [10, 25, 50, 100],
+}: Props) {
+  const notify = useNotify();
+  const { data: brigades = [], isPending, error } = useBrigades();
+  const remove = useDeleteBrigade();
+  const [modal, setModal] = useState<null | { mode: 'add' | 'edit'; data?: any }>(null);
+
+  useEffect(() => {
+    if (error) {
+      console.error('[BrigadesAdmin] load error:', error);
+      notify.error(`Ошибка загрузки бригад: ${error.message}`);
+    } else if (!isPending && brigades.length === 0) {
+      notify.info('Записей не найдено');
+    }
+  }, [error, isPending, brigades, notify]);
+
+  const columns = [
+    { field: 'id', headerName: 'ID', width: 80 },
+    { field: 'name', headerName: 'Название', flex: 1 },
+    {
+      field: 'actions',
+      type: 'actions',
+      width: 110,
+      getActions: ({ row }: any) => [
+        <GridActionsCellItem
+          key="edit"
+          icon={<EditIcon />}
+          label="Редактировать"
+          onClick={() => setModal({ mode: 'edit', data: row })}
+        />,
+        <GridActionsCellItem
+          key="del"
+          icon={<DeleteIcon color="error" />}
+          label="Удалить"
+          onClick={() => {
+            if (!window.confirm('Удалить бригаду?')) return;
+            remove.mutate(row.id, {
+              onSuccess: () => notify.success('Бригада удалена'),
+              onError: (e) => notify.error(e.message),
+            });
+          }}
+        />,
+      ],
+    },
+  ];
+
+  const close = () => setModal(null);
+  const ok = (msg: string) => {
+    close();
+    notify.success(msg);
+  };
+
+  return (
+    <>
+      {modal && (
+        <Dialog open onClose={close} maxWidth="sm" fullWidth>
+          <DialogTitle>
+            {modal.mode === 'add' ? 'Новая бригада' : 'Редактировать бригаду'}
+          </DialogTitle>
+          <DialogContent>
+            <BrigadeForm
+              initialData={modal.mode === 'edit' ? modal.data : undefined}
+              onSuccess={() =>
+                ok(modal.mode === 'add' ? 'Бригада создана' : 'Бригада обновлена')
+              }
+              onCancel={close}
+            />
+          </DialogContent>
+        </Dialog>
+      )}
+
+      <AdminDataGrid
+        title="Бригады"
+        rows={brigades}
+        columns={columns}
+        loading={isPending}
+        onAdd={() => setModal({ mode: 'add' })}
+        pageSize={pageSize}
+        rowsPerPageOptions={rowsPerPageOptions}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- create new `brigades` table description
- add CRUD hooks and form for brigades
- integrate brigades admin panel
- connect `fix_by` selector to brigades or contractors
- show brigade/contractor names on defects page

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e5de1e8b4832eb9f45ed1ba12c2b1