### PR TITLE
Fix defects page unit names and status editing

### DIFF
--- a/src/entities/defect.ts
+++ b/src/entities/defect.ts
@@ -87,3 +87,23 @@ export function useDeleteDefect() {
     onError: (e) => notify.error(e.message),
   });
 }
+
+/** Обновить статус дефекта */
+export function useUpdateDefectStatus() {
+  const qc = useQueryClient();
+  const notify = useNotify();
+  return useMutation<{ id: number; defect_status_id: number | null }, Error, { id: number; statusId: number | null }>({
+    mutationFn: async ({ id, statusId }) => {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .update({ defect_status_id: statusId })
+        .eq('id', id)
+        .select('id, defect_status_id')
+        .single();
+      if (error) throw error;
+      return data as { id: number; defect_status_id: number | null };
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: [TABLE] }),
+    onError: (e) => notify.error(`Ошибка обновления статуса: ${e.message}`),
+  });
+}

--- a/src/features/defect/DefectStatusSelect.tsx
+++ b/src/features/defect/DefectStatusSelect.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Select, Tag } from 'antd';
+import { useDefectStatuses } from '@/entities/defectStatus';
+import { useUpdateDefectStatus } from '@/entities/defect';
+
+interface Props {
+  defectId: number;
+  statusId: number | null;
+  statusName?: string | null;
+}
+
+/** Выпадающий список для смены статуса дефекта в таблице */
+export default function DefectStatusSelect({
+  defectId,
+  statusId,
+  statusName,
+}: Props) {
+  const { data: statuses = [], isLoading } = useDefectStatuses();
+  const update = useUpdateDefectStatus();
+  const [editing, setEditing] = React.useState(false);
+
+  const options = React.useMemo(
+    () => statuses.map((s) => ({ label: s.name, value: s.id })),
+    [statuses],
+  );
+
+  const current = React.useMemo(
+    () => statuses.find((s) => s.id === statusId) ||
+      (statusId ? { id: statusId, name: statusName ?? String(statusId) } : null),
+    [statuses, statusId, statusName],
+  );
+
+  const handleChange = (value: number) => {
+    (update as any).mutate({ id: defectId, statusId: value });
+    setEditing(false);
+  };
+
+  if (!editing) {
+    return (
+      <Tag onClick={() => setEditing(true)} style={{ cursor: 'pointer' }}>
+        {current?.name ?? '—'}
+      </Tag>
+    );
+  }
+
+  return (
+    <Select
+      size="small"
+      autoFocus
+      open
+      defaultValue={statusId ?? undefined}
+      onBlur={() => setEditing(false)}
+      onChange={handleChange}
+      loading={isLoading || update.isPending}
+      options={options}
+      style={{ width: '100%' }}
+    />
+  );
+}

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -22,6 +22,7 @@ import DefectsFilters from '@/widgets/DefectsFilters';
 import TableColumnsDrawer from '@/widgets/TableColumnsDrawer';
 import type { TableColumnSetting } from '@/shared/types/tableColumnSetting';
 import DefectViewModal from '@/features/defect/DefectViewModal';
+import DefectStatusSelect from '@/features/defect/DefectStatusSelect';
 import ExportDefectsButton from '@/features/defect/ExportDefectsButton';
 import { filterDefects } from '@/shared/utils/defectFilter';
 import formatUnitName from '@/shared/utils/formatUnitName';
@@ -163,9 +164,16 @@ export default function DefectsPage() {
       },
       status: {
         title: 'Статус',
-        dataIndex: 'defectStatusName',
+        dataIndex: 'defect_status_id',
         sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
           (a.defectStatusName || '').localeCompare(b.defectStatusName || ''),
+        render: (_: number, row: DefectWithInfo) => (
+          <DefectStatusSelect
+            defectId={row.id}
+            statusId={row.defect_status_id}
+            statusName={row.defectStatusName}
+          />
+        ),
       },
       fixBy: {
         title: 'Кем устраняется',
@@ -182,11 +190,11 @@ export default function DefectsPage() {
         render: fmt,
       },
       created: {
-        title: 'Дата создания',
-        dataIndex: 'created_at',
+        title: 'Дата устранения',
+        dataIndex: 'fixed_at',
         sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
-          (a.created_at ? dayjs(a.created_at).valueOf() : 0) -
-          (b.created_at ? dayjs(b.created_at).valueOf() : 0),
+          (a.fixed_at ? dayjs(a.fixed_at).valueOf() : 0) -
+          (b.fixed_at ? dayjs(b.fixed_at).valueOf() : 0),
         render: fmt,
       },
       actions: {

--- a/src/shared/utils/formatUnitName.ts
+++ b/src/shared/utils/formatUnitName.ts
@@ -14,11 +14,21 @@ export default function formatUnitName(
   },
 ): string {
   const parts: string[] = [];
-  if (unit.building) parts.push(`Корпус ${unit.building}`);
-  if (unit.section) parts.push(`Секция ${unit.section}`);
+
+  if (unit.building) {
+    const b = unit.building.trim();
+    parts.push(/^\s*корпус/i.test(b) ? b : `Корпус ${b}`);
+  }
+
   if (unit.floor !== undefined && unit.floor !== null) {
     parts.push(`Этаж ${unit.floor}`);
   }
-  parts.push(unit.name);
+
+  if (unit.section) {
+    const s = unit.section.trim();
+    parts.push(/^\s*секция/i.test(s) ? s : `Секция ${s}`);
+  }
+
+  parts.push(`Объект ${unit.name}`);
   return parts.join(', ');
 }

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -4,6 +4,7 @@ import { Table, Button, Tooltip, Skeleton, Popconfirm, message, Space } from 'an
 import { EyeOutlined, DeleteOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import { useDeleteDefect } from '@/entities/defect';
+import DefectStatusSelect from '@/features/defect/DefectStatusSelect';
 import type { DefectWithInfo } from '@/shared/types/defect';
 import type { DefectFilters } from '@/shared/types/defectFilters';
 import { filterDefects } from '@/shared/utils/defectFilter';
@@ -59,9 +60,16 @@ export default function DefectsTable({ defects, filters, loading, columns: colum
     },
     {
       title: 'Статус',
-      dataIndex: 'defectStatusName',
+      dataIndex: 'defect_status_id',
       sorter: (a, b) =>
         (a.defectStatusName || '').localeCompare(b.defectStatusName || ''),
+      render: (_: number, row) => (
+        <DefectStatusSelect
+          defectId={row.id}
+          statusId={row.defect_status_id}
+          statusName={row.defectStatusName}
+        />
+      ),
     },
     {
       title: 'Кем устраняется',
@@ -77,11 +85,11 @@ export default function DefectsTable({ defects, filters, loading, columns: colum
       render: fmt,
     },
     {
-      title: 'Дата создания',
-      dataIndex: 'created_at',
+      title: 'Дата устранения',
+      dataIndex: 'fixed_at',
       sorter: (a, b) =>
-        (a.created_at ? dayjs(a.created_at).valueOf() : 0) -
-        (b.created_at ? dayjs(b.created_at).valueOf() : 0),
+        (a.fixed_at ? dayjs(a.fixed_at).valueOf() : 0) -
+        (b.fixed_at ? dayjs(b.fixed_at).valueOf() : 0),
       render: fmt,
     },
     {


### PR DESCRIPTION
## Summary
- fix format of unit names
- allow inline defect status change in table
- show fix date instead of creation date

## Testing
- `npm run lint` *(fails: Parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e71480674832ea33d78199042391a