### PR TITLE
Fix defect executor toggle and DB field

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -442,8 +442,15 @@
   },
   {
     "table_name": "defects",
-    "column_name": "fix_by",
-    "data_type": "text",
+    "column_name": "brigade_id",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": null
+  },
+  {
+    "table_name": "defects",
+    "column_name": "contractor_id",
+    "data_type": "integer",
     "is_nullable": "YES",
     "column_default": null
   },

--- a/src/entities/defect.ts
+++ b/src/entities/defect.ts
@@ -7,7 +7,8 @@ export interface NewDefect {
   description: string;
   defect_type_id: number | null;
   defect_status_id: number | null;
-  fix_by: string | null;
+  brigade_id: number | null;
+  contractor_id: number | null;
   received_at: string | null;
   fixed_at: string | null;
 }
@@ -22,7 +23,7 @@ export function useDefects() {
       const { data, error } = await supabase
         .from(TABLE)
         .select(
-          'id, description, defect_type_id, defect_status_id, fix_by, received_at, fixed_at, created_at,' +
+          'id, description, defect_type_id, defect_status_id, brigade_id, contractor_id, received_at, fixed_at, created_at,' +
           ' defect_type:defect_types(id,name), defect_status:defect_statuses(id,name)'
         )
         .order('id');
@@ -42,7 +43,7 @@ export function useDefect(id?: number) {
       const { data, error } = await supabase
         .from(TABLE)
         .select(
-          'id, description, defect_type_id, defect_status_id, fix_by, received_at, fixed_at, created_at,' +
+          'id, description, defect_type_id, defect_status_id, brigade_id, contractor_id, received_at, fixed_at, created_at,' +
           ' defect_type:defect_types(id,name), defect_status:defect_statuses(id,name)'
         )
         .eq('id', id as number)

--- a/src/features/ticket/TicketFormAntd.tsx
+++ b/src/features/ticket/TicketFormAntd.tsx
@@ -43,7 +43,15 @@ export interface TicketFormAntdValues {
   is_warranty: boolean;
   received_at: Dayjs;
   fixed_at: Dayjs | null;
-  defects?: Array<{ type_id: number | null; fixed_at: Dayjs | null; fix_by: string }>;
+  defects?: Array<{
+    type_id: number | null;
+    fixed_at: Dayjs | null;
+    brigade_id: number | null;
+    contractor_id: number | null;
+    description?: string;
+    status_id?: number | null;
+    received_at?: Dayjs | null;
+  }>;
   /** Дополнительные данные разметки, не отправляются на сервер */
   pins?: unknown;
 }
@@ -131,7 +139,8 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
         description: d.description || '',
         defect_type_id: d.type_id ?? null,
         defect_status_id: d.status_id ?? null,
-        fix_by: d.fix_by || null,
+        brigade_id: d.brigade_id ?? null,
+        contractor_id: d.contractor_id ?? null,
         received_at: d.received_at ? d.received_at.format('YYYY-MM-DD') : null,
         fixed_at: d.fixed_at ? d.fixed_at.format('YYYY-MM-DD') : null,
       }));

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -67,14 +67,10 @@ export default function DefectsPage() {
         .filter(Boolean)
         .join(', ');
       let fixByName = '—';
-      if (d.fix_by?.startsWith('b:')) {
-        const id = Number(d.fix_by.slice(2));
-        fixByName = brigades.find((b) => b.id === id)?.name || 'Бригада';
-      } else if (d.fix_by?.startsWith('c:')) {
-        const id = Number(d.fix_by.slice(2));
-        fixByName = contractors.find((c) => c.id === id)?.name || 'Подрядчик';
-      } else if (d.fix_by) {
-        fixByName = d.fix_by === 'contractor' ? 'Подрядчик' : 'Собственные силы';
+      if (d.brigade_id) {
+        fixByName = brigades.find((b) => b.id === d.brigade_id)?.name || 'Бригада';
+      } else if (d.contractor_id) {
+        fixByName = contractors.find((c) => c.id === d.contractor_id)?.name || 'Подрядчик';
       }
       return {
         ...d,

--- a/src/shared/types/defect.ts
+++ b/src/shared/types/defect.ts
@@ -8,8 +8,10 @@ export interface DefectRecord {
   defect_type_id: number | null;
   /** Статус дефекта */
   defect_status_id: number | null;
-  /** Кем устраняется (own|contractor) */
-  fix_by: string | null;
+  /** Исполнитель - бригада */
+  brigade_id: number | null;
+  /** Исполнитель - подрядчик */
+  contractor_id: number | null;
   /** Дата получения */
   received_at: string | null;
   /** Дата устранения */
@@ -30,7 +32,7 @@ export interface DefectWithInfo extends DefectRecord {
   defectTypeName?: string;
   /** Название статуса дефекта */
   defectStatusName?: string;
-  /** Текстовое значение поля fix_by */
+  /** Название исполнителя */
   fixByName?: string;
   /** Идентификаторы проектов, связанные с замечаниями */
   projectIds?: number[];

--- a/src/shared/utils/defectFilter.ts
+++ b/src/shared/utils/defectFilter.ts
@@ -14,8 +14,8 @@ export function filterDefects<T extends {
   projectIds?: number[];
   defect_type_id: number | null;
   defect_status_id: number | null;
-  fix_by: string | null;
   defectStatusName?: string;
+  fixByName?: string;
 }>(rows: T[], f: DefectFilters): T[] {
   return rows.filter((d) => {
     if (Array.isArray(f.id) && f.id.length > 0 && !f.id.includes(d.id)) {
@@ -59,7 +59,7 @@ export function filterDefects<T extends {
     if (
       Array.isArray(f.fixBy) &&
       f.fixBy.length > 0 &&
-      (!d.fix_by || !f.fixBy.includes(d.fix_by))
+      (!d.fixByName || !f.fixBy.includes(d.fixByName))
     ) {
       return false;
     }

--- a/src/widgets/DefectEditableTable.tsx
+++ b/src/widgets/DefectEditableTable.tsx
@@ -53,30 +53,26 @@ export default function DefectEditableTable({ fields, add, remove, projectId }: 
   };
 
   const FixByField = ({ field }: { field: any }) => {
-    const namePath = [field.name, 'fix_by'];
-    const value: string | undefined = Form.useWatch(namePath, form);
-    const initialMode = value?.startsWith('c:') ? 'contractor' : 'brigade';
+    const brigadePath = [field.name, 'brigade_id'];
+    const contractorPath = [field.name, 'contractor_id'];
+    const brigadeVal: number | undefined = Form.useWatch(brigadePath, form);
+    const contractorVal: number | undefined = Form.useWatch(contractorPath, form);
+    const initialMode = contractorVal ? 'contractor' : 'brigade';
     const [mode, setMode] = React.useState<'brigade' | 'contractor'>(initialMode as any);
-    const options = (mode === 'brigade' ? brigades : contractors).map((b: any) => ({
-      value: `${mode === 'brigade' ? 'b' : 'c'}:${b.id}`,
-      label: b.name,
-    }));
 
     React.useEffect(() => {
-      if (!value) return;
-      const nextMode = value.startsWith('c:') ? 'contractor' : 'brigade';
-      if (nextMode !== mode) {
-        setMode(nextMode);
-      }
-    }, [value]);
-
-    React.useEffect(() => {
-      const current: string | undefined = form.getFieldValue(namePath);
-      const prefix = mode === 'brigade' ? 'b:' : 'c:';
-      if (current && !current.startsWith(prefix)) {
-        form.setFieldValue(namePath, undefined);
+      if (mode === 'brigade') {
+        form.setFieldValue(contractorPath, null);
+      } else {
+        form.setFieldValue(brigadePath, null);
       }
     }, [mode]);
+
+    const namePath = mode === 'brigade' ? brigadePath : contractorPath;
+    const options = (mode === 'brigade' ? brigades : contractors).map((b: any) => ({
+      value: b.id,
+      label: b.name,
+    }));
 
     return (
       <Space direction="vertical" style={{ width: '100%' }}>
@@ -269,7 +265,7 @@ export default function DefectEditableTable({ fields, add, remove, projectId }: 
             Кем устраняется<span style={{ color: 'red' }}>*</span>
           </span>
         ),
-        dataIndex: 'fix_by',
+        dataIndex: 'executor',
         width: 180,
         ellipsis: true,
         render: (_: any, field: any) => <FixByField field={field} />, 
@@ -312,7 +308,8 @@ export default function DefectEditableTable({ fields, add, remove, projectId }: 
               type_id: null,
               received_at: dayjs(),
               fixed_at: null,
-              fix_by: null,
+              brigade_id: null,
+              contractor_id: null,
             })
           }
         >


### PR DESCRIPTION
## Summary
- split `fix_by` into `brigade_id` and `contractor_id`
- adjust editable defect table and ticket form
- adapt defect queries, filters and page view
- update DB structure description

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e72897cac832eb38c30ae9112c59d