### PR TITLE
Fix contractor toggle in defect table

### DIFF
--- a/src/widgets/DefectEditableTable.tsx
+++ b/src/widgets/DefectEditableTable.tsx
@@ -55,34 +55,50 @@ export default function DefectEditableTable({ fields, add, remove, projectId }: 
   const FixByField = ({ field }: { field: any }) => {
     const brigadePath = [field.name, 'brigade_id'];
     const contractorPath = [field.name, 'contractor_id'];
-    const brigadeVal: number | undefined = Form.useWatch(brigadePath, form);
+    const modePath = [field.name, 'executor_type'];
+
     const contractorVal: number | undefined = Form.useWatch(contractorPath, form);
-    const initialMode = contractorVal ? 'contractor' : 'brigade';
-    const [mode, setMode] = React.useState<'brigade' | 'contractor'>(initialMode as any);
+    const currentMode: 'brigade' | 'contractor' =
+      Form.useWatch(modePath, form) ?? (contractorVal ? 'contractor' : 'brigade');
 
     React.useEffect(() => {
-      if (mode === 'brigade') {
+      if (form.getFieldValue(modePath) == null) {
+        form.setFieldValue(modePath, currentMode);
+      }
+    }, []);
+
+    const handleModeChange = (val: 'brigade' | 'contractor') => {
+      form.setFieldValue(modePath, val);
+      if (val === 'brigade') {
         form.setFieldValue(contractorPath, null);
       } else {
         form.setFieldValue(brigadePath, null);
       }
-    }, [mode]);
+    };
 
-    const namePath = mode === 'brigade' ? brigadePath : contractorPath;
-    const options = (mode === 'brigade' ? brigades : contractors).map((b: any) => ({
+    const namePath = currentMode === 'brigade' ? brigadePath : contractorPath;
+    const options = (currentMode === 'brigade' ? brigades : contractors).map((b: any) => ({
       value: b.id,
       label: b.name,
     }));
 
     return (
       <Space direction="vertical" style={{ width: '100%' }}>
-        <Radio.Group size="small" value={mode} onChange={(e) => setMode(e.target.value)}>
+        <Radio.Group
+          size="small"
+          value={currentMode}
+          onChange={(e) => handleModeChange(e.target.value)}
+        >
           <Radio.Button value="brigade">Собст</Radio.Button>
           <Radio.Button value="contractor">Подряд</Radio.Button>
         </Radio.Group>
-        <Form.Item name={namePath} noStyle rules={[{ required: true, message: 'Выберите исполнителя' }]}>
+        <Form.Item
+          name={namePath}
+          noStyle
+          rules={[{ required: true, message: 'Выберите исполнителя' }]}
+        >
           <Select
-            key={mode}
+            key={currentMode}
             size="small"
             placeholder="Исполнитель"
             showSearch


### PR DESCRIPTION
## Summary
- maintain executor type in form state to keep radio selection persistent
- update selection logic for brigade/contractor in defects table

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e80af92b4832e9cb9235fb9c41814