### PR TITLE
fix contractor toggle on defects table

### DIFF
--- a/src/widgets/DefectEditableTable.tsx
+++ b/src/widgets/DefectEditableTable.tsx
@@ -55,10 +55,9 @@ export default function DefectEditableTable({ fields, add, remove, projectId }: 
   const FixByField = ({ field }: { field: any }) => {
     const brigadePath = [field.name, 'brigade_id'];
     const contractorPath = [field.name, 'contractor_id'];
-    const brigadeVal: number | undefined = Form.useWatch(brigadePath, form);
-    const contractorVal: number | undefined = Form.useWatch(contractorPath, form);
-    const initialMode = contractorVal ? 'contractor' : 'brigade';
-    const [mode, setMode] = React.useState<'brigade' | 'contractor'>(initialMode as any);
+    const [mode, setMode] = React.useState<'brigade' | 'contractor'>(() =>
+      form.getFieldValue(contractorPath) ? 'contractor' : 'brigade',
+    );
 
     React.useEffect(() => {
       if (mode === 'brigade') {


### PR DESCRIPTION
## Summary
- fix contractor toggle state in DefectEditableTable

## Testing
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_684e80af92b4832e9cb9235fb9c41814