### PR TITLE
Fix defects table rendering and refresh

### DIFF
--- a/src/entities/ticket.js
+++ b/src/entities/ticket.js
@@ -298,6 +298,7 @@ export function useCreateTicket() {
     onSuccess: (_, vars) => {
       const pid = vars.project_id ?? projectId;
       qc.invalidateQueries({ queryKey: ["tickets", pid] });
+      qc.invalidateQueries({ queryKey: ["tickets-simple", pid] });
       notify.success("Замечание успешно создано");
     },
     onError: (e) => notify.error(`Ошибка создания замечания: ${e.message}`),

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -58,10 +58,10 @@ export default function DefectsPage() {
     return defects.map((d: any) => {
       const linked = ticketsMap.get(d.id) || [];
       const unitIds = Array.from(new Set(linked.flatMap((l) => l.unit_ids)));
-      const unitNames = unitIds
+      const unitNamesList = unitIds
         .map((id) => unitMap.get(id))
-        .filter(Boolean)
-        .join(', ');
+        .filter(Boolean);
+      const unitNames = unitNamesList.join(', ');
       const projectIds = Array.from(new Set(linked.map((l) => l.project_id)));
       const projectNames = projectIds
         .map((id) => projectMap.get(id))
@@ -78,6 +78,7 @@ export default function DefectsPage() {
         ticketIds: linked.map((l) => l.id),
         unitIds,
         unitNames,
+        unitNamesList,
         projectIds,
         projectNames,
         fixByName,
@@ -142,9 +143,18 @@ export default function DefectsPage() {
       },
       units: {
         title: 'Объекты',
-        dataIndex: 'unitNames',
+        dataIndex: 'unitNamesList',
         sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
           (a.unitNames || '').localeCompare(b.unitNames || ''),
+        render: (_: string[], row: DefectWithInfo) => (
+          <>
+            {row.unitNamesList?.map((n, i) => (
+              <div key={i} style={{ whiteSpace: 'nowrap' }}>
+                {n}
+              </div>
+            ))}
+          </>
+        ),
       },
       description: {
         title: 'Описание',

--- a/src/shared/types/defect.ts
+++ b/src/shared/types/defect.ts
@@ -28,6 +28,8 @@ export interface DefectWithInfo extends DefectRecord {
   unitIds: number[];
   /** Названия объектов, объединённые в строку */
   unitNames?: string;
+  /** Названия объектов в виде массива */
+  unitNamesList?: string[];
   /** Название типа дефекта */
   defectTypeName?: string;
   /** Название статуса дефекта */

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -44,8 +44,17 @@ export default function DefectsTable({ defects, filters, loading, columns: colum
     },
     {
       title: 'Объекты',
-      dataIndex: 'unitNames',
+      dataIndex: 'unitNamesList',
       sorter: (a, b) => (a.unitNames || '').localeCompare(b.unitNames || ''),
+      render: (_: string[], row) => (
+        <>
+          {row.unitNamesList?.map((n, i) => (
+            <div key={i} style={{ whiteSpace: 'nowrap' }}>
+              {n}
+            </div>
+          ))}
+        </>
+      ),
     },
     {
       title: 'Описание',


### PR DESCRIPTION
## Summary
- show each object on new line in defects table
- refresh tickets-simple query after creating ticket so projects/objects show immediately

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e8394467c832e9dbc9c4da5472a91