### PR TITLE
Update default filter state on defects page

### DIFF
--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -115,9 +115,9 @@ export default function DefectsPage() {
   const [showFilters, setShowFilters] = useState(() => {
     try {
       const saved = localStorage.getItem(LS_FILTERS_VISIBLE_KEY);
-      return saved ? JSON.parse(saved) : true;
+      return saved ? JSON.parse(saved) : false;
     } catch {
-      return true;
+      return false;
     }
   });
 


### PR DESCRIPTION
## Summary
- hide filters by default on the `/defects` page

## Testing
- `npm run lint` *(fails: Parsing errors in other files)*

------
https://chatgpt.com/codex/tasks/task_e_684ea25d1f30832ea2d74a1431c75851