### PR TITLE
Add days since fix column to defects page

### DIFF
--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -84,6 +84,9 @@ export default function DefectsPage() {
         fixByName,
         defectTypeName: d.defect_type?.name ?? '',
         defectStatusName: d.defect_status?.name ?? '',
+        daysSinceFix: d.fixed_at
+          ? dayjs().diff(dayjs(d.fixed_at), 'day') + 1
+          : null,
       } as DefectWithInfo;
     });
   }, [defects, tickets, units, projects]);
@@ -202,6 +205,12 @@ export default function DefectsPage() {
           (a.fixed_at ? dayjs(a.fixed_at).valueOf() : 0) -
           (b.fixed_at ? dayjs(b.fixed_at).valueOf() : 0),
         render: fmt,
+      },
+      daysSinceFix: {
+        title: 'Прошло дней с даты устранения',
+        dataIndex: 'daysSinceFix',
+        sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
+          (a.daysSinceFix ?? -1) - (b.daysSinceFix ?? -1),
       },
       actions: {
         title: 'Действия',

--- a/src/shared/types/defect.ts
+++ b/src/shared/types/defect.ts
@@ -40,4 +40,6 @@ export interface DefectWithInfo extends DefectRecord {
   projectIds?: number[];
   /** Названия проектов, объединённые в строку */
   projectNames?: string;
+  /** Прошло дней с даты устранения */
+  daysSinceFix?: number | null;
 }

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -12,6 +12,7 @@ import { filterDefects } from '@/shared/utils/defectFilter';
 const fmt = (v: string | null) =>
   v ? dayjs(v).format('DD.MM.YYYY') : '—';
 
+
 interface Props {
   defects: DefectWithInfo[];
   filters: DefectFilters;
@@ -100,6 +101,11 @@ export default function DefectsTable({ defects, filters, loading, columns: colum
         (a.fixed_at ? dayjs(a.fixed_at).valueOf() : 0) -
         (b.fixed_at ? dayjs(b.fixed_at).valueOf() : 0),
       render: fmt,
+    },
+    {
+      title: 'Прошло дней с даты устранения',
+      dataIndex: 'daysSinceFix',
+      sorter: (a, b) => (a.daysSinceFix ?? -1) - (b.daysSinceFix ?? -1),
     },
     {
       title: 'Действия',


### PR DESCRIPTION
## Summary
- track how many days passed since a defect was fixed
- show this value in the defects table and allow sorting
- expose `daysSinceFix` field in `DefectWithInfo`

## Testing
- `npm run lint` *(fails: Parsing errors in many files)*

------
https://chatgpt.com/codex/tasks/task_e_684ea3728420832ebba62a9e34ea18d2