### PR TITLE
Добавлена колонка количества дней на странице дефектов

### DIFF
--- a/src/features/defect/ExportDefectsButton.tsx
+++ b/src/features/defect/ExportDefectsButton.tsx
@@ -21,6 +21,7 @@ export default function ExportDefectsButton({
   filters,
 }: ExportDefectsButtonProps) {
   const handleClick = React.useCallback(async () => {
+    const today = dayjs();
     const rows = filterDefects(defects, filters).map((d) => ({
       'ID дефекта': d.id,
       'ID замечание': d.ticketIds.join(', '),
@@ -31,6 +32,9 @@ export default function ExportDefectsButton({
       Статус: d.defectStatusName ?? '',
       'Кем устраняется': d.fixByName ?? '',
       'Дата получения': d.received_at ? dayjs(d.received_at).format('DD.MM.YYYY') : '',
+      'Прошло дней с Даты получения': d.received_at
+        ? today.diff(dayjs(d.received_at), 'day') + 1
+        : '',
       'Дата создания': d.created_at ? dayjs(d.created_at).format('DD.MM.YYYY') : '',
     }));
     const wb = new ExcelJS.Workbook();

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -82,6 +82,7 @@ export default function DefectsPage() {
         projectIds,
         projectNames,
         fixByName,
+        days: d.received_at ? dayjs().diff(dayjs(d.received_at), 'day') + 1 : null,
         defectTypeName: d.defect_type?.name ?? '',
         defectStatusName: d.defect_status?.name ?? '',
       } as DefectWithInfo;
@@ -134,6 +135,11 @@ export default function DefectsPage() {
         sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
           a.ticketIds.join(',').localeCompare(b.ticketIds.join(',')),
         render: (v: number[]) => v.join(', '),
+      },
+      days: {
+        title: 'Прошло дней с даты получения',
+        dataIndex: 'days',
+        sorter: (a: DefectWithInfo, b: DefectWithInfo) => (a.days ?? -1) - (b.days ?? -1),
       },
       project: {
         title: 'Проект',

--- a/src/shared/types/defect.ts
+++ b/src/shared/types/defect.ts
@@ -40,4 +40,6 @@ export interface DefectWithInfo extends DefectRecord {
   projectIds?: number[];
   /** Названия проектов, объединённые в строку */
   projectNames?: string;
+  /** Прошло дней с даты получения */
+  days?: number | null;
 }

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -38,6 +38,11 @@ export default function DefectsTable({ defects, filters, loading, columns: colum
       render: (v: number[]) => v.join(', '),
     },
     {
+      title: 'Прошло дней с даты получения',
+      dataIndex: 'days',
+      sorter: (a, b) => (a.days ?? -1) - (b.days ?? -1),
+    },
+    {
       title: 'Проект',
       dataIndex: 'projectNames',
       sorter: (a, b) => (a.projectNames || '').localeCompare(b.projectNames || ''),


### PR DESCRIPTION
## Summary
- добавлено поле `days` в тип `DefectWithInfo`
- подсчёт прошедших дней с даты получения в `DefectsPage`
- колонка "Прошло дней с даты получения" перед колонкой "Проект" в таблице дефектов
- экспорт в Excel дополнен новой колонкой

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ea51a7698832ea3670f31c540afbf