### PR TITLE
Добавлена возможность фиксировать устранение дефекта

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -455,6 +455,13 @@
     "column_default": null
   },
   {
+    "table_name": "defects",
+    "column_name": "attachment_ids",
+    "data_type": "ARRAY",
+    "is_nullable": "YES",
+    "column_default": "ARRAY[]::integer[]"
+  },
+  {
     "table_name": "letter_links",
     "column_name": "parent_id",
     "data_type": "bigint",

--- a/src/entities/attachment.js
+++ b/src/entities/attachment.js
@@ -90,6 +90,15 @@ export function uploadTicketAttachment(file, projectId, ticketId) {
 }
 
 /**
+ * Загружает файл дефекта в хранилище Supabase.
+ * @param {File} file
+ * @param {number} defectId
+ */
+export function uploadDefectAttachment(file, defectId) {
+    return upload(file, `defects/${defectId}`);
+}
+
+/**
  * Загружает файлы дела и создаёт записи в таблице attachments
  * с возвратом созданных строк.
  * @param {{file: File, type_id: number | null}[]} files
@@ -174,6 +183,34 @@ export async function addTicketAttachments(files, projectId, ticketId) {
 }
 
 /**
+ * Загружает файлы дефекта и создаёт записи в таблице attachments
+ * с возвратом созданных строк.
+ * @param {{file: File, type_id: number | null}[]} files
+ * @param {number} defectId
+ */
+export async function addDefectAttachments(files, defectId) {
+    const uploaded = await Promise.all(
+        files.map(({ file }) => uploadDefectAttachment(file, defectId)),
+    );
+
+    const rows = uploaded.map((u, idx) => ({
+        file_url: u.url,
+        file_type: u.type,
+        original_name: files[idx].file.name,
+        storage_path: u.path,
+        attachment_type_id: files[idx].type_id ?? null,
+    }));
+
+    const { data, error } = await supabase
+        .from('attachments')
+        .insert(rows)
+        .select('id, storage_path, file_url, file_type, attachment_type_id, original_name');
+
+    if (error) throw error;
+    return data ?? [];
+}
+
+/**
  * Возвращает вложения по указанным id
  * @param {number[]} ids
  */
@@ -188,4 +225,4 @@ export async function getAttachmentsByIds(ids) {
     return data ?? [];
 }
 
-export { ATTACH_BUCKET };
+export { ATTACH_BUCKET, uploadDefectAttachment, addDefectAttachments };

--- a/src/entities/defect.ts
+++ b/src/entities/defect.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/shared/api/supabaseClient';
 import { useNotify } from '@/shared/hooks/useNotify';
+import { addDefectAttachments } from '@/entities/attachment';
 import type { DefectRecord } from '@/shared/types/defect';
 
 export interface NewDefect {
@@ -23,7 +24,7 @@ export function useDefects() {
       const { data, error } = await supabase
         .from(TABLE)
         .select(
-          'id, description, defect_type_id, defect_status_id, brigade_id, contractor_id, received_at, fixed_at, created_at,' +
+          'id, description, defect_type_id, defect_status_id, brigade_id, contractor_id, received_at, fixed_at, attachment_ids, created_at,' +
           ' defect_type:defect_types(id,name), defect_status:defect_statuses(id,name)'
         )
         .order('id');
@@ -43,7 +44,7 @@ export function useDefect(id?: number) {
       const { data, error } = await supabase
         .from(TABLE)
         .select(
-          'id, description, defect_type_id, defect_status_id, brigade_id, contractor_id, received_at, fixed_at, created_at,' +
+          'id, description, defect_type_id, defect_status_id, brigade_id, contractor_id, received_at, fixed_at, attachment_ids, created_at,' +
           ' defect_type:defect_types(id,name), defect_status:defect_statuses(id,name)'
         )
         .eq('id', id as number)
@@ -107,4 +108,50 @@ export function useUpdateDefectStatus() {
     onSuccess: () => qc.invalidateQueries({ queryKey: [TABLE] }),
     onError: (e) => notify.error(`Ошибка обновления статуса: ${e.message}`),
   });
+}
+
+/** Обновить данные устранения дефекта */
+export function useFixDefect() {
+  const qc = useQueryClient();
+  const notify = useNotify();
+  return useMutation(
+    async ({
+      id,
+      brigade_id,
+      contractor_id,
+      fixed_at,
+      attachments = [],
+    }: {
+      id: number;
+      brigade_id: number | null;
+      contractor_id: number | null;
+      fixed_at: string | null;
+      attachments: { file: File; type_id: number | null }[];
+    }) => {
+      const { data: current } = await supabase
+        .from(TABLE)
+        .select('attachment_ids')
+        .eq('id', id)
+        .single();
+      let ids: number[] = current?.attachment_ids ?? [];
+      let uploaded: any[] = [];
+      if (attachments.length) {
+        uploaded = await addDefectAttachments(attachments, id);
+        ids = ids.concat(uploaded.map((u) => u.id));
+      }
+      const { error } = await supabase
+        .from(TABLE)
+        .update({ brigade_id, contractor_id, fixed_at, attachment_ids: ids })
+        .eq('id', id);
+      if (error) throw error;
+      return uploaded;
+    },
+    {
+      onSuccess: () => {
+        qc.invalidateQueries({ queryKey: [TABLE] });
+        notify.success('Дефект обновлён');
+      },
+      onError: (e: any) => notify.error(`Ошибка обновления: ${e.message}`),
+    },
+  );
 }

--- a/src/features/defect/DefectFixModal.tsx
+++ b/src/features/defect/DefectFixModal.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import dayjs from 'dayjs';
+import { Modal, Form, Select, DatePicker, Button } from 'antd';
+import FileDropZone from '@/shared/ui/FileDropZone';
+import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
+import { useBrigades } from '@/entities/brigade';
+import { useContractors } from '@/entities/contractor';
+import { useAttachmentTypes } from '@/entities/attachmentType';
+import { useFixDefect } from '@/entities/defect';
+import type { NewDefectFile } from '@/shared/types/defectFile';
+
+interface Props {
+  defectId: number | null;
+  open: boolean;
+  onClose: () => void;
+}
+
+/** Модальное окно внесения данных об устранении дефекта */
+export default function DefectFixModal({ defectId, open, onClose }: Props) {
+  const { data: brigades = [] } = useBrigades();
+  const { data: contractors = [] } = useContractors();
+  const { data: attachmentTypes = [] } = useAttachmentTypes();
+  const fix = useFixDefect();
+
+  const [brigadeId, setBrigadeId] = useState<number | null>(null);
+  const [contractorId, setContractorId] = useState<number | null>(null);
+  const [fixedAt, setFixedAt] = useState<dayjs.Dayjs | null>(null);
+  const [files, setFiles] = useState<NewDefectFile[]>([]);
+
+  const handleFiles = (f: File[]) => {
+    setFiles((p) => [...p, ...f.map((file) => ({ file, type_id: null }))]);
+  };
+
+  const changeType = (idx: number, type: number | null) => {
+    setFiles((p) => p.map((f, i) => (i === idx ? { ...f, type_id: type } : f)));
+  };
+
+  const removeFile = (idx: number) => {
+    setFiles((p) => p.filter((_, i) => i !== idx));
+  };
+
+  const handleOk = async () => {
+    if (!defectId) return;
+    await fix.mutateAsync({
+      id: defectId,
+      brigade_id: brigadeId,
+      contractor_id: contractorId,
+      fixed_at: fixedAt ? fixedAt.format('YYYY-MM-DD') : null,
+      attachments: files,
+    });
+    setFiles([]);
+    setBrigadeId(null);
+    setContractorId(null);
+    setFixedAt(null);
+    onClose();
+  };
+
+  return (
+    <Modal
+      open={open}
+      onCancel={onClose}
+      onOk={handleOk}
+      confirmLoading={fix.isPending}
+      title="Устранение дефекта"
+    >
+      <Form layout="vertical">
+        <Form.Item label="Бригада">
+          <Select
+            allowClear
+            value={brigadeId ?? undefined}
+            options={brigades.map((b) => ({ value: b.id, label: b.name }))}
+            onChange={(v) => {
+              setBrigadeId(v ?? null);
+              if (v) setContractorId(null);
+            }}
+          />
+        </Form.Item>
+        <Form.Item label="Подрядчик">
+          <Select
+            allowClear
+            value={contractorId ?? undefined}
+            options={contractors.map((c) => ({ value: c.id, label: c.name }))}
+            onChange={(v) => {
+              setContractorId(v ?? null);
+              if (v) setBrigadeId(null);
+            }}
+          />
+        </Form.Item>
+        <Form.Item label="Дата устранения">
+          <DatePicker
+            format="DD.MM.YYYY"
+            value={fixedAt ?? undefined}
+            onChange={(d) => setFixedAt(d)}
+            style={{ width: '100%' }}
+          />
+        </Form.Item>
+        <Form.Item label="Файлы">
+          <FileDropZone onFiles={handleFiles} />
+          <AttachmentEditorTable
+            newFiles={files.map((f) => ({ file: f.file, typeId: f.type_id, mime: f.file.type }))}
+            attachmentTypes={attachmentTypes}
+            onRemoveNew={removeFile}
+            onChangeNewType={changeType}
+          />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+}

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -9,7 +9,7 @@ import {
   Popconfirm,
   message,
 } from 'antd';
-import { SettingOutlined, EyeOutlined, DeleteOutlined } from '@ant-design/icons';
+import { SettingOutlined, EyeOutlined, DeleteOutlined, CheckOutlined } from '@ant-design/icons';
 import ruRU from 'antd/locale/ru_RU';
 import { useDefects, useDeleteDefect } from '@/entities/defect';
 import { useTicketsSimple } from '@/entities/ticket';
@@ -24,6 +24,7 @@ import type { TableColumnSetting } from '@/shared/types/tableColumnSetting';
 import DefectViewModal from '@/features/defect/DefectViewModal';
 import DefectStatusSelect from '@/features/defect/DefectStatusSelect';
 import ExportDefectsButton from '@/features/defect/ExportDefectsButton';
+import DefectFixModal from '@/features/defect/DefectFixModal';
 import { filterDefects } from '@/shared/utils/defectFilter';
 import formatUnitName from '@/shared/utils/formatUnitName';
 import type { DefectWithInfo } from '@/shared/types/defect';
@@ -108,6 +109,7 @@ export default function DefectsPage() {
 
   const [filters, setFilters] = useState<DefectFilters>({});
   const [viewId, setViewId] = useState<number | null>(null);
+  const [fixId, setFixId] = useState<number | null>(null);
   const { mutateAsync: removeDefect, isPending: removing } = useDeleteDefect();
 
   const LS_FILTERS_VISIBLE_KEY = 'defectsFiltersVisible';
@@ -221,6 +223,14 @@ export default function DefectsPage() {
                 type="text"
                 icon={<EyeOutlined />}
                 onClick={() => setViewId(row.id)}
+              />
+            </Tooltip>
+            <Tooltip title="Устранён">
+              <Button
+                size="small"
+                type="text"
+                icon={<CheckOutlined />}
+                onClick={() => setFixId(row.id)}
               />
             </Tooltip>
             <Popconfirm
@@ -351,6 +361,11 @@ export default function DefectsPage() {
           open={viewId !== null}
           defectId={viewId}
           onClose={() => setViewId(null)}
+        />
+        <DefectFixModal
+          open={fixId !== null}
+          defectId={fixId}
+          onClose={() => setFixId(null)}
         />
       </>
     </ConfigProvider>

--- a/src/shared/types/defect.ts
+++ b/src/shared/types/defect.ts
@@ -16,6 +16,8 @@ export interface DefectRecord {
   received_at: string | null;
   /** Дата устранения */
   fixed_at: string | null;
+  /** Массив идентификаторов вложений */
+  attachment_ids?: number[];
   /** Дата создания */
   created_at: string | null;
 }

--- a/src/shared/types/defectFile.ts
+++ b/src/shared/types/defectFile.ts
@@ -1,0 +1,17 @@
+/** Вложение дефекта, загруженное на сервер */
+export interface RemoteDefectFile {
+  id: string | number;
+  name: string;
+  original_name?: string | null;
+  path: string;
+  url: string;
+  type: string;
+  attachment_type_id: number | null;
+  attachment_type_name?: string;
+}
+
+/** Новый файл для вложения дефекта */
+export interface NewDefectFile {
+  file: File;
+  type_id: number | null;
+}


### PR DESCRIPTION
## Summary
- обновлена структура БД: у дефекта появилось поле `attachment_ids`
- добавлены типы файлов дефекта
- реализованы загрузка файлов дефекта в `attachment.js`
- расширен API сущности `defect` новым хукoм `useFixDefect`
- добавлено модальное окно `DefectFixModal`
- в таблице дефектов появилась кнопка «Устранён»

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684ea881330c832eb037e9878a374460