### PR TITLE
Fix defects table column order

### DIFF
--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -257,9 +257,24 @@ export default function DefectsPage() {
     } as Record<string, ColumnsType<DefectWithInfo>[number]>;
   }, [removeDefect, removing]);
 
+  const columnOrder = [
+    'id',
+    'tickets',
+    'days',
+    'project',
+    'units',
+    'description',
+    'type',
+    'status',
+    'fixBy',
+    'received',
+    'created',
+    'actions',
+  ] as const;
+
   const [columnsState, setColumnsState] = useState<TableColumnSetting[]>(() => {
     const base = baseColumns;
-    const defaults = Object.keys(base).map((key) => ({
+    const defaults = columnOrder.map((key) => ({
       key,
       title: base[key].title as string,
       visible: true,
@@ -278,7 +293,7 @@ export default function DefectsPage() {
 
   const handleResetColumns = () => {
     const base = baseColumns;
-    const defaults = Object.keys(base).map((key) => ({
+    const defaults = columnOrder.map((key) => ({
       key,
       title: base[key].title as string,
       visible: true,


### PR DESCRIPTION
## Summary
- ensure column order keeps 'Прошло дней с даты получения' before 'Проект' by defining explicit column sequence

## Testing
- `npm run lint` *(fails: Parsing error: Unexpected token {)*

------
https://chatgpt.com/codex/tasks/task_e_684eb204ff58832e934df9dc4fbba00e