### PR TITLE
Add fixed status to defects

### DIFF
--- a/src/entities/defect.ts
+++ b/src/entities/defect.ts
@@ -12,6 +12,7 @@ export interface NewDefect {
   contractor_id: number | null;
   received_at: string | null;
   fixed_at: string | null;
+  is_fixed: boolean;
 }
 
 const TABLE = 'defects';
@@ -24,7 +25,7 @@ export function useDefects() {
       const { data, error } = await supabase
         .from(TABLE)
         .select(
-          'id, description, defect_type_id, defect_status_id, brigade_id, contractor_id, received_at, fixed_at, attachment_ids, created_at,' +
+          'id, description, defect_type_id, defect_status_id, brigade_id, contractor_id, received_at, fixed_at, is_fixed, attachment_ids, created_at,' +
           ' defect_type:defect_types(id,name), defect_status:defect_statuses(id,name)'
         )
         .order('id');
@@ -44,7 +45,7 @@ export function useDefect(id?: number) {
       const { data, error } = await supabase
         .from(TABLE)
         .select(
-          'id, description, defect_type_id, defect_status_id, brigade_id, contractor_id, received_at, fixed_at, attachment_ids, created_at,' +
+          'id, description, defect_type_id, defect_status_id, brigade_id, contractor_id, received_at, fixed_at, is_fixed, attachment_ids, created_at,' +
           ' defect_type:defect_types(id,name), defect_status:defect_statuses(id,name)'
         )
         .eq('id', id as number)
@@ -65,7 +66,7 @@ export function useCreateDefects() {
       if (!defects.length) return [];
       const { data, error } = await supabase
         .from(TABLE)
-        .insert(defects)
+        .insert(defects.map((d) => ({ ...d, is_fixed: false })))
         .select('id');
       if (error) throw error;
       return (data as { id: number }[]).map((d) => d.id);
@@ -141,7 +142,7 @@ export function useFixDefect() {
       }
       const { error } = await supabase
         .from(TABLE)
-        .update({ brigade_id, contractor_id, fixed_at, attachment_ids: ids })
+        .update({ brigade_id, contractor_id, fixed_at, is_fixed: true, attachment_ids: ids })
         .eq('id', id);
       if (error) throw error;
       return uploaded;

--- a/src/features/ticket/TicketFormAntd.tsx
+++ b/src/features/ticket/TicketFormAntd.tsx
@@ -143,6 +143,7 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
         contractor_id: d.contractor_id ?? null,
         received_at: d.received_at ? d.received_at.format('YYYY-MM-DD') : null,
         fixed_at: d.fixed_at ? d.fixed_at.format('YYYY-MM-DD') : null,
+        is_fixed: false,
       }));
       const defectIds = await createDefects.mutateAsync(newDefs);
       const payload = {

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -83,6 +83,7 @@ export default function DefectsPage() {
         projectIds,
         projectNames,
         fixByName,
+        is_fixed: d.is_fixed,
         days: d.received_at ? dayjs().diff(dayjs(d.received_at), 'day') + 1 : null,
         defectTypeName: d.defect_type?.name ?? '',
         defectStatusName: d.defect_status?.name ?? '',
@@ -229,7 +230,7 @@ export default function DefectsPage() {
               <Button
                 size="small"
                 type="text"
-                icon={<CheckOutlined />}
+                icon={<CheckOutlined style={{ color: '#52c41a', fontSize: 16 }} />}
                 onClick={() => setFixId(row.id)}
               />
             </Tooltip>

--- a/src/shared/types/defect.ts
+++ b/src/shared/types/defect.ts
@@ -16,6 +16,8 @@ export interface DefectRecord {
   received_at: string | null;
   /** Дата устранения */
   fixed_at: string | null;
+  /** Дефект устранён */
+  is_fixed: boolean;
   /** Массив идентификаторов вложений */
   attachment_ids?: number[];
   /** Дата создания */

--- a/src/shared/ui/FixBySelector.tsx
+++ b/src/shared/ui/FixBySelector.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { Space, Radio, Select } from 'antd';
+import type { Brigade } from '@/shared/types/brigade';
+import type { Contractor } from '@/shared/types/contractor';
+
+export interface FixByValue {
+  brigade_id: number | null;
+  contractor_id: number | null;
+}
+
+interface Props {
+  value: FixByValue;
+  onChange: (v: FixByValue) => void;
+  brigades: Brigade[];
+  contractors: Contractor[];
+}
+
+/**
+ * Поле выбора исполнителя дефекта с переключателем
+ * между собственной бригадой и подрядчиком.
+ */
+export default function FixBySelector({
+  value,
+  onChange,
+  brigades,
+  contractors,
+}: Props) {
+  const [mode, setMode] = React.useState<'brigade' | 'contractor'>(
+    value.contractor_id ? 'contractor' : 'brigade',
+  );
+
+  React.useEffect(() => {
+    if (value.contractor_id && mode !== 'contractor') setMode('contractor');
+    if (value.brigade_id && mode !== 'brigade' && !value.contractor_id) setMode('brigade');
+  }, [value, mode]);
+
+  const handleModeChange = (m: 'brigade' | 'contractor') => {
+    setMode(m);
+    if (m === 'brigade') {
+      onChange({ brigade_id: null, contractor_id: null });
+    } else {
+      onChange({ brigade_id: null, contractor_id: null });
+    }
+  };
+
+  const handleSelect = (id: number | undefined) => {
+    if (mode === 'brigade') {
+      onChange({ brigade_id: id ?? null, contractor_id: null });
+    } else {
+      onChange({ brigade_id: null, contractor_id: id ?? null });
+    }
+  };
+
+  const options = (mode === 'brigade' ? brigades : contractors).map((b) => ({
+    value: b.id,
+    label: b.name,
+  }));
+
+  const currentValue = mode === 'brigade' ? value.brigade_id ?? undefined : value.contractor_id ?? undefined;
+
+  return (
+    <Space direction="vertical" style={{ width: '100%' }}>
+      <Radio.Group
+        size="small"
+        value={mode}
+        onChange={(e) => handleModeChange(e.target.value)}
+      >
+        <Radio.Button value="brigade">Собст</Radio.Button>
+        <Radio.Button value="contractor">Подряд</Radio.Button>
+      </Radio.Group>
+      <Select
+        key={mode}
+        size="small"
+        placeholder="Исполнитель"
+        allowClear
+        value={currentValue}
+        options={options}
+        onChange={(v) => handleSelect(v)}
+        showSearch
+        filterOption={(i, o) => (o?.label ?? '').toLowerCase().includes(i.toLowerCase())}
+        style={{ width: '100%' }}
+      />
+    </Space>
+  );
+}


### PR DESCRIPTION
## Summary
- add `FixBySelector` UI for choosing brigade or contractor
- update defect fix modal to preload executor and date
- mark defects as fixed and record executor
- save `is_fixed` flag in DB operations
- tweak fix action button style

## Testing
- `npm run lint` *(fails: ESLint config issues)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eb614e024832ea0bb281be6ba2afe