### PR TITLE
Add defect status filter and attachments

### DIFF
--- a/src/features/defect/DefectFixModal.tsx
+++ b/src/features/defect/DefectFixModal.tsx
@@ -69,7 +69,15 @@ export default function DefectFixModal({ defectId, open, onClose }: Props) {
       onCancel={onClose}
       onOk={handleOk}
       confirmLoading={fix.isPending}
-      title="Устранение дефекта"
+      title={
+        defect
+          ? `Устранение дефекта с ID №${defect.id} от ${
+              defect.received_at
+                ? dayjs(defect.received_at).format('DD.MM.YYYY')
+                : dayjs(defect.created_at).format('DD.MM.YYYY')
+            }`
+          : 'Устранение дефекта'
+      }
     >
       <Form layout="vertical">
         <Form.Item label="Исполнитель">

--- a/src/features/defect/DefectViewModal.tsx
+++ b/src/features/defect/DefectViewModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import dayjs from 'dayjs';
 import { Modal, Typography, Skeleton } from 'antd';
-import { useDefect } from '@/entities/defect';
+import { useDefect, signedUrl } from '@/entities/defect';
 
 interface Props {
   open: boolean;
@@ -36,6 +36,32 @@ export default function DefectViewModal({ open, defectId, onClose }: Props) {
             <b>Дата создания:</b>{' '}
             {defect.created_at ? dayjs(defect.created_at).format('DD.MM.YYYY') : '—'}
           </Typography.Text>
+          {defect.attachments?.length ? (
+            <div>
+              <b>Файлы:</b>
+              <ul style={{ paddingLeft: 20 }}>
+                {defect.attachments.map((f: any) => (
+                  <li key={f.id}>
+                    <a
+                      onClick={async (e) => {
+                        e.preventDefault();
+                        const url = await signedUrl(f.storage_path, f.original_name ?? 'file');
+                        const a = document.createElement('a');
+                        a.href = url;
+                        a.download = f.original_name ?? 'file';
+                        document.body.appendChild(a);
+                        a.click();
+                        a.remove();
+                      }}
+                      href="#"
+                    >
+                      {f.original_name ?? f.storage_path.split('/').pop()}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
         </div>
       )}
     </Modal>

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -9,7 +9,8 @@ import {
   Popconfirm,
   message,
 } from 'antd';
-import { SettingOutlined, EyeOutlined, DeleteOutlined, CheckOutlined } from '@ant-design/icons';
+import { SettingOutlined, EyeOutlined, DeleteOutlined, CheckOutlined, CheckCircleTwoTone, CloseCircleTwoTone } from '@ant-design/icons';
+import { Tag } from 'antd';
 import ruRU from 'antd/locale/ru_RU';
 import { useDefects, useDeleteDefect } from '@/entities/defect';
 import { useTicketsSimple } from '@/entities/ticket';
@@ -140,7 +141,12 @@ export default function DefectsPage() {
         render: (v: number[]) => v.join(', '),
       },
       days: {
-        title: 'Прошло дней с даты получения',
+        title: (
+          <span>
+            Прошло дней
+            <br />с даты получения
+          </span>
+        ),
         dataIndex: 'days',
         sorter: (a: DefectWithInfo, b: DefectWithInfo) => (a.days ?? -1) - (b.days ?? -1),
       },
@@ -195,6 +201,17 @@ export default function DefectsPage() {
         dataIndex: 'fixByName',
         sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
           (a.fixByName || '').localeCompare(b.fixByName || ''),
+      },
+      fixed: {
+        title: 'Устранён',
+        dataIndex: 'is_fixed',
+        sorter: (a: DefectWithInfo, b: DefectWithInfo) => Number(a.is_fixed) - Number(b.is_fixed),
+        render: (v: boolean) =>
+          v ? (
+            <Tag icon={<CheckCircleTwoTone twoToneColor="#52c41a" />} color="success">Да</Tag>
+          ) : (
+            <Tag icon={<CloseCircleTwoTone twoToneColor="#eb2f96" />} color="default">Нет</Tag>
+          ),
       },
       received: {
         title: 'Дата получения',
@@ -268,6 +285,7 @@ export default function DefectsPage() {
     'type',
     'status',
     'fixBy',
+    'fixed',
     'received',
     'created',
     'actions',

--- a/src/shared/types/defectFilters.ts
+++ b/src/shared/types/defectFilters.ts
@@ -9,6 +9,8 @@ export interface DefectFilters {
   typeId?: number[];
   statusId?: number[];
   fixBy?: string[];
+  /** Дефект устранён */
+  fixed?: 'yes' | 'no';
   period?: [Dayjs, Dayjs];
   hideClosed?: boolean;
 }

--- a/src/shared/utils/defectFilter.ts
+++ b/src/shared/utils/defectFilter.ts
@@ -16,6 +16,7 @@ export function filterDefects<T extends {
   defect_status_id: number | null;
   defectStatusName?: string;
   fixByName?: string;
+  is_fixed?: boolean;
 }>(rows: T[], f: DefectFilters): T[] {
   return rows.filter((d) => {
     if (Array.isArray(f.id) && f.id.length > 0 && !f.id.includes(d.id)) {
@@ -62,6 +63,10 @@ export function filterDefects<T extends {
       (!d.fixByName || !f.fixBy.includes(d.fixByName))
     ) {
       return false;
+    }
+    if (f.fixed) {
+      const want = f.fixed === 'yes';
+      if (d.is_fixed !== want) return false;
     }
     if (f.period && f.period.length === 2) {
       const [from, to] = f.period;

--- a/src/widgets/DefectsFilters.tsx
+++ b/src/widgets/DefectsFilters.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { Form, Select, Button, DatePicker, Switch } from 'antd';
+const { Option } = Select;
 import type { DefectFilters } from '@/shared/types/defectFilters';
 
 const { RangePicker } = DatePicker;
@@ -61,6 +62,12 @@ export default function DefectsFilters({
       </Form.Item>
       <Form.Item name="ticketId" label="ID замечание">
         <Select mode="multiple" allowClear options={options.tickets} showSearch optionFilterProp="label" />
+      </Form.Item>
+      <Form.Item name="fixed" label="Устранён">
+        <Select allowClear>
+          <Option value="yes">Да</Option>
+          <Option value="no">Нет</Option>
+        </Select>
       </Form.Item>
       <Form.Item name="hideClosed" label="Скрыть закрытые" valuePropName="checked">
         <Switch />

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import dayjs from 'dayjs';
-import { Table, Button, Tooltip, Skeleton, Popconfirm, message, Space } from 'antd';
-import { EyeOutlined, DeleteOutlined } from '@ant-design/icons';
+import { Table, Button, Tooltip, Skeleton, Popconfirm, message, Space, Tag } from 'antd';
+import { EyeOutlined, DeleteOutlined, CheckCircleTwoTone, CloseCircleTwoTone } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import { useDeleteDefect } from '@/entities/defect';
 import DefectStatusSelect from '@/features/defect/DefectStatusSelect';
@@ -38,7 +38,12 @@ export default function DefectsTable({ defects, filters, loading, columns: colum
       render: (v: number[]) => v.join(', '),
     },
     {
-      title: 'Прошло дней с даты получения',
+      title: (
+        <span>
+          Прошло дней
+          <br />с даты получения
+        </span>
+      ),
       dataIndex: 'days',
       sorter: (a, b) => (a.days ?? -1) - (b.days ?? -1),
     },
@@ -89,6 +94,17 @@ export default function DefectsTable({ defects, filters, loading, columns: colum
       title: 'Кем устраняется',
       dataIndex: 'fixByName',
       sorter: (a, b) => (a.fixByName || '').localeCompare(b.fixByName || ''),
+    },
+    {
+      title: 'Устранён',
+      dataIndex: 'is_fixed',
+      sorter: (a, b) => Number(a.is_fixed) - Number(b.is_fixed),
+      render: (v: boolean) =>
+        v ? (
+          <Tag icon={<CheckCircleTwoTone twoToneColor="#52c41a" />} color="success">Да</Tag>
+        ) : (
+          <Tag icon={<CloseCircleTwoTone twoToneColor="#eb2f96" />} color="default">Нет</Tag>
+        ),
     },
     {
       title: 'Дата получения',


### PR DESCRIPTION
## Summary
- mark defects as fixed with icon
- show fixed state column and filter
- show attachments in defect view modal
- improve fix modal header
- tweak column heading layout
- support signed URLs for defect attachments

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ebae9a094832ea5f9fb48a6ea0512