### PR TITLE
Fix tables updates and filters

### DIFF
--- a/src/entities/defect.ts
+++ b/src/entities/defect.ts
@@ -177,6 +177,7 @@ export function useFixDefect() {
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: [TABLE] });
+      qc.invalidateQueries({ queryKey: ['defects-by-ids'] });
       notify.success('Дефект обновлён');
     },
     onError: (e: any) => notify.error(`Ошибка обновления: ${e.message}`),

--- a/src/entities/ticket.js
+++ b/src/entities/ticket.js
@@ -624,6 +624,7 @@ export function useUpdateTicketClosed() {
           : { is_fixed: true };
         await supabase.from('defects').update(update).in('id', data.defect_ids);
         qc.invalidateQueries({ queryKey: ['defects'] });
+        qc.invalidateQueries({ queryKey: ['defects-by-ids'] });
       }
       return { id: data.id, is_closed: data.is_closed };
     },

--- a/src/index.css
+++ b/src/index.css
@@ -84,6 +84,10 @@ body {
 .ticket-fixed-row {
   background: #f6ffed !important;
 }
+.ticket-closed-row {
+  color: #aaa;
+  background: inherit !important;
+}
 .main-case-row {
   background: #eaf4ff !important;
   font-weight: 600;

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -112,24 +112,30 @@ export default function DefectsPage() {
   }, [defects, tickets, units, projects]);
 
   const options = useMemo(() => {
-    const uniq = (arr: any[], key: string) =>
-      Array.from(new Set(arr.map((i) => i[key]).filter(Boolean))).map((v) => ({
-        label: String(v),
-        value: v,
-      }));
-    return {
-      ids: uniq(data, "id"),
-      tickets: uniq(
-        data.flatMap((d) => d.ticketIds.map((t) => ({ ticket: t }))),
-        "ticket",
-      ).map((o) => ({ label: o.label, value: Number(o.label) })),
-      units: units.map((u) => ({ label: u.name, value: u.id })),
-      projects: uniq(data, "projectNames"),
-      types: uniq(data, "defectTypeName"),
-      statuses: uniq(data, "defectStatusName"),
-      fixBy: uniq(data, "fixByName"),
+    const uniq = (entries: [number | null, string | null][]) => {
+      const map = new Map<number, string>();
+      entries.forEach(([id, name]) => {
+        if (id != null && name) map.set(id, name);
+      });
+      return Array.from(map.entries()).map(([value, label]) => ({ value, label }));
     };
-  }, [data, units]);
+    return {
+      ids: Array.from(new Set(data.map((d) => d.id))).map((id) => ({
+        label: String(id),
+        value: id,
+      })),
+      tickets: Array.from(
+        new Set(data.flatMap((d) => d.ticketIds))
+      ).map((id) => ({ label: String(id), value: id })),
+      units: units.map((u) => ({ label: u.name, value: u.id })),
+      projects: projects.map((p) => ({ label: p.name, value: p.id })),
+      types: uniq(data.map((d) => [d.defect_type_id, d.defectTypeName])),
+      statuses: uniq(data.map((d) => [d.defect_status_id, d.defectStatusName])),
+      fixBy: Array.from(new Set(data.map((d) => d.fixByName).filter(Boolean))).map(
+        (name) => ({ label: String(name), value: String(name) })
+      ),
+    };
+  }, [data, units, projects]);
 
   const [filters, setFilters] = useState<DefectFilters>({});
   const [viewId, setViewId] = useState<number | null>(null);

--- a/src/widgets/DefectsFilters.tsx
+++ b/src/widgets/DefectsFilters.tsx
@@ -9,9 +9,9 @@ interface Options {
   ids: { label: string; value: number }[];
   tickets: { label: string; value: number }[];
   units: { label: string; value: number }[];
-  projects: { label: string; value: string }[];
-  types: { label: string; value: string }[];
-  statuses: { label: string; value: string }[];
+  projects: { label: string; value: number }[];
+  types: { label: string; value: number }[];
+  statuses: { label: string; value: number }[];
   fixBy: { label: string; value: string }[];
 }
 

--- a/src/widgets/TicketsTable.tsx
+++ b/src/widgets/TicketsTable.tsx
@@ -318,6 +318,7 @@ export default function TicketsTable({
   const rowClassName = (record: any) => {
     const classes = [record.parentId ? 'child-ticket-row' : 'main-ticket-row'];
     if (record.allDefectsFixed) classes.push('ticket-fixed-row');
+    if (record.isClosed) classes.push('ticket-closed-row');
     return classes.join(' ');
   };
 


### PR DESCRIPTION
## Summary
- highlight closed tickets immediately when defects fixed
- gray out closed tickets
- fix project and status filter options in defects
- update invalidation logic when fixing defects or closing tickets

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ed0386b3c832e9f700b2b292860b8