### PR TITLE
Add editable defects table in ticket view

### DIFF
--- a/src/features/ticket/TicketFormAntdEdit.tsx
+++ b/src/features/ticket/TicketFormAntdEdit.tsx
@@ -28,6 +28,7 @@ import { useUnsavedChangesWarning } from '@/shared/hooks/useUnsavedChangesWarnin
 import { downloadZip } from '@/shared/utils/downloadZip';
 import { signedUrl } from '@/entities/ticket';
 import { useChangedFields } from '@/shared/hooks/useChangedFields';
+import TicketDefectsTable from '@/widgets/TicketDefectsTable';
 
 export interface TicketFormAntdEditProps {
   ticketId?: string;
@@ -374,6 +375,11 @@ export default function TicketFormAntdEdit({
       >
         <Input.TextArea rows={2} />
       </Form.Item>
+      {isEdit && ticket?.defectIds?.length ? (
+        <div style={{ marginBottom: 16 }}>
+          <TicketDefectsTable defectIds={ticket.defectIds} />
+        </div>
+      ) : null}
       <Form.Item label="Файлы" style={attachmentsChanged ? { background: '#fffbe6', padding: 4, borderRadius: 2 } : {}}>
         <FileDropZone onFiles={handleFiles} />
         <Button

--- a/src/shared/types/defectWithNames.ts
+++ b/src/shared/types/defectWithNames.ts
@@ -1,0 +1,13 @@
+export interface DefectWithNames {
+  id: number;
+  description: string;
+  defect_type_id: number | null;
+  defect_status_id: number | null;
+  brigade_id: number | null;
+  contractor_id: number | null;
+  received_at: string | null;
+  fixed_at: string | null;
+  is_fixed: boolean;
+  defectTypeName: string | null;
+  defectStatusName: string | null;
+}

--- a/src/widgets/TicketDefectsTable.tsx
+++ b/src/widgets/TicketDefectsTable.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import { Table, Tag, Button, Tooltip, Space, Popconfirm, message } from 'antd';
+import { EyeOutlined, CheckOutlined, DeleteOutlined } from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import { useDefectsWithNames, useDeleteDefect } from '@/entities/defect';
+import DefectStatusSelect from '@/features/defect/DefectStatusSelect';
+import DefectViewModal from '@/features/defect/DefectViewModal';
+import DefectFixModal from '@/features/defect/DefectFixModal';
+import type { DefectWithNames } from '@/shared/types/defectWithNames';
+
+interface Props {
+  defectIds: number[];
+}
+
+/** Таблица дефектов конкретного замечания */
+export default function TicketDefectsTable({ defectIds }: Props) {
+  const { data: defects = [], isLoading } = useDefectsWithNames(defectIds);
+  const { mutateAsync: removeDefect, isPending } = useDeleteDefect();
+  const [viewId, setViewId] = React.useState<number | null>(null);
+  const [fixId, setFixId] = React.useState<number | null>(null);
+
+  const columns: ColumnsType<DefectWithNames> = [
+    { title: 'ID', dataIndex: 'id', width: 60 },
+    { title: 'Описание', dataIndex: 'description', ellipsis: true },
+    { title: 'Тип', dataIndex: 'defectTypeName', width: 140 },
+    {
+      title: 'Статус',
+      dataIndex: 'defect_status_id',
+      width: 160,
+      render: (_: unknown, row) => (
+        <DefectStatusSelect
+          defectId={row.id}
+          statusId={row.defect_status_id}
+          statusName={row.defectStatusName ?? undefined}
+        />
+      ),
+    },
+    {
+      title: 'Устранён',
+      dataIndex: 'is_fixed',
+      width: 100,
+      render: (v: boolean) =>
+        v ? <Tag color="green">Да</Tag> : <Tag color="default">Нет</Tag>,
+    },
+    {
+      title: 'Дата получения',
+      dataIndex: 'received_at',
+      width: 120,
+      render: (v: string | null) => (v ? dayjs(v).format('DD.MM.YYYY') : '—'),
+    },
+    {
+      title: 'Дата устранения',
+      dataIndex: 'fixed_at',
+      width: 120,
+      render: (v: string | null) => (v ? dayjs(v).format('DD.MM.YYYY') : '—'),
+    },
+    {
+      title: 'Действия',
+      key: 'actions',
+      width: 100,
+      render: (_: unknown, row) => (
+        <Space size="middle">
+          <Tooltip title="Просмотр">
+            <Button size="small" type="text" icon={<EyeOutlined />} onClick={() => setViewId(row.id)} />
+          </Tooltip>
+          <Tooltip title="Устранён">
+            <Button
+              size="small"
+              type="text"
+              icon={<CheckOutlined style={{ color: '#52c41a', fontSize: 16 }} />}
+              onClick={() => setFixId(row.id)}
+            />
+          </Tooltip>
+          <Popconfirm
+            title="Удалить дефект?"
+            okText="Да"
+            cancelText="Нет"
+            onConfirm={async () => {
+              await removeDefect(row.id);
+              message.success('Удалено');
+            }}
+            disabled={isPending}
+          >
+            <Button size="small" type="text" danger icon={<DeleteOutlined />} loading={isPending} />
+          </Popconfirm>
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <Table
+        rowKey="id"
+        size="small"
+        pagination={false}
+        columns={columns}
+        dataSource={defects}
+        loading={isLoading}
+      />
+      <DefectViewModal open={viewId !== null} defectId={viewId} onClose={() => setViewId(null)} />
+      <DefectFixModal open={fixId !== null} defectId={fixId} onClose={() => setFixId(null)} />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add `useDefectsWithNames` hook for fetching defect details
- create `TicketDefectsTable` widget with edit/delete actions
- display related defects in `TicketFormAntdEdit`
- define `DefectWithNames` shared type

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ed10b1b8c832eb9b485a2ed56038b