### PR TITLE
Move fixed column after ticket id

### DIFF
--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -162,6 +162,22 @@ export default function DefectsPage() {
           a.ticketIds.join(",").localeCompare(b.ticketIds.join(",")),
         render: (v: number[]) => v.join(", "),
       },
+      fixed: {
+        title: "Устранён",
+        dataIndex: "is_fixed",
+        sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
+          Number(a.is_fixed) - Number(b.is_fixed),
+        render: (v: boolean) =>
+          v ? (
+            <Tag icon={<CheckCircleTwoTone twoToneColor="#52c41a" />} color="success">
+              Да
+            </Tag>
+          ) : (
+            <Tag icon={<CloseCircleTwoTone twoToneColor="#eb2f96" />} color="default">
+              Нет
+            </Tag>
+          ),
+      },
       days: {
         title: (
           <span>
@@ -224,28 +240,6 @@ export default function DefectsPage() {
         dataIndex: "fixByName",
         sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
           (a.fixByName || "").localeCompare(b.fixByName || ""),
-      },
-      fixed: {
-        title: "Устранён",
-        dataIndex: "is_fixed",
-        sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
-          Number(a.is_fixed) - Number(b.is_fixed),
-        render: (v: boolean) =>
-          v ? (
-            <Tag
-              icon={<CheckCircleTwoTone twoToneColor="#52c41a" />}
-              color="success"
-            >
-              Да
-            </Tag>
-          ) : (
-            <Tag
-              icon={<CloseCircleTwoTone twoToneColor="#eb2f96" />}
-              color="default"
-            >
-              Нет
-            </Tag>
-          ),
       },
       received: {
         title: "Дата получения",

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -61,6 +61,21 @@ export default function DefectsTable({
       render: (v: number[]) => v.join(", "),
     },
     {
+      title: "Устранён",
+      dataIndex: "is_fixed",
+      sorter: (a, b) => Number(a.is_fixed) - Number(b.is_fixed),
+      render: (v: boolean) =>
+        v ? (
+          <Tag icon={<CheckCircleTwoTone twoToneColor="#52c41a" />} color="success">
+            Да
+          </Tag>
+        ) : (
+          <Tag icon={<CloseCircleTwoTone twoToneColor="#eb2f96" />} color="default">
+            Нет
+          </Tag>
+        ),
+    },
+    {
       title: (
         <span>
           Прошло дней
@@ -118,27 +133,6 @@ export default function DefectsTable({
       title: "Кем устраняется",
       dataIndex: "fixByName",
       sorter: (a, b) => (a.fixByName || "").localeCompare(b.fixByName || ""),
-    },
-    {
-      title: "Устранён",
-      dataIndex: "is_fixed",
-      sorter: (a, b) => Number(a.is_fixed) - Number(b.is_fixed),
-      render: (v: boolean) =>
-        v ? (
-          <Tag
-            icon={<CheckCircleTwoTone twoToneColor="#52c41a" />}
-            color="success"
-          >
-            Да
-          </Tag>
-        ) : (
-          <Tag
-            icon={<CloseCircleTwoTone twoToneColor="#eb2f96" />}
-            color="default"
-          >
-            Нет
-          </Tag>
-        ),
     },
     {
       title: "Дата получения",


### PR DESCRIPTION
## Summary
- move 'Устранён' column after 'ID замечание' in default defects table
- keep same order for `DefectsTable` widget

## Testing
- `npm run lint` *(fails: many parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ed22da000832e9dfdb30c42d562fc