### PR TITLE
Add inline defect fix toggle

### DIFF
--- a/src/entities/defect.ts
+++ b/src/entities/defect.ts
@@ -174,6 +174,26 @@ export function useUpdateDefectStatus() {
   });
 }
 
+/** Обновить признак устранения дефекта */
+export function useUpdateDefectFixed() {
+  const qc = useQueryClient();
+  const notify = useNotify();
+  return useMutation<{ id: number; is_fixed: boolean }, Error, { id: number; isFixed: boolean }>({
+    mutationFn: async ({ id, isFixed }) => {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .update({ is_fixed: isFixed })
+        .eq('id', id)
+        .select('id, is_fixed')
+        .single();
+      if (error) throw error;
+      return data as { id: number; is_fixed: boolean };
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: [TABLE] }),
+    onError: (e) => notify.error(`Ошибка обновления: ${e.message}`),
+  });
+}
+
 /** Обновить данные устранения дефекта */
 export function useFixDefect() {
   const qc = useQueryClient();

--- a/src/features/defect/DefectFixedSelect.tsx
+++ b/src/features/defect/DefectFixedSelect.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Select, Tag } from 'antd';
+import { useUpdateDefectFixed } from '@/entities/defect';
+
+interface Props {
+  defectId: number;
+  isFixed: boolean;
+}
+
+/**
+ * Инлайн‑редактор признака устранения дефекта.
+ * Отображает текущее значение как тег. По клику — выпадающий список.
+ */
+export default function DefectFixedSelect({ defectId, isFixed }: Props) {
+  const update = useUpdateDefectFixed();
+  const [editing, setEditing] = React.useState(false);
+
+  const handleChange = (value: 'yes' | 'no') => {
+    update.mutate({ id: defectId, isFixed: value === 'yes' });
+    setEditing(false);
+  };
+
+  if (!editing) {
+    return (
+      <Tag
+        color={isFixed ? 'success' : 'default'}
+        onClick={() => setEditing(true)}
+        style={{ cursor: 'pointer' }}
+      >
+        {isFixed ? 'Да' : 'Нет'}
+      </Tag>
+    );
+  }
+
+  return (
+    <Select
+      size="small"
+      autoFocus
+      open
+      defaultValue={isFixed ? 'yes' : 'no'}
+      onBlur={() => setEditing(false)}
+      onChange={handleChange}
+      loading={update.isPending}
+      options={[
+        { label: 'Да', value: 'yes' },
+        { label: 'Нет', value: 'no' },
+      ]}
+      style={{ width: '100%' }}
+    />
+  );
+}

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -14,10 +14,8 @@ import {
   EyeOutlined,
   DeleteOutlined,
   CheckOutlined,
-  CheckCircleTwoTone,
-  CloseCircleTwoTone,
 } from "@ant-design/icons";
-import { Tag } from "antd";
+
 import ruRU from "antd/locale/ru_RU";
 import { useDefects, useDeleteDefect } from "@/entities/defect";
 import { useTicketsSimple } from "@/entities/ticket";
@@ -31,6 +29,7 @@ import TableColumnsDrawer from "@/widgets/TableColumnsDrawer";
 import type { TableColumnSetting } from "@/shared/types/tableColumnSetting";
 import DefectViewModal from "@/features/defect/DefectViewModal";
 import DefectStatusSelect from "@/features/defect/DefectStatusSelect";
+import DefectFixedSelect from "@/features/defect/DefectFixedSelect";
 import ExportDefectsButton from "@/features/defect/ExportDefectsButton";
 import DefectFixModal from "@/features/defect/DefectFixModal";
 import { filterDefects } from "@/shared/utils/defectFilter";
@@ -173,16 +172,9 @@ export default function DefectsPage() {
         dataIndex: "is_fixed",
         sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
           Number(a.is_fixed) - Number(b.is_fixed),
-        render: (v: boolean) =>
-          v ? (
-            <Tag icon={<CheckCircleTwoTone twoToneColor="#52c41a" />} color="success">
-              Да
-            </Tag>
-          ) : (
-            <Tag icon={<CloseCircleTwoTone twoToneColor="#eb2f96" />} color="default">
-              Нет
-            </Tag>
-          ),
+        render: (_: boolean, row: DefectWithInfo) => (
+          <DefectFixedSelect defectId={row.id} isFixed={row.is_fixed} />
+        ),
       },
       days: {
         title: (

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -8,17 +8,12 @@ import {
   Popconfirm,
   message,
   Space,
-  Tag,
 } from "antd";
-import {
-  EyeOutlined,
-  DeleteOutlined,
-  CheckCircleTwoTone,
-  CloseCircleTwoTone,
-} from "@ant-design/icons";
+import { EyeOutlined, DeleteOutlined } from "@ant-design/icons";
 import type { ColumnsType } from "antd/es/table";
 import { useDeleteDefect } from "@/entities/defect";
 import DefectStatusSelect from "@/features/defect/DefectStatusSelect";
+import DefectFixedSelect from "@/features/defect/DefectFixedSelect";
 import type { DefectWithInfo } from "@/shared/types/defect";
 import type { DefectFilters } from "@/shared/types/defectFilters";
 import { filterDefects } from "@/shared/utils/defectFilter";
@@ -64,16 +59,9 @@ export default function DefectsTable({
       title: "Устранён",
       dataIndex: "is_fixed",
       sorter: (a, b) => Number(a.is_fixed) - Number(b.is_fixed),
-      render: (v: boolean) =>
-        v ? (
-          <Tag icon={<CheckCircleTwoTone twoToneColor="#52c41a" />} color="success">
-            Да
-          </Tag>
-        ) : (
-          <Tag icon={<CloseCircleTwoTone twoToneColor="#eb2f96" />} color="default">
-            Нет
-          </Tag>
-        ),
+      render: (_: boolean, row) => (
+        <DefectFixedSelect defectId={row.id} isFixed={row.is_fixed} />
+      ),
     },
     {
       title: (

--- a/src/widgets/TicketDefectsTable.tsx
+++ b/src/widgets/TicketDefectsTable.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import dayjs from 'dayjs';
-import { Table, Tag, Button, Tooltip, Space, Popconfirm, message } from 'antd';
+import { Table, Button, Tooltip, Space, Popconfirm, message } from 'antd';
 import { EyeOutlined, CheckOutlined, DeleteOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import { useDefectsWithNames, useDeleteDefect } from '@/entities/defect';
 import DefectStatusSelect from '@/features/defect/DefectStatusSelect';
+import DefectFixedSelect from '@/features/defect/DefectFixedSelect';
 import DefectViewModal from '@/features/defect/DefectViewModal';
 import DefectFixModal from '@/features/defect/DefectFixModal';
 import type { DefectWithNames } from '@/shared/types/defectWithNames';
@@ -40,8 +41,9 @@ export default function TicketDefectsTable({ defectIds }: Props) {
       title: 'Устранён',
       dataIndex: 'is_fixed',
       width: 100,
-      render: (v: boolean) =>
-        v ? <Tag color="green">Да</Tag> : <Tag color="default">Нет</Tag>,
+      render: (_: boolean, row) => (
+        <DefectFixedSelect defectId={row.id} isFixed={row.is_fixed} />
+      ),
     },
     {
       title: 'Дата получения',


### PR DESCRIPTION
## Summary
- allow toggling `is_fixed` for defects directly in tables
- support updating `is_fixed` via `useUpdateDefectFixed`
- show dropdown editor in defects tables

## Testing
- `npm run lint` *(fails: parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_684edc1cc0ec832eb7d37b751abcdbd9