### PR TITLE
Add color to defect and court case statuses

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -378,6 +378,13 @@
     "column_default": null
   },
   {
+    "table_name": "defect_statuses",
+    "column_name": "color",
+    "data_type": "character varying",
+    "is_nullable": "YES",
+    "column_default": null
+  },
+  {
     "table_name": "defect_types",
     "column_name": "id",
     "data_type": "integer",
@@ -630,17 +637,24 @@
     "column_default": null
   },
   {
-    "table_name": "litigation_stages",
+    "table_name": "court_cases_statuses",
     "column_name": "id",
     "data_type": "integer",
     "is_nullable": "NO",
-    "column_default": "nextval('litigation_stages_id_seq'::regclass)"
+    "column_default": "nextval('court_cases_statuses_id_seq'::regclass)"
   },
   {
-    "table_name": "litigation_stages",
+    "table_name": "court_cases_statuses",
     "column_name": "name",
     "data_type": "text",
     "is_nullable": "NO",
+    "column_default": null
+  },
+  {
+    "table_name": "court_cases_statuses",
+    "column_name": "color",
+    "data_type": "character varying",
+    "is_nullable": "YES",
     "column_default": null
   },
   {

--- a/src/entities/courtCaseStatus.ts
+++ b/src/entities/courtCaseStatus.ts
@@ -1,4 +1,4 @@
-// src/entities/litigationStage.js
+// src/entities/courtCaseStatus.ts
 // -----------------------------------------------------------------------------
 // Справочник стадий судебного дела (глобальный, без project_id)
 // -----------------------------------------------------------------------------
@@ -8,20 +8,20 @@ import {
     useMutation,
     useQueryClient,
 } from '@tanstack/react-query';
-import type { LitigationStage } from '@/shared/types/litigationStage';
+import type { CourtCaseStatus } from '@/shared/types/courtCaseStatus';
 
-const TABLE = 'litigation_stages';
-const KEY   = [TABLE];
+const TABLE = 'court_cases_statuses';
+const KEY = [TABLE];
 
 /* ----------------------- READ ----------------------- */
 /** @returns {import('@tanstack/react-query').UseQueryResult<Array<{id:number,name:string}>>} */
-export const useLitigationStages = () =>
-    useQuery<LitigationStage[]>({
+export const useCourtCaseStatuses = () =>
+    useQuery<CourtCaseStatus[]>({
         queryKey: KEY,
         queryFn : async () => {
             const { data, error } = await supabase
                 .from(TABLE)
-                .select('*')
+                .select('id, name, color')
                 .order('id');
             if (error) throw error;
             return data ?? [];
@@ -34,38 +34,38 @@ const invalidate = (qc: ReturnType<typeof useQueryClient>) =>
     qc.invalidateQueries({ queryKey: KEY });
 
 /** Добавить стадию */
-export const useAddLitigationStage = () => {
+export const useAddCourtCaseStatus = () => {
     const qc = useQueryClient();
-    return useMutation<LitigationStage, Error, { name: string }>({
-        mutationFn: async ({ name }): Promise<LitigationStage> => {
+    return useMutation<CourtCaseStatus, Error, { name: string; color: string }>({
+        mutationFn: async ({ name, color }): Promise<CourtCaseStatus> => {
             if (!name?.trim()) throw new Error('Название стадии обязательно');
             const { data, error } = await supabase
                 .from(TABLE)
-                .insert({ name: name.trim() })
-                .select('*')
+                .insert({ name: name.trim(), color })
+                .select('id, name, color')
                 .single();
             if (error) throw error;
-            return data;
+            return data as CourtCaseStatus;
         },
         onSuccess: () => invalidate(qc),
     });
 };
 
 /** Обновить стадию */
-export const useUpdateLitigationStage = () => {
+export const useUpdateCourtCaseStatus = () => {
     const qc = useQueryClient();
-    return useMutation<LitigationStage, Error, { id: number; updates: Partial<Omit<LitigationStage, 'id'>> }>({
-        mutationFn: async ({ id, updates }): Promise<LitigationStage> => {
+    return useMutation<CourtCaseStatus, Error, { id: number; updates: Partial<Omit<CourtCaseStatus, 'id'>> }>({
+        mutationFn: async ({ id, updates }): Promise<CourtCaseStatus> => {
             const { error } = await supabase.from(TABLE).update(updates).eq('id', id);
             if (error) throw error;
-            return { id, ...(updates as Partial<LitigationStage>) } as LitigationStage;
+            return { id, ...(updates as Partial<CourtCaseStatus>) } as CourtCaseStatus;
         },
         onSuccess: () => invalidate(qc),
     });
 };
 
 /** Удалить стадию */
-export const useDeleteLitigationStage = () => {
+export const useDeleteCourtCaseStatus = () => {
     const qc = useQueryClient();
     return useMutation<number, Error, number>({
         mutationFn: async (id: number): Promise<number> => {

--- a/src/entities/defect.ts
+++ b/src/entities/defect.ts
@@ -28,7 +28,7 @@ export function useDefects() {
         .from(TABLE)
         .select(
           'id, description, defect_type_id, defect_status_id, brigade_id, contractor_id, received_at, fixed_at, fixed_by, attachment_ids, created_at,' +
-          ' defect_type:defect_types(id,name), defect_status:defect_statuses(id,name), fixed_by_user:profiles(id,name)'
+          ' defect_type:defect_types(id,name), defect_status:defect_statuses(id,name,color), fixed_by_user:profiles(id,name)'
         )
         .order('id');
       if (error) throw error;
@@ -52,7 +52,7 @@ export function useDefect(id?: number) {
         .from(TABLE)
         .select(
           'id, description, defect_type_id, defect_status_id, brigade_id, contractor_id, received_at, fixed_at, fixed_by, attachment_ids, created_at,' +
-          ' defect_type:defect_types(id,name), defect_status:defect_statuses(id,name), fixed_by_user:profiles(id,name)'
+          ' defect_type:defect_types(id,name), defect_status:defect_statuses(id,name,color), fixed_by_user:profiles(id,name)'
         )
         .eq('id', id as number)
         .single();
@@ -102,7 +102,7 @@ export function useDefectsWithNames(ids?: number[]) {
       const { data, error } = await supabase
         .from(TABLE)
         .select(
-          'id, description, defect_type_id, defect_status_id, brigade_id, contractor_id, received_at, fixed_at, fixed_by, defect_type:defect_types(id,name), defect_status:defect_statuses(id,name), fixed_by_user:profiles(id,name)'
+          'id, description, defect_type_id, defect_status_id, brigade_id, contractor_id, received_at, fixed_at, fixed_by, defect_type:defect_types(id,name), defect_status:defect_statuses(id,name,color), fixed_by_user:profiles(id,name)'
         )
         .in('id', ids as number[]);
       if (error) throw error;
@@ -118,6 +118,7 @@ export function useDefectsWithNames(ids?: number[]) {
         fixed_by: d.fixed_by,
         defectTypeName: d.defect_type?.name ?? null,
         defectStatusName: d.defect_status?.name ?? null,
+        defectStatusColor: d.defect_status?.color ?? null,
         fixedByUserName: d.fixed_by_user?.name ?? null,
       })) as DefectWithNames[];
     },

--- a/src/entities/defectStatus.ts
+++ b/src/entities/defectStatus.ts
@@ -8,7 +8,10 @@ export const useDefectStatuses = () =>
   useQuery<DefectStatus[]>({
     queryKey: [TABLE],
     queryFn: async () => {
-      const { data, error } = await supabase.from(TABLE).select('*').order('id');
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select('id, name, color')
+        .order('id');
       if (error) throw error;
       return (data ?? []) as unknown as DefectStatus[];
     },
@@ -22,7 +25,7 @@ export const useAddDefectStatus = () => {
       const { data, error } = await supabase
         .from(TABLE)
         .insert(payload)
-        .select('*')
+        .select('id, name, color')
         .single();
       if (error) throw error;
       return data as unknown as DefectStatus;
@@ -39,7 +42,7 @@ export const useUpdateDefectStatus = () => {
         .from(TABLE)
         .update(updates)
         .eq('id', id)
-        .select('*')
+        .select('id, name, color')
         .single();
       if (error) throw error;
       return data as unknown as DefectStatus;

--- a/src/features/courtCase/AddCourtCaseForm.tsx
+++ b/src/features/courtCase/AddCourtCaseForm.tsx
@@ -15,7 +15,7 @@ import dayjs, { Dayjs } from 'dayjs';
 import { useProjects } from '@/entities/project';
 import { useUnitsByProject } from '@/entities/unit';
 import { useUsers } from '@/entities/user';
-import { useLitigationStages } from '@/entities/litigationStage';
+import { useCourtCaseStatuses } from '@/entities/courtCaseStatus';
 import { useAddCourtCase } from '@/entities/courtCase';
 import { useAuthStore } from '@/shared/store/authStore';
 import { useNotify } from '@/shared/hooks/useNotify';
@@ -64,7 +64,7 @@ export default function AddCourtCaseForm({
   const { data: projects = [] } = useProjects();
   const { data: units = [] } = useUnitsByProject(projectId);
   const { data: users = [] } = useUsers();
-  const { data: stages = [] } = useLitigationStages();
+  const { data: stages = [] } = useCourtCaseStatuses();
 
   useEffect(() => {
     setValue('unit_ids', initialUnitId != null ? [initialUnitId] : []);

--- a/src/features/courtCase/AddCourtCaseFormAntd.tsx
+++ b/src/features/courtCase/AddCourtCaseFormAntd.tsx
@@ -20,7 +20,7 @@ import {
   useDeleteContractor,
 } from '@/entities/contractor';
 import { useUsers } from '@/entities/user';
-import { useLitigationStages } from '@/entities/litigationStage';
+import { useCourtCaseStatuses } from '@/entities/courtCaseStatus';
 import { usePersons, useDeletePerson } from '@/entities/person';
 import { useAddCourtCase, useUpdateCourtCase } from '@/entities/courtCase';
 import { useAttachmentTypes } from '@/entities/attachmentType';
@@ -95,7 +95,7 @@ export default function AddCourtCaseFormAntd({
   const { data: units = [], isPending: unitsLoading } = useUnitsByProject(projectId);
   const { data: contractors = [], isPending: contractorsLoading } = useContractors();
   const { data: users = [], isPending: usersLoading } = useUsers();
-  const { data: stages = [], isPending: stagesLoading } = useLitigationStages();
+  const { data: stages = [], isPending: stagesLoading } = useCourtCaseStatuses();
   const { data: personsList = [] } = usePersons();
   const { data: attachmentTypes = [] } = useAttachmentTypes();
   const addCaseMutation = useAddCourtCase();

--- a/src/features/courtCase/CourtCaseFormAntdEdit.tsx
+++ b/src/features/courtCase/CourtCaseFormAntdEdit.tsx
@@ -5,7 +5,7 @@ import { useProjects } from '@/entities/project';
 import { useUnitsByProject } from '@/entities/unit';
 import { useContractors } from '@/entities/contractor';
 import { useUsers } from '@/entities/user';
-import { useLitigationStages } from '@/entities/litigationStage';
+import { useCourtCaseStatuses } from '@/entities/courtCaseStatus';
 import { usePersons } from '@/entities/person';
 import { useAttachmentTypes } from '@/entities/attachmentType';
 import { useCourtCase, useUpdateCourtCaseFull } from '@/entities/courtCase';
@@ -37,7 +37,7 @@ export default function CourtCaseFormAntdEdit({
   const { data: units = [] } = useUnitsByProject(projectId);
   const { data: contractors = [] } = useContractors();
   const { data: users = [] } = useUsers();
-  const { data: stages = [] } = useLitigationStages();
+  const { data: stages = [] } = useCourtCaseStatuses();
   const { data: personsList = [] } = usePersons();
   const { data: attachmentTypes = [] } = useAttachmentTypes();
   const update = useUpdateCourtCaseFull();

--- a/src/features/courtCase/CourtCaseStatusSelect.tsx
+++ b/src/features/courtCase/CourtCaseStatusSelect.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Select } from 'antd';
-import { useLitigationStages } from '@/entities/litigationStage';
+import { Select, Tag } from 'antd';
+import { useCourtCaseStatuses } from '@/entities/courtCaseStatus';
 import { useUpdateCourtCase } from '@/entities/courtCase';
 
 interface Props {
@@ -12,7 +12,7 @@ interface Props {
  * Выпадающий список для смены статуса судебного дела непосредственно из таблицы.
  */
 export default function CourtCaseStatusSelect({ caseId, status }: Props) {
-  const { data: stages = [] } = useLitigationStages();
+  const { data: stages = [] } = useCourtCaseStatuses();
   const update = useUpdateCourtCase();
 
   const handleChange = (value: number) => {
@@ -25,7 +25,11 @@ export default function CourtCaseStatusSelect({ caseId, status }: Props) {
       value={status}
       onChange={handleChange}
       loading={update.isPending}
-      options={stages.map((s) => ({ label: s.name, value: s.id }))}
+      optionLabelProp="label"
+      options={stages.map((s) => ({
+        label: <Tag color={s.color ?? undefined}>{s.name}</Tag>,
+        value: s.id,
+      }))}
       style={{ width: '100%' }}
     />
   );

--- a/src/features/courtCaseStatus/CourtCaseStatusForm.tsx
+++ b/src/features/courtCaseStatus/CourtCaseStatusForm.tsx
@@ -1,4 +1,4 @@
-// src/features/litigationStage/LitigationStageForm.js
+// src/features/courtCaseStatus/CourtCaseStatusForm.tsx
 // -----------------------------------------------------------------------------
 // Модальная форма добавления / редактирования стадии судебного дела
 // -----------------------------------------------------------------------------
@@ -6,19 +6,20 @@
 import React, { useState } from 'react';
 import { Stack, TextField, Button, DialogActions } from '@mui/material';
 
-interface LitigationStageFormProps {
-    initialData?: { id?: number; name?: string };
-    onSubmit: (values: { name: string }) => void;
+interface CourtCaseStatusFormProps {
+    initialData?: { id?: number; name?: string; color?: string | null };
+    onSubmit: (values: { name: string; color: string }) => void;
     onCancel: () => void;
 }
 
-export default function LitigationStageForm({ initialData, onSubmit, onCancel }: LitigationStageFormProps) {
+export default function CourtCaseStatusForm({ initialData, onSubmit, onCancel }: CourtCaseStatusFormProps) {
     const [name, setName] = useState(initialData?.name ?? '');
+    const [color, setColor] = useState(initialData?.color ?? '#1976d2');
 
     const handleSave = (e) => {
         e.preventDefault();
         if (!name.trim()) return;
-        onSubmit({ name: name.trim() });
+        onSubmit({ name: name.trim(), color });
     };
 
     return (
@@ -32,6 +33,15 @@ export default function LitigationStageForm({ initialData, onSubmit, onCancel }:
                     required
                     size="small"
                     fullWidth
+                />
+                <TextField
+                    label="Цвет"
+                    type="color"
+                    value={color}
+                    onChange={(e) => setColor(e.target.value)}
+                    required
+                    fullWidth
+                    inputProps={{ style: { height: 48, padding: 0 } }}
                 />
                 <DialogActions sx={{ px: 0 }}>
                     <Button onClick={onCancel}>Отмена</Button>

--- a/src/features/defect/DefectStatusSelect.tsx
+++ b/src/features/defect/DefectStatusSelect.tsx
@@ -7,6 +7,7 @@ interface Props {
   defectId: number;
   statusId: number | null;
   statusName?: string | null;
+  statusColor?: string | null;
 }
 
 /** Выпадающий список для смены статуса дефекта в таблице */
@@ -14,20 +15,32 @@ export default function DefectStatusSelect({
   defectId,
   statusId,
   statusName,
+  statusColor,
 }: Props) {
   const { data: statuses = [], isLoading } = useDefectStatuses();
   const update = useUpdateDefectStatus();
   const [editing, setEditing] = React.useState(false);
 
   const options = React.useMemo(
-    () => statuses.map((s) => ({ label: s.name, value: s.id })),
+    () =>
+      statuses.map((s) => ({
+        label: <Tag color={s.color ?? undefined}>{s.name}</Tag>,
+        value: s.id,
+      })),
     [statuses],
   );
 
   const current = React.useMemo(
-    () => statuses.find((s) => s.id === statusId) ||
-      (statusId ? { id: statusId, name: statusName ?? String(statusId) } : null),
-    [statuses, statusId, statusName],
+    () =>
+      statuses.find((s) => s.id === statusId) ||
+      (statusId
+        ? {
+            id: statusId,
+            name: statusName ?? String(statusId),
+            color: statusColor ?? undefined,
+          }
+        : null),
+    [statuses, statusId, statusName, statusColor],
   );
 
   const handleChange = (value: number) => {
@@ -37,7 +50,11 @@ export default function DefectStatusSelect({
 
   if (!editing) {
     return (
-      <Tag onClick={() => setEditing(true)} style={{ cursor: 'pointer' }}>
+      <Tag
+        color={current?.color}
+        onClick={() => setEditing(true)}
+        style={{ cursor: 'pointer' }}
+      >
         {current?.name ?? '—'}
       </Tag>
     );
@@ -52,6 +69,7 @@ export default function DefectStatusSelect({
       onBlur={() => setEditing(false)}
       onChange={handleChange}
       loading={isLoading || update.isPending}
+      optionLabelProp="label"
       options={options}
       style={{ width: '100%' }}
     />

--- a/src/features/defectStatus/DefectStatusForm.tsx
+++ b/src/features/defectStatus/DefectStatusForm.tsx
@@ -3,14 +3,21 @@ import { useForm, Controller } from 'react-hook-form';
 import { Stack, TextField, Button, DialogActions } from '@mui/material';
 
 interface Props {
-  initialData?: { id?: number; name?: string };
-  onSubmit: (values: { name: string }) => void;
+  initialData?: { id?: number; name?: string; color?: string | null };
+  onSubmit: (values: { name: string; color: string }) => void;
   onCancel: () => void;
 }
 
 export default function DefectStatusForm({ initialData, onSubmit, onCancel }: Props) {
-  const { control, handleSubmit, formState: { isSubmitting } } = useForm({
-    defaultValues: { name: initialData?.name ?? '' },
+  const {
+    control,
+    handleSubmit,
+    formState: { isSubmitting },
+  } = useForm({
+    defaultValues: {
+      name: initialData?.name ?? '',
+      color: initialData?.color ?? '#1976d2',
+    },
   });
 
   return (
@@ -29,6 +36,20 @@ export default function DefectStatusForm({ initialData, onSubmit, onCancel }: Pr
               error={!!fieldState.error}
               helperText={fieldState.error?.message}
               autoFocus
+            />
+          )}
+        />
+        <Controller
+          name="color"
+          control={control}
+          rules={{ required: 'Цвет обязателен' }}
+          render={({ field }) => (
+            <TextField
+              {...field}
+              label="Цвет статуса"
+              type="color"
+              fullWidth
+              inputProps={{ style: { height: 48, padding: 0 } }}
             />
           )}
         />

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -12,7 +12,7 @@ import { useProjects } from '@/entities/project';
 import { useUnitsByIds } from '@/entities/unit';
 import { useContractors } from '@/entities/contractor';
 import { useUsers } from '@/entities/user';
-import { useLitigationStages } from '@/entities/litigationStage';
+import { useCourtCaseStatuses } from '@/entities/courtCaseStatus';
 import { usePersons } from '@/entities/person';
 import {
   PlusOutlined,
@@ -91,7 +91,7 @@ export default function CourtCasesPage() {
   const { data: projects = [] } = useProjects();
   const { data: contractors = [] } = useContractors();
   const { data: users = [] } = useUsers();
-  const { data: stages = [] } = useLitigationStages();
+  const { data: stages = [] } = useCourtCaseStatuses();
   const { data: personsList = [] } = usePersons();
 
   const unitIds = React.useMemo(() => Array.from(new Set(cases.flatMap((c) => c.unit_ids).filter(Boolean))), [cases]);

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -104,6 +104,7 @@ export default function DefectsPage() {
           : null,
         defectTypeName: d.defect_type?.name ?? "",
         defectStatusName: d.defect_status?.name ?? "",
+        defectStatusColor: d.defect_status?.color ?? null,
       } as DefectWithInfo;
     });
   }, [defects, tickets, units, projects]);
@@ -219,6 +220,7 @@ export default function DefectsPage() {
             defectId={row.id}
             statusId={row.defect_status_id}
             statusName={row.defectStatusName}
+            statusColor={row.defectStatusColor}
           />
         ),
       },

--- a/src/pages/UnitsPage/AdminPage.tsx
+++ b/src/pages/UnitsPage/AdminPage.tsx
@@ -9,7 +9,7 @@ import DefectTypesAdmin from "../../widgets/DefectTypesAdmin";
 import DefectStatusesAdmin from "../../widgets/DefectStatusesAdmin";
 import DefectDeadlinesAdmin from "../../widgets/DefectDeadlinesAdmin";
 import UsersTable from "../../widgets/UsersTable";
-import LitigationStagesAdmin from "../../widgets/LitigationStagesAdmin";
+import CourtCaseStatusesAdmin from "../../widgets/CourtCaseStatusesAdmin";
 import LetterTypesAdmin from "../../widgets/LetterTypesAdmin";
 import AttachmentTypesAdmin from "../../widgets/AttachmentTypesAdmin";
 import LetterStatusesAdmin from "../../widgets/LetterStatusesAdmin";
@@ -43,7 +43,7 @@ export default function AdminPage() {
           rowsPerPageOptions={[10, 25, 50, 100]}
         />
 
-        <LitigationStagesAdmin
+        <CourtCaseStatusesAdmin
           pageSize={25}
           rowsPerPageOptions={[10, 25, 50, 100]}
         />

--- a/src/shared/types/courtCaseStatus.ts
+++ b/src/shared/types/courtCaseStatus.ts
@@ -1,0 +1,6 @@
+export interface CourtCaseStatus {
+  id: number;
+  name: string;
+  /** Цвет статуса */
+  color: string | null;
+}

--- a/src/shared/types/defect.ts
+++ b/src/shared/types/defect.ts
@@ -38,6 +38,8 @@ export interface DefectWithInfo extends DefectRecord {
   defectTypeName?: string;
   /** Название статуса дефекта */
   defectStatusName?: string;
+  /** Цвет статуса */
+  defectStatusColor?: string | null;
   /** Название исполнителя */
   fixByName?: string;
   /** Пользователь, подтвердивший устранение */

--- a/src/shared/types/defectStatus.ts
+++ b/src/shared/types/defectStatus.ts
@@ -1,4 +1,6 @@
 export interface DefectStatus {
   id: number;
   name: string;
+  /** Цвет метки в HEX формате */
+  color: string | null;
 }

--- a/src/shared/types/defectWithNames.ts
+++ b/src/shared/types/defectWithNames.ts
@@ -10,5 +10,6 @@ export interface DefectWithNames {
   fixed_by: string | null;
   defectTypeName: string | null;
   defectStatusName: string | null;
+  defectStatusColor: string | null;
   fixedByUserName?: string | null;
 }

--- a/src/shared/types/litigationStage.ts
+++ b/src/shared/types/litigationStage.ts
@@ -1,4 +1,0 @@
-export interface LitigationStage {
-  id: number;
-  name: string;
-}

--- a/src/widgets/CourtCaseStatusesAdmin.tsx
+++ b/src/widgets/CourtCaseStatusesAdmin.tsx
@@ -1,4 +1,4 @@
-// src/widgets/LitigationStagesAdmin.tsx
+// src/widgets/CourtCaseStatusesAdmin.tsx
 
 import React, { useState } from 'react';
 import { GridActionsCellItem } from '@mui/x-data-grid';
@@ -6,34 +6,34 @@ import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 
 import {
-    useLitigationStages,
-    useAddLitigationStage,
-    useUpdateLitigationStage,
-    useDeleteLitigationStage,
-} from '@/entities/litigationStage';
+    useCourtCaseStatuses,
+    useAddCourtCaseStatus,
+    useUpdateCourtCaseStatus,
+    useDeleteCourtCaseStatus,
+} from '@/entities/courtCaseStatus';
 
-import LitigationStageForm from '@/features/litigationStage/LitigationStageForm';
+import CourtCaseStatusForm from '@/features/courtCaseStatus/CourtCaseStatusForm';
 import AdminDataGrid from '@/shared/ui/AdminDataGrid';
 import { Dialog, DialogTitle, DialogContent } from '@mui/material';
 import { useNotify } from '@/shared/hooks/useNotify';
 
 // Интерфейс пропсов для поддержки пагинации
-interface LitigationStagesAdminProps {
+interface CourtCaseStatusesAdminProps {
     pageSize?: number;
     rowsPerPageOptions?: number[];
 }
 
-export default function LitigationStagesAdmin({
+export default function CourtCaseStatusesAdmin({
                                                   pageSize = 25,
                                                   rowsPerPageOptions = [10, 25, 50, 100],
-                                              }: LitigationStagesAdminProps) {
+                                              }: CourtCaseStatusesAdminProps) {
     const notify = useNotify();
 
     /* -------- данные -------- */
-    const { data: stages = [], isPending } = useLitigationStages();
-    const add = useAddLitigationStage();
-    const update = useUpdateLitigationStage();
-    const remove = useDeleteLitigationStage();
+    const { data: stages = [], isPending } = useCourtCaseStatuses();
+    const add = useAddCourtCaseStatus();
+    const update = useUpdateCourtCaseStatus();
+    const remove = useDeleteCourtCaseStatus();
 
     const [modal, setModal] = useState<null | { mode: 'add' | 'edit'; data?: any }>(null);
 
@@ -81,7 +81,7 @@ export default function LitigationStagesAdmin({
                         {modal.mode === 'add' ? 'Новая стадия' : 'Редактировать стадию'}
                     </DialogTitle>
                     <DialogContent dividers>
-                        <LitigationStageForm
+                        <CourtCaseStatusForm
                             initialData={modal.mode === 'edit' ? modal.data : undefined}
                             onSubmit={(d) =>
                                 (modal.mode === 'add'

--- a/src/widgets/CourtCasesFilters.tsx
+++ b/src/widgets/CourtCasesFilters.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Form, Select, Input, DatePicker, Switch, Button } from 'antd';
 import { Project } from '@/shared/types/project';
 import { Unit } from '@/shared/types/unit';
-import { LitigationStage } from '@/shared/types/litigationStage';
+import { CourtCaseStatus } from '@/shared/types/courtCaseStatus';
 import { User } from '@/shared/types/user';
 import dayjs from 'dayjs';
 
@@ -26,7 +26,7 @@ export interface CourtCasesFiltersProps {
   onReset: () => void;
   projects: Project[];
   units: Unit[];
-  stages: LitigationStage[];
+  stages: CourtCaseStatus[];
   users: User[];
   idOptions: { value: number; label: string }[];
 }

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -105,6 +105,7 @@ export default function DefectsTable({
           defectId={row.id}
           statusId={row.defect_status_id}
           statusName={row.defectStatusName}
+          statusColor={row.defectStatusColor}
         />
       ),
     },

--- a/src/widgets/TicketDefectsTable.tsx
+++ b/src/widgets/TicketDefectsTable.tsx
@@ -33,6 +33,7 @@ export default function TicketDefectsTable({ defectIds }: Props) {
           defectId={row.id}
           statusId={row.defect_status_id}
           statusName={row.defectStatusName ?? undefined}
+          statusColor={row.defectStatusColor ?? undefined}
         />
       ),
     },


### PR DESCRIPTION
## Summary
- add `color` column for defect and court case statuses in DB schema
- rename litigation stage entities and widgets to court case statuses
- support color in status selects and admin forms
- display colored tags for defect and court case statuses
- update related types and pages

## Testing
- `npm run lint` *(fails: Parsing error due to missing ESLint dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684ef333ba14832e8caec10be236ea97