### PR TITLE
Update court case status tag

### DIFF
--- a/src/features/courtCase/CourtCaseStatusSelect.tsx
+++ b/src/features/courtCase/CourtCaseStatusSelect.tsx
@@ -5,31 +5,69 @@ import { useUpdateCourtCase } from '@/entities/courtCase';
 
 interface Props {
   caseId: number;
-  status: number;
+  /** ID текущего статуса */
+  statusId: number | null;
+  /** Имя статуса до загрузки справочника */
+  statusName?: string | null;
+  /** Цвет статуса до загрузки справочника */
+  statusColor?: string | null;
 }
 
 /**
  * Выпадающий список для смены статуса судебного дела непосредственно из таблицы.
  */
-export default function CourtCaseStatusSelect({ caseId, status }: Props) {
-  const { data: stages = [] } = useCourtCaseStatuses();
+export default function CourtCaseStatusSelect({
+  caseId,
+  statusId,
+  statusName,
+  statusColor,
+}: Props) {
+  const { data: stages = [], isLoading } = useCourtCaseStatuses();
   const update = useUpdateCourtCase();
+  const [editing, setEditing] = React.useState(false);
+
+  const options = React.useMemo(
+    () =>
+      stages.map((s) => ({
+        label: <Tag color={s.color ?? undefined}>{s.name}</Tag>,
+        value: s.id,
+      })),
+    [stages],
+  );
+
+  const current = React.useMemo(
+    () =>
+      stages.find((s) => s.id === statusId) ||
+      (statusId
+        ? { id: statusId, name: statusName ?? String(statusId), color: statusColor ?? undefined }
+        : null),
+    [stages, statusId, statusName, statusColor],
+  );
 
   const handleChange = (value: number) => {
     update.mutate({ id: caseId, updates: { status: value } });
+    setEditing(false);
   };
+
+  if (!editing) {
+    return (
+      <Tag color={current?.color} onClick={() => setEditing(true)} style={{ cursor: 'pointer' }}>
+        {current?.name ?? '—'}
+      </Tag>
+    );
+  }
 
   return (
     <Select
       size="small"
-      value={status}
+      autoFocus
+      open
+      defaultValue={statusId ?? undefined}
+      onBlur={() => setEditing(false)}
       onChange={handleChange}
-      loading={update.isPending}
+      loading={isLoading || update.isPending}
       optionLabelProp="label"
-      options={stages.map((s) => ({
-        label: <Tag color={s.color ?? undefined}>{s.name}</Tag>,
-        value: s.id,
-      }))}
+      options={options}
       style={{ width: '100%' }}
     />
   );

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -183,6 +183,8 @@ export default function CourtCasesPage() {
       c.defendant,
     responsibleLawyer: users.find((u) => u.id === c.responsible_lawyer_id)?.name ?? c.responsibleLawyer,
     daysSinceFixStart: c.fix_start_date ? dayjs(c.fix_end_date ?? dayjs()).diff(dayjs(c.fix_start_date), 'day') : null,
+    statusName: stages.find((s) => s.id === c.status)?.name ?? null,
+    statusColor: stages.find((s) => s.id === c.status)?.color ?? null,
   }));
 
   const idOptions = React.useMemo(
@@ -299,7 +301,14 @@ export default function CourtCasesPage() {
       title: 'Статус',
       dataIndex: 'status',
       sorter: (a, b) => a.status - b.status,
-      render: (_: number, row) => <CourtCaseStatusSelect caseId={row.id} status={row.status} />,
+      render: (_: number, row) => (
+        <CourtCaseStatusSelect
+          caseId={row.id}
+          statusId={row.status}
+          statusName={row.statusName}
+          statusColor={row.statusColor}
+        />
+      ),
     },
     daysSinceFixStart: {
       title: 'Прошло дней с начала устранения',


### PR DESCRIPTION
## Summary
- show court case status as colored tag
- add name and color of current status to page rows

## Testing
- `npm run lint` *(fails: eslint plugins not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f9a0565a8832e90301e8dace71ccd