### PR TITLE
Fix attachment selects width and validation

### DIFF
--- a/src/features/correspondence/AddLetterForm.tsx
+++ b/src/features/correspondence/AddLetterForm.tsx
@@ -11,6 +11,7 @@ import {
   Radio,
   Space,
   Popconfirm,
+  message,
 } from 'antd';
 import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
 import dayjs, { Dayjs } from 'dayjs';
@@ -122,6 +123,10 @@ export default function AddLetterForm({ onSubmit, parentId = null, initialValues
   };
 
   const submit = (values: Omit<AddLetterFormData, 'attachments'>) => {
+    if (files.some((f) => f.type_id == null)) {
+      message.error('Укажите тип файла для всех документов');
+      return;
+    }
     onSubmit({
       ...values,
       date: values.date ?? dayjs(),
@@ -361,7 +366,7 @@ export default function AddLetterForm({ onSubmit, parentId = null, initialValues
               <div key={i} style={{ display: 'flex', alignItems: 'center', marginTop: 4 }}>
                 <span style={{ marginRight: 8 }}>{f.file.name}</span>
                 <Select
-                    style={{ width: 160 }}
+                    style={{ width: 220 }}
                     placeholder="Тип файла"
                     value={f.type_id ?? undefined}
                     onChange={(v) => setType(i, v)}

--- a/src/features/courtCase/AddCourtCaseFormAntd.tsx
+++ b/src/features/courtCase/AddCourtCaseFormAntd.tsx
@@ -135,6 +135,10 @@ export default function AddCourtCaseFormAntd({
   const handleCaseFiles = (files: File[]) => addCaseFiles(files);
 
   const handleAddCase = async (values: any) => {
+    if (caseFiles.some((f) => f.type_id == null)) {
+      notify.error('Укажите тип файла для всех документов');
+      return;
+    }
     try {
       const newCase = await addCaseMutation.mutateAsync({
         project_id: values.project_id,
@@ -371,7 +375,7 @@ export default function AddCourtCaseFormAntd({
                 <Col flex="auto">
                   <span>{f.file.name}</span>
                 </Col>
-                <Col flex="160px">
+                <Col flex="220px">
                   <Select
                     style={{ width: '100%' }}
                     placeholder="Тип файла"

--- a/src/shared/ui/AttachmentEditorTable.tsx
+++ b/src/shared/ui/AttachmentEditorTable.tsx
@@ -125,13 +125,13 @@ export default function AttachmentEditorTable({
     {
       title: 'Тип',
       dataIndex: 'typeId',
-      width: 320,
+      width: 420,
       render: (_: number | null, row) => (
         <Space size={4}>
           {onChangeRemoteType && row.isRemote ? (
             <Select
               size="small"
-              style={{ width: 300 }}
+              style={{ width: 400 }}
               value={row.typeId ?? undefined}
               onChange={(v) => onChangeRemoteType(row.id as string, v ?? null)}
               options={[{ value: undefined, label: 'Тип не указан' }, ...attachmentTypes.map((t) => ({ value: t.id, label: t.name }))]}
@@ -139,7 +139,7 @@ export default function AttachmentEditorTable({
           ) : onChangeNewType && !row.isRemote ? (
             <Select
               size="small"
-              style={{ width: 300 }}
+              style={{ width: 400 }}
               value={row.typeId ?? undefined}
               onChange={(v) => onChangeNewType(Number(row.key.split('-')[1]), v ?? null)}
               options={[{ value: undefined, label: 'Тип не указан' }, ...attachmentTypes.map((t) => ({ value: t.id, label: t.name }))]}
@@ -207,5 +207,15 @@ export default function AttachmentEditorTable({
     },
   ];
 
-  return <Table rowKey="key" size="small" pagination={false} columns={columns} dataSource={data} />;
+  return (
+    <Table
+      rowKey="key"
+      size="small"
+      pagination={false}
+      columns={columns}
+      dataSource={data}
+      showHeader={false}
+      style={{ width: 'fit-content', marginLeft: 0 }}
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- widen file type selects in AddLetterForm and AddCourtCaseFormAntd
- require file type selection before submitting these forms
- enlarge selects in AttachmentEditorTable and hide its header

## Testing
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_684f9f91616c832eafa57d8619fe1926