### PR TITLE
Fix defect list refresh on ticket delete

### DIFF
--- a/src/entities/ticket.js
+++ b/src/entities/ticket.js
@@ -461,6 +461,10 @@ export function useTicket(ticketId) {
 }
 
 // ──────────────────────────── delete ──────────────────────────────
+/**
+ * Удалить замечание вместе с вложениями и связанными дефектами.
+ * После успешного удаления инвалидирует кэш замечаний и дефектов.
+ */
 export function useDeleteTicket() {
   const projectId = useProjectId();
   const qc = useQueryClient();
@@ -519,6 +523,9 @@ export function useDeleteTicket() {
         queryKey: ["ticket", id, projectId],
         exact: true,
       });
+      qc.invalidateQueries({ queryKey: ["defects"] });
+      qc.invalidateQueries({ queryKey: ["defects-by-ids"] });
+      qc.invalidateQueries({ queryKey: ["defects-with-names"] });
       notify.success("Замечание удалено вместе с вложениями");
     },
     onError: (e) => notify.error(`Ошибка удаления замечания: ${e.message}`),


### PR DESCRIPTION
## Summary
- refresh defect queries when deleting a ticket
- document useDeleteTicket behaviour

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684fa0275a30832eb3fde67ab1f4f508