### PR TITLE
Fix view modals hook order

### DIFF
--- a/src/features/correspondence/LetterViewModal.tsx
+++ b/src/features/correspondence/LetterViewModal.tsx
@@ -12,8 +12,8 @@ interface Props {
 
 /** Модальное окно просмотра письма */
 export default function LetterViewModal({ open, letterId, onClose }: Props) {
-  if (!letterId) return null;
-  const { data: letter } = useLetter(letterId);
+  const { data: letter } = useLetter(letterId ?? undefined);
+  if (!open || !letterId) return null;
   const titleText = letter
     ? `Письмо №${letter.number} от ${dayjs(letter.date).format('DD.MM.YYYY')} (${
         letter.type === 'incoming' ? 'входящее' : 'исходящее'

--- a/src/features/ticket/TicketViewModal.tsx
+++ b/src/features/ticket/TicketViewModal.tsx
@@ -11,8 +11,8 @@ interface Props {
 
 /** Модальное окно просмотра замечания */
 export default function TicketViewModal({ open, ticketId, onClose }: Props) {
-  if (!ticketId) return null;
-  const { data: ticket } = useTicket(ticketId);
+  const { data: ticket } = useTicket(ticketId ?? undefined);
+  if (!open || !ticketId) return null;
   const titleText = ticket
     ? `Замечание №${ticket.id}. Создано ${
         ticket.createdAt ? ticket.createdAt.format('DD.MM.YYYY [в] HH:mm') : ''


### PR DESCRIPTION
## Summary
- keep React hook order in view modals

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684fa34eca64832eb14e8d451cad39fd