### PR TITLE
Add role-based permissions system

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -1063,4 +1063,9 @@
     "is_nullable": "YES",
     "column_default": null
   }
+,
+  {"table_name": "role_permissions", "column_name": "role_name", "data_type": "text", "is_nullable": "NO", "column_default": null},
+  {"table_name": "role_permissions", "column_name": "pages", "data_type": "jsonb", "is_nullable": "NO", "column_default": "'[]'::jsonb"},
+  {"table_name": "role_permissions", "column_name": "edit_tables", "data_type": "jsonb", "is_nullable": "NO", "column_default": "'[]'::jsonb"},
+  {"table_name": "role_permissions", "column_name": "delete_tables", "data_type": "jsonb", "is_nullable": "NO", "column_default": "'[]'::jsonb"}
 ]

--- a/src/app/Router.tsx
+++ b/src/app/Router.tsx
@@ -17,6 +17,7 @@ import LoginPage from "@/pages/UnitsPage/LoginPage"; // ← CHANGE
 import RegisterPage from "@/pages/UnitsPage/RegisterPage"; // ← CHANGE
 import AdminPage from "@/pages/UnitsPage/AdminPage";
 import ProjectStructurePage from "@/pages/ProjectStructurePage/ProjectStructurePage";
+import RequirePermission from "@/shared/components/RequirePermission";
 
 /** --------------------------------------------------------------------------
  *  Компонент-сторож
@@ -63,7 +64,9 @@ export default function AppRouter() {
         path="/"
         element={
           <RequireAuth data-oid="_5wblnc">
-            <DashboardPage data-oid="mxrre2o" />
+            <RequirePermission page="dashboard">
+              <DashboardPage data-oid="mxrre2o" />
+            </RequirePermission>
           </RequireAuth>
         }
         data-oid="9:ob6bt"
@@ -73,7 +76,9 @@ export default function AppRouter() {
         path="/tickets"
         element={
           <RequireAuth data-oid="nq-xmuj">
-            <TicketsPage data-oid="i99wikm" />
+            <RequirePermission page="tickets">
+              <TicketsPage data-oid="i99wikm" />
+            </RequirePermission>
           </RequireAuth>
         }
         data-oid="41m4r4h"
@@ -83,7 +88,9 @@ export default function AppRouter() {
         path="/defects"
         element={
           <RequireAuth>
-            <DefectsPage />
+            <RequirePermission page="defects">
+              <DefectsPage />
+            </RequirePermission>
           </RequireAuth>
         }
       />
@@ -92,7 +99,9 @@ export default function AppRouter() {
         path="/court-cases"
         element={
           <RequireAuth>
-            <CourtCasesPage />
+            <RequirePermission page="court-cases">
+              <CourtCasesPage />
+            </RequirePermission>
           </RequireAuth>
         }
       />
@@ -101,7 +110,9 @@ export default function AppRouter() {
         path="/correspondence"
         element={
           <RequireAuth>
-            <CorrespondencePage />
+            <RequirePermission page="correspondence">
+              <CorrespondencePage />
+            </RequirePermission>
           </RequireAuth>
         }
       />
@@ -110,7 +121,9 @@ export default function AppRouter() {
         path="/structure"
         element={
           <RequireAuth data-oid="khk60eg">
-            <ProjectStructurePage data-oid="1zm.al-" />
+            <RequirePermission page="structure">
+              <ProjectStructurePage data-oid="1zm.al-" />
+            </RequirePermission>
           </RequireAuth>
         }
         data-oid="50g:286"
@@ -121,7 +134,9 @@ export default function AppRouter() {
         path="/tickets/:ticketId/edit"
         element={
           <RequireAuth data-oid="jw4mt.4">
-            <TicketFormPage data-oid="r9pp63u" />
+            <RequirePermission page="tickets">
+              <TicketFormPage data-oid="r9pp63u" />
+            </RequirePermission>
           </RequireAuth>
         }
         data-oid="rdc_d7y"
@@ -132,7 +147,9 @@ export default function AppRouter() {
         path="/admin"
         element={
           <RequireAuth data-oid="f0b3w1p">
-            <AdminPage data-oid="rs22ppe" />
+            <RequirePermission page="admin">
+              <AdminPage data-oid="rs22ppe" />
+            </RequirePermission>
           </RequireAuth>
         }
         data-oid="b1_45g_"

--- a/src/entities/rolePermission.ts
+++ b/src/entities/rolePermission.ts
@@ -1,0 +1,54 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/shared/api/supabaseClient';
+import type { RolePermission, RoleName } from '@/shared/types/rolePermission';
+import { DEFAULT_ROLE_PERMISSIONS } from '@/shared/types/rolePermission';
+
+const TABLE = 'role_permissions';
+const FIELDS = 'role_name, pages, edit_tables, delete_tables';
+
+/** Получить настройки ролей */
+export const useRolePermissions = () =>
+  useQuery<RolePermission[]>({
+    queryKey: [TABLE],
+    queryFn: async () => {
+      const { data, error } = await supabase.from(TABLE).select(FIELDS);
+      if (error) throw error;
+      return data ?? [];
+    },
+    staleTime: 10 * 60_000,
+  });
+
+/** Получить настройки конкретной роли */
+export const useRolePermission = (role: RoleName | undefined) =>
+  useQuery<RolePermission>({
+    queryKey: [TABLE, role],
+    queryFn: async () => {
+      if (!role) throw new Error('no role');
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select(FIELDS)
+        .eq('role_name', role)
+        .single();
+      if (error && error.code !== 'PGRST116') throw error;
+      return data ?? DEFAULT_ROLE_PERMISSIONS[role];
+    },
+    enabled: !!role,
+    staleTime: 5 * 60_000,
+  });
+
+/** Обновить настройки роли */
+export const useUpsertRolePermission = () => {
+  const qc = useQueryClient();
+  return useMutation<RolePermission, Error, RolePermission>({
+    mutationFn: async (payload) => {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .upsert(payload, { onConflict: 'role_name' })
+        .select(FIELDS)
+        .single();
+      if (error) throw error;
+      return data as RolePermission;
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: [TABLE] }),
+  });
+};

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -14,6 +14,9 @@ import { useContractors } from '@/entities/contractor';
 import { useUsers } from '@/entities/user';
 import { useCourtCaseStatuses } from '@/entities/courtCaseStatus';
 import { usePersons } from '@/entities/person';
+import { useRolePermission } from '@/entities/rolePermission';
+import { useAuthStore } from '@/shared/store/authStore';
+import type { RoleName } from '@/shared/types/rolePermission';
 import {
   PlusOutlined,
   DeleteOutlined,
@@ -92,6 +95,8 @@ export default function CourtCasesPage() {
   const { data: users = [] } = useUsers();
   const { data: stages = [] } = useCourtCaseStatuses();
   const { data: personsList = [] } = usePersons();
+  const role = useAuthStore((s) => s.profile?.role as RoleName | undefined);
+  const { data: perm } = useRolePermission(role);
 
   const unitIds = React.useMemo(() => Array.from(new Set(cases.flatMap((c) => c.unit_ids).filter(Boolean))), [cases]);
   const { data: caseUnits = [] } = useUnitsByIds(unitIds);
@@ -364,14 +369,16 @@ export default function CourtCasesPage() {
               />
             </Tooltip>
           )}
-          <Popconfirm
-            title="Удалить дело?"
-            okText="Да"
-            cancelText="Нет"
-            onConfirm={() => deleteCaseMutation.mutate(record.id)}
-          >
-            <Button type="text" danger icon={<DeleteOutlined />} />
-          </Popconfirm>
+          {perm?.delete_tables.includes('court_cases') && (
+            <Popconfirm
+              title="Удалить дело?"
+              okText="Да"
+              cancelText="Нет"
+              onConfirm={() => deleteCaseMutation.mutate(record.id)}
+            >
+              <Button type="text" danger icon={<DeleteOutlined />} />
+            </Popconfirm>
+          )}
         </Space>
       ),
     },
@@ -428,9 +435,15 @@ export default function CourtCasesPage() {
   return (
     <ConfigProvider locale={ruRU}>
       <>
-        <Button type="primary" onClick={() => setShowAddForm((p) => !p)} style={{ marginTop: 16, marginRight: 8 }}>
-          {showAddForm ? 'Скрыть форму' : 'Добавить дело'}
-        </Button>
+        {perm?.edit_tables.includes('court_cases') && (
+          <Button
+            type="primary"
+            onClick={() => setShowAddForm((p) => !p)}
+            style={{ marginTop: 16, marginRight: 8 }}
+          >
+            {showAddForm ? 'Скрыть форму' : 'Добавить дело'}
+          </Button>
+        )}
         <Button onClick={() => setShowFilters((p) => !p)} style={{ marginTop: 16 }}>
           {showFilters ? 'Скрыть фильтры' : 'Показать фильтры'}
         </Button>

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -23,6 +23,9 @@ import { useUnitsByIds } from "@/entities/unit";
 import { useProjects } from "@/entities/project";
 import { useBrigades } from "@/entities/brigade";
 import { useContractors } from "@/entities/contractor";
+import { useRolePermission } from "@/entities/rolePermission";
+import { useAuthStore } from "@/shared/store/authStore";
+import type { RoleName } from "@/shared/types/rolePermission";
 import DefectsTable from "@/widgets/DefectsTable";
 import DefectsFilters from "@/widgets/DefectsFilters";
 import TableColumnsDrawer from "@/widgets/TableColumnsDrawer";
@@ -139,6 +142,8 @@ export default function DefectsPage() {
   const [viewId, setViewId] = useState<number | null>(null);
   const [fixId, setFixId] = useState<number | null>(null);
   const { mutateAsync: removeDefect, isPending: removing } = useDeleteDefect();
+  const role = useAuthStore((s) => s.profile?.role as RoleName | undefined);
+  const { data: perm } = useRolePermission(role);
 
   const LS_FILTERS_VISIBLE_KEY = "defectsFiltersVisible";
   const LS_COLUMNS_KEY = "defectsColumns";
@@ -270,24 +275,26 @@ export default function DefectsPage() {
                 onClick={() => setFixId(row.id)}
               />
             </Tooltip>
-            <Popconfirm
-              title="Удалить дефект?"
-              okText="Да"
-              cancelText="Нет"
-              onConfirm={async () => {
-                await removeDefect(row.id);
-                message.success("Удалено");
-              }}
-              disabled={removing}
-            >
-              <Button
-                size="small"
-                type="text"
-                danger
-                icon={<DeleteOutlined />}
-                loading={removing}
-              />
-            </Popconfirm>
+            {perm?.delete_tables.includes('defects') && (
+              <Popconfirm
+                title="Удалить дефект?"
+                okText="Да"
+                cancelText="Нет"
+                onConfirm={async () => {
+                  await removeDefect(row.id);
+                  message.success("Удалено");
+                }}
+                disabled={removing}
+              >
+                <Button
+                  size="small"
+                  type="text"
+                  danger
+                  icon={<DeleteOutlined />}
+                  loading={removing}
+                />
+              </Popconfirm>
+            )}
           </>
         ),
       } as any,

--- a/src/pages/UnitsPage/AdminPage.tsx
+++ b/src/pages/UnitsPage/AdminPage.tsx
@@ -13,6 +13,7 @@ import CourtCaseStatusesAdmin from "../../widgets/CourtCaseStatusesAdmin";
 import LetterTypesAdmin from "../../widgets/LetterTypesAdmin";
 import AttachmentTypesAdmin from "../../widgets/AttachmentTypesAdmin";
 import LetterStatusesAdmin from "../../widgets/LetterStatusesAdmin";
+import RolePermissionsAdmin from "../../widgets/RolePermissionsAdmin";
 
 export default function AdminPage() {
   return (
@@ -65,6 +66,8 @@ export default function AdminPage() {
         />
 
         <UsersTable pageSize={25} rowsPerPageOptions={[10, 25, 50, 100]} />
+
+        <RolePermissionsAdmin />
       </Stack>
     </Container>
   );

--- a/src/shared/components/RequirePermission.tsx
+++ b/src/shared/components/RequirePermission.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuthStore } from '@/shared/store/authStore';
+import { useRolePermission } from '@/entities/rolePermission';
+import type { RoleName } from '@/shared/types/rolePermission';
+
+interface Props {
+  page: string;
+  children: JSX.Element;
+}
+
+export default function RequirePermission({ page, children }: Props) {
+  const role = useAuthStore((s) => s.profile?.role as RoleName | undefined);
+  const { data: perm, isLoading } = useRolePermission(role);
+
+  if (isLoading) return null;
+
+  if (role === 'ADMIN' || perm?.pages.includes(page)) return children;
+
+  return <Navigate to="/" replace />;
+}

--- a/src/shared/types/rolePermission.ts
+++ b/src/shared/types/rolePermission.ts
@@ -1,0 +1,43 @@
+export interface RolePermission {
+  role_name: string;
+  pages: string[];
+  edit_tables: string[];
+  delete_tables: string[];
+}
+
+export type RoleName = 'ADMIN' | 'ENGINEER' | 'LAWYER' | 'CONTRACTOR';
+
+export const DEFAULT_ROLE_PERMISSIONS: Record<RoleName, RolePermission> = {
+  ADMIN: {
+    role_name: 'ADMIN',
+    pages: [
+      'dashboard',
+      'structure',
+      'tickets',
+      'defects',
+      'court-cases',
+      'correspondence',
+      'admin',
+    ],
+    edit_tables: ['tickets', 'defects', 'court_cases', 'letters'],
+    delete_tables: ['tickets', 'defects', 'court_cases', 'letters'],
+  },
+  ENGINEER: {
+    role_name: 'ENGINEER',
+    pages: ['dashboard', 'structure', 'tickets', 'defects', 'court-cases', 'correspondence'],
+    edit_tables: ['tickets', 'defects', 'letters'],
+    delete_tables: ['tickets', 'defects', 'letters'],
+  },
+  LAWYER: {
+    role_name: 'LAWYER',
+    pages: ['dashboard', 'structure', 'tickets', 'defects', 'court-cases', 'correspondence'],
+    edit_tables: ['court_cases', 'letters'],
+    delete_tables: ['court_cases', 'letters'],
+  },
+  CONTRACTOR: {
+    role_name: 'CONTRACTOR',
+    pages: ['defects'],
+    edit_tables: [],
+    delete_tables: [],
+  },
+};

--- a/src/widgets/NavBar.tsx
+++ b/src/widgets/NavBar.tsx
@@ -17,6 +17,7 @@ import LogoutIcon from "@mui/icons-material/Logout";
 import { supabase } from "@/shared/api/supabaseClient";
 import { useAuthStore } from "@/shared/store/authStore";
 import { useProjects } from "@/entities/project";
+import { useRolePermission } from "@/entities/rolePermission";
 
 const NavBar = () => {
   const profile = useAuthStore((s) => s.profile);
@@ -24,6 +25,7 @@ const NavBar = () => {
   const setProjectId = useAuthStore((s) => s.setProjectId);
 
   const { data: projects = [], isPending } = useProjects();
+  const { data: perm } = useRolePermission(profile?.role as any);
 
   const logout = async () => {
     await supabase.auth.signOut();
@@ -48,52 +50,62 @@ const NavBar = () => {
 
         {/* --- навигация --- */}
         <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
-          <Button
-            color="inherit"
-            component={RouterLink}
-            to="/structure"
-            sx={{ whiteSpace: "normal" }}
-          >
-            Структура проекта
-          </Button>
-          <Button
-            color="inherit"
-            component={RouterLink}
-            to="/tickets"
-            sx={{ whiteSpace: "normal" }}
-          >
-            Замечания
-          </Button>
-          <Button
-            color="inherit"
-            component={RouterLink}
-            to="/defects"
-            sx={{ whiteSpace: "normal" }}
-          >
-            Дефекты
-          </Button>
-          <Button
-            color="inherit"
-            component={RouterLink}
-            to="/court-cases"
-            sx={{ whiteSpace: "normal" }}
-          >
-            Судебные дела
-          </Button>
-          <Button
-            color="inherit"
-            component={RouterLink}
-            to="/correspondence"
-            sx={{ whiteSpace: "normal" }}
-          >
-            Письма
-          </Button>
-          {profile?.role === "ADMIN" && (
+          {perm?.pages.includes('structure') && (
+            <Button
+              color="inherit"
+              component={RouterLink}
+              to="/structure"
+              sx={{ whiteSpace: 'normal' }}
+            >
+              Структура проекта
+            </Button>
+          )}
+          {perm?.pages.includes('tickets') && (
+            <Button
+              color="inherit"
+              component={RouterLink}
+              to="/tickets"
+              sx={{ whiteSpace: 'normal' }}
+            >
+              Замечания
+            </Button>
+          )}
+          {perm?.pages.includes('defects') && (
+            <Button
+              color="inherit"
+              component={RouterLink}
+              to="/defects"
+              sx={{ whiteSpace: 'normal' }}
+            >
+              Дефекты
+            </Button>
+          )}
+          {perm?.pages.includes('court-cases') && (
+            <Button
+              color="inherit"
+              component={RouterLink}
+              to="/court-cases"
+              sx={{ whiteSpace: 'normal' }}
+            >
+              Судебные дела
+            </Button>
+          )}
+          {perm?.pages.includes('correspondence') && (
+            <Button
+              color="inherit"
+              component={RouterLink}
+              to="/correspondence"
+              sx={{ whiteSpace: 'normal' }}
+            >
+              Письма
+            </Button>
+          )}
+          {perm?.pages.includes('admin') && (
             <Button
               color="inherit"
               component={RouterLink}
               to="/admin"
-              sx={{ whiteSpace: "normal" }}
+              sx={{ whiteSpace: 'normal' }}
             >
               Администрирование
             </Button>

--- a/src/widgets/RolePermissionsAdmin.tsx
+++ b/src/widgets/RolePermissionsAdmin.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { Table, Switch, Skeleton } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import {
+  useRolePermissions,
+  useUpsertRolePermission,
+} from '@/entities/rolePermission';
+import type { RolePermission, RoleName } from '@/shared/types/rolePermission';
+import { DEFAULT_ROLE_PERMISSIONS } from '@/shared/types/rolePermission';
+
+const PAGES = [
+  'dashboard',
+  'structure',
+  'tickets',
+  'defects',
+  'court-cases',
+  'correspondence',
+  'admin',
+];
+
+const TABLES = ['tickets', 'defects', 'court_cases', 'letters'];
+
+export default function RolePermissionsAdmin() {
+  const { data = [], isLoading } = useRolePermissions();
+  const upsert = useUpsertRolePermission();
+
+  const merged: RolePermission[] = (['ADMIN', 'ENGINEER', 'LAWYER', 'CONTRACTOR'] as RoleName[]).map(
+    (r) => data.find((d) => d.role_name === r) ?? DEFAULT_ROLE_PERMISSIONS[r],
+  );
+
+  const handleToggle = (
+    role: RoleName,
+    field: 'pages' | 'edit_tables' | 'delete_tables',
+    value: string,
+  ) => {
+    const current = merged.find((m) => m.role_name === role)!;
+    const list = new Set(current[field]);
+    if (list.has(value)) list.delete(value);
+    else list.add(value);
+    upsert.mutate({ ...current, [field]: Array.from(list) });
+  };
+
+  const columns: ColumnsType<RolePermission> = [
+    {
+      title: 'Роль',
+      dataIndex: 'role_name',
+    },
+    {
+      title: 'Доступные страницы',
+      render: (_, record) => (
+        <div>
+          {PAGES.map((p) => (
+            <div key={p} style={{ marginBottom: 4 }}>
+              <Switch
+                size="small"
+                checked={record.pages.includes(p)}
+                onChange={() => handleToggle(record.role_name as RoleName, 'pages', p)}
+              />{' '}
+              {p}
+            </div>
+          ))}
+        </div>
+      ),
+    },
+    {
+      title: 'Редактирование',
+      render: (_, record) => (
+        <div>
+          {TABLES.map((t) => (
+            <div key={t} style={{ marginBottom: 4 }}>
+              <Switch
+                size="small"
+                checked={record.edit_tables.includes(t)}
+                onChange={() => handleToggle(record.role_name as RoleName, 'edit_tables', t)}
+              />{' '}
+              {t}
+            </div>
+          ))}
+        </div>
+      ),
+    },
+    {
+      title: 'Удаление',
+      render: (_, record) => (
+        <div>
+          {TABLES.map((t) => (
+            <div key={t} style={{ marginBottom: 4 }}>
+              <Switch
+                size="small"
+                checked={record.delete_tables.includes(t)}
+                onChange={() => handleToggle(record.role_name as RoleName, 'delete_tables', t)}
+              />{' '}
+              {t}
+            </div>
+          ))}
+        </div>
+      ),
+    },
+  ];
+
+  if (isLoading) return <Skeleton active />;
+
+  return <Table rowKey="role_name" pagination={false} dataSource={merged} columns={columns} />;
+}


### PR DESCRIPTION
## Summary
- manage role permissions in DB
- gate routes via `RequirePermission`
- hide navbar links per role
- allow admin to edit role permissions

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850dda95acc832eb8e64f32b85b51e8