### PR TITLE
Add project visibility toggle

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -812,6 +812,13 @@
     "column_default": "'[]'::jsonb"
   },
   {
+    "table_name": "role_permissions",
+    "column_name": "only_assigned_project",
+    "data_type": "boolean",
+    "is_nullable": "NO",
+    "column_default": "false"
+  },
+  {
     "table_name": "roles",
     "column_name": "id",
     "data_type": "integer",

--- a/sql/alter_role_permissions.sql
+++ b/sql/alter_role_permissions.sql
@@ -1,0 +1,3 @@
+-- Добавление флага только своего проекта для ролей
+ALTER TABLE role_permissions
+ADD COLUMN only_assigned_project boolean NOT NULL DEFAULT false;

--- a/src/entities/rolePermission.ts
+++ b/src/entities/rolePermission.ts
@@ -4,7 +4,7 @@ import type { RolePermission, RoleName } from '@/shared/types/rolePermission';
 import { DEFAULT_ROLE_PERMISSIONS } from '@/shared/types/rolePermission';
 
 const TABLE = 'role_permissions';
-const FIELDS = 'role_name, pages, edit_tables, delete_tables';
+const FIELDS = 'role_name, pages, edit_tables, delete_tables, only_assigned_project';
 
 /** Получить настройки ролей */
 export const useRolePermissions = () =>

--- a/src/shared/types/rolePermission.ts
+++ b/src/shared/types/rolePermission.ts
@@ -3,6 +3,8 @@ export interface RolePermission {
   pages: string[];
   edit_tables: string[];
   delete_tables: string[];
+  /** Ограничить видимость только назначенным проектом */
+  only_assigned_project: boolean;
 }
 
 export type RoleName = 'ADMIN' | 'ENGINEER' | 'LAWYER' | 'CONTRACTOR';
@@ -21,23 +23,27 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<RoleName, RolePermission> = {
     ],
     edit_tables: ['tickets', 'defects', 'court_cases', 'letters'],
     delete_tables: ['tickets', 'defects', 'court_cases', 'letters'],
+    only_assigned_project: false,
   },
   ENGINEER: {
     role_name: 'ENGINEER',
     pages: ['dashboard', 'structure', 'tickets', 'defects', 'court-cases', 'correspondence'],
     edit_tables: ['tickets', 'defects', 'letters'],
     delete_tables: ['tickets', 'defects', 'letters'],
+    only_assigned_project: false,
   },
   LAWYER: {
     role_name: 'LAWYER',
     pages: ['dashboard', 'structure', 'tickets', 'defects', 'court-cases', 'correspondence'],
     edit_tables: ['court_cases', 'letters'],
     delete_tables: ['court_cases', 'letters'],
+    only_assigned_project: false,
   },
   CONTRACTOR: {
     role_name: 'CONTRACTOR',
     pages: ['defects'],
     edit_tables: [],
     delete_tables: [],
+    only_assigned_project: false,
   },
 };

--- a/src/widgets/RolePermissionsAdmin.tsx
+++ b/src/widgets/RolePermissionsAdmin.tsx
@@ -40,10 +40,28 @@ export default function RolePermissionsAdmin() {
     upsert.mutate({ ...current, [field]: Array.from(list) });
   };
 
+  const handleProjectToggle = (role: RoleName, value: boolean) => {
+    const current = merged.find((m) => m.role_name === role)!;
+    upsert.mutate({ ...current, only_assigned_project: value });
+  };
+
   const columns: ColumnsType<RolePermission> = [
     {
       title: 'Роль',
       dataIndex: 'role_name',
+    },
+    {
+      title: 'Только свой проект',
+      dataIndex: 'only_assigned_project',
+      render: (_, record) => (
+        <Switch
+          size="small"
+          checked={record.only_assigned_project}
+          onChange={(checked) =>
+            handleProjectToggle(record.role_name as RoleName, checked)
+          }
+        />
+      ),
     },
     {
       title: 'Доступные страницы',


### PR DESCRIPTION
## Summary
- add `only_assigned_project` column definition
- expose `only_assigned_project` in role permissions types
- support boolean toggle for roles in admin UI
- document DB migration

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6850f00fc4f0832e923e6d09d711a66c