### PR TITLE
Limit project visibility by role

### DIFF
--- a/src/features/correspondence/AddLetterForm.tsx
+++ b/src/features/correspondence/AddLetterForm.tsx
@@ -17,7 +17,7 @@ import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
 import dayjs, { Dayjs } from 'dayjs';
 import { useUsers } from '@/entities/user';
 import { useLetterTypes } from '@/entities/letterType';
-import { useProjects } from '@/entities/project';
+import { useVisibleProjects } from '@/entities/project';
 import { useUnitsByProject } from '@/entities/unit';
 import { useContractors, useDeleteContractor } from '@/entities/contractor';
 import { usePersons, useDeletePerson } from '@/entities/person';
@@ -68,7 +68,7 @@ export default function AddLetterForm({ onSubmit, parentId = null, initialValues
 
   const { data: users = [], isLoading: loadingUsers } = useUsers();
   const { data: letterTypes = [], isLoading: loadingTypes } = useLetterTypes();
-  const { data: projects = [], isLoading: loadingProjects } = useProjects();
+  const { data: projects = [], isLoading: loadingProjects } = useVisibleProjects();
   const { data: units = [], isLoading: loadingUnits } = useUnitsByProject(projectId);
   const { data: contractors = [], isLoading: loadingContractors } = useContractors();
   const { data: persons = [], isLoading: loadingPersons } = usePersons();

--- a/src/features/correspondence/LetterFormAntdEdit.tsx
+++ b/src/features/correspondence/LetterFormAntdEdit.tsx
@@ -17,7 +17,7 @@ import {
 import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
 import { useUsers } from '@/entities/user';
 import { useLetterTypes } from '@/entities/letterType';
-import { useProjects } from '@/entities/project';
+import { useVisibleProjects } from '@/entities/project';
 import { useUnitsByProject } from '@/entities/unit';
 import { useAttachmentTypes } from '@/entities/attachmentType';
 import { useContractors, useDeleteContractor } from '@/entities/contractor';
@@ -44,7 +44,7 @@ export default function LetterFormAntdEdit({ letterId, onCancel, onSaved, embedd
   const { data: letter } = useLetter(letterId);
   const { data: users = [] } = useUsers();
   const { data: letterTypes = [] } = useLetterTypes();
-  const { data: projects = [] } = useProjects();
+  const { data: projects = [] } = useVisibleProjects();
   const projectId = Form.useWatch('project_id', form);
   const { data: units = [] } = useUnitsByProject(projectId); 
   const { data: attachmentTypes = [] } = useAttachmentTypes();

--- a/src/features/courtCase/AddCourtCaseForm.tsx
+++ b/src/features/courtCase/AddCourtCaseForm.tsx
@@ -12,7 +12,7 @@ import {
 } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers';
 import dayjs, { Dayjs } from 'dayjs';
-import { useProjects } from '@/entities/project';
+import { useVisibleProjects } from '@/entities/project';
 import { useUnitsByProject } from '@/entities/unit';
 import { useUsers } from '@/entities/user';
 import { useCourtCaseStatuses } from '@/entities/courtCaseStatus';
@@ -61,7 +61,7 @@ export default function AddCourtCaseForm({
 
   const projectId = watch('project_id');
 
-  const { data: projects = [] } = useProjects();
+  const { data: projects = [] } = useVisibleProjects();
   const { data: units = [] } = useUnitsByProject(projectId);
   const { data: users = [] } = useUsers();
   const { data: stages = [] } = useCourtCaseStatuses();

--- a/src/features/courtCase/AddCourtCaseFormAntd.tsx
+++ b/src/features/courtCase/AddCourtCaseFormAntd.tsx
@@ -13,7 +13,7 @@ import {
   Modal,
 } from 'antd';
 import { Dayjs } from 'dayjs';
-import { useProjects } from '@/entities/project';
+import { useVisibleProjects } from '@/entities/project';
 import { useUnitsByProject } from '@/entities/unit';
 import {
   useContractors,
@@ -92,7 +92,7 @@ export default function AddCourtCaseFormAntd({
     prevProjectIdRef.current = projectId ?? null;
   }, [projectId, form]);
 
-  const { data: projects = [] } = useProjects();
+  const { data: projects = [] } = useVisibleProjects();
   const { data: units = [], isPending: unitsLoading } = useUnitsByProject(projectId);
   const { data: contractors = [], isPending: contractorsLoading } = useContractors();
   const { data: users = [], isPending: usersLoading } = useUsers();

--- a/src/features/courtCase/CourtCaseFormAntdEdit.tsx
+++ b/src/features/courtCase/CourtCaseFormAntdEdit.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import dayjs, { Dayjs } from 'dayjs';
 import { Form, Input, Select, DatePicker, Row, Col, Button, Skeleton } from 'antd';
-import { useProjects } from '@/entities/project';
+import { useVisibleProjects } from '@/entities/project';
 import { useUnitsByProject } from '@/entities/unit';
 import { useContractors } from '@/entities/contractor';
 import { useUsers } from '@/entities/user';
@@ -32,7 +32,7 @@ export default function CourtCaseFormAntdEdit({
 }: CourtCaseFormAntdEditProps) {
   const [form] = Form.useForm();
   const { data: courtCase } = useCourtCase(caseId);
-  const { data: projects = [] } = useProjects();
+  const { data: projects = [] } = useVisibleProjects();
   const projectId = Form.useWatch('project_id', form);
   const { data: units = [] } = useUnitsByProject(projectId);
   const { data: contractors = [] } = useContractors();

--- a/src/features/defectDeadline/DefectDeadlineForm.tsx
+++ b/src/features/defectDeadline/DefectDeadlineForm.tsx
@@ -8,7 +8,7 @@ import {
   CircularProgress,
   MenuItem,
 } from '@mui/material';
-import { useProjects } from '@/entities/project';
+import { useVisibleProjects } from '@/entities/project';
 import { useDefectTypes } from '@/entities/defectType';
 
 interface FormValues {
@@ -32,7 +32,7 @@ export default function DefectDeadlineForm({ initialData, onSubmit, onCancel }: 
     },
   });
 
-  const { data: projects = [] } = useProjects();
+  const { data: projects = [] } = useVisibleProjects();
   const { data: types = [] } = useDefectTypes();
 
   return (

--- a/src/features/ticket/TicketForm.tsx
+++ b/src/features/ticket/TicketForm.tsx
@@ -22,7 +22,7 @@ import { useDefectTypes } from "@/entities/defectType";
 import { useTicketStatuses } from "@/entities/ticketStatus";
 import { useUnitsByProject } from "@/entities/unit";
 import { useUsers } from "@/entities/user";
-import { useProjects } from "@/entities/project";
+import { useVisibleProjects } from "@/entities/project";
 import { useDefectDeadlines } from "@/entities/defectDeadline";
 import { useAttachmentTypes } from "@/entities/attachmentType";
 import { useCreateTicket, useTicket, signedUrl } from "@/entities/ticket";
@@ -112,7 +112,7 @@ export default function TicketForm({
     },
   });
 
-  const { data: projects = [] } = useProjects();
+  const { data: projects = [] } = useVisibleProjects();
   const { data: types = [] } = useDefectTypes();
   const { data: statuses = [] } = useTicketStatuses();
   const { data: users = [] } = useUsers();

--- a/src/features/ticket/TicketFormAntd.tsx
+++ b/src/features/ticket/TicketFormAntd.tsx
@@ -7,7 +7,7 @@ import { Form, Input, Select, DatePicker, Switch, Button, Row, Col } from 'antd'
 import { useTicketStatuses } from '@/entities/ticketStatus';
 import { useUnitsByProject } from '@/entities/unit';
 import { useUsers } from '@/entities/user';
-import { useProjects } from '@/entities/project';
+import { useVisibleProjects } from '@/entities/project';
 import { useCreateTicket } from '@/entities/ticket';
 import { useCreateDefects, type NewDefect } from '@/entities/defect';
 import { useAttachmentTypes } from '@/entities/attachmentType';
@@ -63,7 +63,7 @@ export default function TicketFormAntd({ onCreated, initialValues = {} }: Ticket
   const projectId = projectIdWatch != null ? Number(projectIdWatch) : null;
 
   const { data: statuses = [] } = useTicketStatuses();
-  const { data: projects = [] } = useProjects();
+  const { data: projects = [] } = useVisibleProjects();
   const { data: units = [] } = useUnitsByProject(projectId);
   const { data: users = [] } = useUsers();
   const { data: attachmentTypes = [] } = useAttachmentTypes();

--- a/src/features/ticket/TicketFormAntdEdit.tsx
+++ b/src/features/ticket/TicketFormAntdEdit.tsx
@@ -15,7 +15,7 @@ import { useDefectTypes } from '@/entities/defectType';
 import { useTicketStatuses } from '@/entities/ticketStatus';
 import { useUnitsByProject } from '@/entities/unit';
 import { useUsers } from '@/entities/user';
-import { useProjects } from '@/entities/project';
+import { useVisibleProjects } from '@/entities/project';
 import { useCreateTicket, useTicket } from '@/entities/ticket';
 import { useAttachmentTypes } from '@/entities/attachmentType';
 import { useProjectId } from '@/shared/hooks/useProjectId';
@@ -66,7 +66,7 @@ export default function TicketFormAntdEdit({
 
   const { data: types = [] } = useDefectTypes();
   const { data: statuses = [] } = useTicketStatuses();
-  const { data: projects = [] } = useProjects();
+  const { data: projects = [] } = useVisibleProjects();
   const { data: users = [] } = useUsers();
   const projectIdWatch = Form.useWatch('project_id', form) ?? globalProjectId;
   const projectId = projectIdWatch != null ? Number(projectIdWatch) : null;

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -40,7 +40,7 @@ import { fixForeignKeys } from '@/shared/utils/fixForeignKeys';
 
 import { useUsers } from '@/entities/user';
 import { useLetterTypes } from '@/entities/letterType';
-import { useProjects } from '@/entities/project';
+import { useVisibleProjects } from '@/entities/project';
 import { useUnitsByProject, useUnitsByIds } from '@/entities/unit';
 import { useAttachmentTypes } from '@/entities/attachmentType';
 import { useNotify } from '@/shared/hooks/useNotify';
@@ -188,7 +188,7 @@ export default function CorrespondencePage() {
   const { data: statuses = [] } = useLetterStatuses();
   const { data: contractors = [] } = useContractors();
   const { data: persons = [] } = usePersons();
-  const { data: projects = [] } = useProjects();
+  const { data: projects = [] } = useVisibleProjects();
   const { data: attachmentTypes = [] } = useAttachmentTypes();
   const { data: projectUnits = [] } = useUnitsByProject(
     filters.project ? Number(filters.project) : null,

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -8,7 +8,7 @@ import { ConfigProvider, Button, Card, Table, Space, Popconfirm, Tooltip, Typogr
 import ruRU from 'antd/locale/ru_RU';
 import type { ColumnsType } from 'antd/es/table';
 import type { CourtCase } from '@/shared/types/courtCase';
-import { useProjects } from '@/entities/project';
+import { useVisibleProjects } from '@/entities/project';
 import { useUnitsByIds } from '@/entities/unit';
 import { useContractors } from '@/entities/contractor';
 import { useUsers } from '@/entities/user';
@@ -90,7 +90,7 @@ export default function CourtCasesPage() {
     }
   }, [searchParams]);
 
-  const { data: projects = [] } = useProjects();
+  const { data: projects = [] } = useVisibleProjects();
   const { data: contractors = [] } = useContractors();
   const { data: users = [] } = useUsers();
   const { data: stages = [] } = useCourtCaseStatuses();

--- a/src/pages/DashboardPage/DashboardPage.tsx
+++ b/src/pages/DashboardPage/DashboardPage.tsx
@@ -10,12 +10,12 @@ import {
   Skeleton,
 } from "@mui/material";
 import { useSnackbar } from "notistack";
-import { useProjects } from "../../entities/project";
+import { useVisibleProjects } from "../../entities/project";
 import { useAuthStore } from "../../shared/store/authStore";
 
 const DashboardPage = () => {
   const { enqueueSnackbar } = useSnackbar();
-  const { data: projects = [], isPending, error } = useProjects();
+  const { data: projects = [], isPending, error } = useVisibleProjects();
   const profile = useAuthStore((s) => s.profile);
 
   useEffect(() => {

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -20,7 +20,7 @@ import ruRU from "antd/locale/ru_RU";
 import { useDefects, useDeleteDefect } from "@/entities/defect";
 import { useTicketsSimple } from "@/entities/ticket";
 import { useUnitsByIds } from "@/entities/unit";
-import { useProjects } from "@/entities/project";
+import { useVisibleProjects } from "@/entities/project";
 import { useBrigades } from "@/entities/brigade";
 import { useContractors } from "@/entities/contractor";
 import { useRolePermission } from "@/entities/rolePermission";
@@ -50,7 +50,7 @@ export default function DefectsPage() {
     [tickets],
   );
   const { data: units = [] } = useUnitsByIds(unitIds);
-  const { data: projects = [] } = useProjects();
+  const { data: projects = [] } = useVisibleProjects();
   const { data: brigades = [] } = useBrigades();
   const { data: contractors = [] } = useContractors();
 

--- a/src/pages/UnitsPage/RegisterPage.tsx
+++ b/src/pages/UnitsPage/RegisterPage.tsx
@@ -20,7 +20,7 @@ import {
 } from "@mui/material";
 import { useSnackbar } from "notistack";
 
-import { useProjects } from "@/entities/project";
+import { useVisibleProjects } from "@/entities/project";
 
 /**
  * Страница регистрации нового пользователя.
@@ -36,7 +36,7 @@ export default function RegisterPage() {
   const [project, setProject] = useState(null);
   const [loading, setLoading] = useState(false);
 
-  const { data: projects = [], isLoading: projLoad } = useProjects();
+  const { data: projects = [], isLoading: projLoad } = useVisibleProjects();
 
   /** Отправка формы регистрации */
   async function signUp(e) {

--- a/src/shared/hooks/useProjectStructure.ts
+++ b/src/shared/hooks/useProjectStructure.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { supabase } from '@/shared/api/supabaseClient';
 import type { Project } from '@/shared/types/project';
+import { useVisibleProjects } from '@/entities/project';
 
 const LS_KEY = 'structurePageSelection';
 
@@ -9,7 +10,7 @@ const LS_KEY = 'structurePageSelection';
  * Сохраняет состояние в localStorage и синхронизирует его между вкладками.
  */
 export default function useProjectStructure() {
-    const [projects, setProjects] = useState<Project[]>([]);
+    const { data: projects = [] } = useVisibleProjects();
     const [projectId, setProjectIdState] = useState<string>('');
     const [buildings, setBuildings] = useState<string[]>([]);
     const [building, setBuildingState] = useState<string>('');
@@ -47,13 +48,7 @@ export default function useProjectStructure() {
         } catch { /* ignore */ }
     }, []);
 
-    // --- Projects ---
-    useEffect(() => {
-        (async () => {
-            const { data } = await supabase.from('projects').select('*').order('id');
-            setProjects((data ?? []) as Project[]);
-        })();
-    }, []);
+
 
     // --- Buildings and sections auto-refresh ---
     const refreshAll = useCallback(async () => {

--- a/src/widgets/NavBar.tsx
+++ b/src/widgets/NavBar.tsx
@@ -16,7 +16,7 @@ import LogoutIcon from "@mui/icons-material/Logout";
 
 import { supabase } from "@/shared/api/supabaseClient";
 import { useAuthStore } from "@/shared/store/authStore";
-import { useProjects } from "@/entities/project";
+import { useVisibleProjects } from "@/entities/project";
 import { useRolePermission } from "@/entities/rolePermission";
 
 const NavBar = () => {
@@ -24,7 +24,7 @@ const NavBar = () => {
   const setProfile = useAuthStore((s) => s.setProfile);
   const setProjectId = useAuthStore((s) => s.setProjectId);
 
-  const { data: projects = [], isPending } = useProjects();
+  const { data: projects = [], isPending } = useVisibleProjects();
   const { data: perm } = useRolePermission(profile?.role as any);
 
   const logout = async () => {
@@ -138,6 +138,7 @@ const NavBar = () => {
                   value={profile.project_id ?? ""}
                   onChange={(e) => setProjectId(e.target.value)}
                   displayEmpty
+                  disabled={perm?.only_assigned_project}
                   sx={{
                     color: "inherit",
                     fontSize: 12,


### PR DESCRIPTION
## Summary
- add `useVisibleProjects` helper for role-based project filtering
- filter projects in `useProjectStructure`
- hide project switch if restricted
- enforce filtering in forms and pages

## Testing
- `npm run lint` *(fails: eslint plugin deps missing)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850f3ab6e54832e8df7f7a1d5e5e2c7