### PR TITLE
Implement user role save on registration

### DIFF
--- a/src/entities/user.ts
+++ b/src/entities/user.ts
@@ -5,6 +5,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/shared/api/supabaseClient';
 import type { User } from '@/shared/types/user';
+import type { RoleName } from '@/shared/types/rolePermission';
 
 const FIELDS = 'id, name, email, role, project_id';
 
@@ -57,3 +58,20 @@ export const useDeleteUser = () => {
         onSuccess: () => qc.invalidateQueries({ queryKey: ['users', 'all'] }),
     });
 };
+
+/* ─────────── CREATE ─────────── */
+/**
+ * Создает запись профиля пользователя в таблице `profiles`.
+ * Используется после регистрации нового аккаунта.
+ */
+export async function addUserProfile(payload: {
+    id: string;
+    name: string | null;
+    email: string;
+    role: RoleName;
+    project_id: number;
+}): Promise<void> {
+    const { error } = await supabase.from('profiles').insert(payload);
+    if (error) throw error;
+}
+

--- a/src/pages/UnitsPage/RegisterPage.tsx
+++ b/src/pages/UnitsPage/RegisterPage.tsx
@@ -22,6 +22,7 @@ import {
 import { useSnackbar } from "notistack";
 
 import { useVisibleProjects } from "@/entities/project";
+import { addUserProfile } from "@/entities/user";
 import type { RoleName } from "@/shared/types/rolePermission";
 
 const ROLE_OPTIONS: { value: RoleName; label: string }[] = [
@@ -77,6 +78,21 @@ export default function RegisterPage() {
         console.error("[signUp error]", error, JSON.stringify(data, null, 2));
         enqueueSnackbar(error.message, { variant: "error" });
         return;
+      }
+
+      if (data?.user) {
+        try {
+          await addUserProfile({
+            id: data.user.id,
+            name: fullName,
+            email,
+            role,
+            project_id: project.id,
+          });
+        } catch (insertErr) {
+          // eslint-disable-next-line no-console
+          console.error('[profile insert]', insertErr);
+        }
       }
 
       enqueueSnackbar("Проверьте e-mail — отправили ссылку подтверждения.", {


### PR DESCRIPTION
## Summary
- add helper to insert profile record
- save selected role into profiles table after sign up

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68523819fb1c832ea3a8b42b23d08792