### PR TITLE
Fix project selector id handling

### DIFF
--- a/src/pages/ProjectStructurePage/ProjectStructurePage.tsx
+++ b/src/pages/ProjectStructurePage/ProjectStructurePage.tsx
@@ -218,7 +218,7 @@ export default function ProjectStructurePage() {
                         >
                             <Select
                                 value={projectId || ""}
-                                onChange={(e) => setProjectId(e.target.value)}
+                                onChange={(e) => setProjectId(String(e.target.value))}
                                 displayEmpty
                                 sx={{
                                     bgcolor: "rgba(255,255,255,0.11)",

--- a/src/shared/hooks/useProjectStructure.ts
+++ b/src/shared/hooks/useProjectStructure.ts
@@ -31,7 +31,7 @@ export default function useProjectStructure() {
     // --- Обёртки, чтобы сеттеры писали в localStorage ---
     const setProjectId = (id: string) => {
         setProjectIdState(id);
-        setGlobalProjectId(id ? String(id) : null);
+        setGlobalProjectId(id ? Number(id) : null);
         saveToLS({ projectId: id, building, section });
     };
     const setBuilding = (bld: string) => {
@@ -49,7 +49,7 @@ export default function useProjectStructure() {
             const saved = JSON.parse(localStorage.getItem(LS_KEY) || '{}') as Partial<ProjectStructureSelection>;
             if (saved.projectId) {
                 setProjectIdState(saved.projectId);
-                setGlobalProjectId(saved.projectId);
+                setGlobalProjectId(Number(saved.projectId));
             }
             if (saved.building) setBuildingState(saved.building);
             if (saved.section) setSectionState(saved.section);
@@ -89,7 +89,7 @@ export default function useProjectStructure() {
     // --- Автоматическое сохранение выбранных значений при изменении ---
     useEffect(() => {
         saveToLS({ projectId, building, section });
-        setGlobalProjectId(projectId || null);
+        setGlobalProjectId(projectId ? Number(projectId) : null);
     }, [projectId, building, section]);
 
     // --- Поддержка обновления между вкладками ---
@@ -100,7 +100,7 @@ export default function useProjectStructure() {
                     const saved = JSON.parse(e.newValue || '{}') as Partial<ProjectStructureSelection>;
                     if (saved.projectId) {
                         setProjectIdState(saved.projectId);
-                        setGlobalProjectId(saved.projectId);
+                        setGlobalProjectId(Number(saved.projectId));
                     }
                     if (saved.building) setBuildingState(saved.building);
                     if (saved.section) setSectionState(saved.section);

--- a/src/shared/store/authStore.ts
+++ b/src/shared/store/authStore.ts
@@ -22,7 +22,16 @@ export const useAuthStore = create<AuthState>((set) => ({
   setProfile: (profile) => set({ profile }),
   clearProfile: () => set({ profile: null }),
   setProjectId: (project_id) =>
-    set((s) => (s.profile ? { profile: { ...s.profile, project_id } } : {})),
+    set((s) =>
+      s.profile
+        ? {
+            profile: {
+              ...s.profile,
+              project_id: project_id != null ? Number(project_id) : null,
+            },
+          }
+        : {},
+    ),
   setProjectIds: (project_ids) =>
     set((s) => (s.profile ? { profile: { ...s.profile, project_ids } } : {})),
 }));

--- a/src/widgets/NavBar.tsx
+++ b/src/widgets/NavBar.tsx
@@ -136,7 +136,10 @@ const NavBar = () => {
               <FormControl variant="standard" size="small">
                 <Select
                   value={profile.project_id ?? ""}
-                  onChange={(e) => setProjectId(e.target.value)}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    setProjectId(val === '' ? null : Number(val));
+                  }}
                   displayEmpty
                   disabled={perm?.only_assigned_project}
                   sx={{


### PR DESCRIPTION
## Summary
- ensure project ID stored as number in auth store
- forward numeric ID through project structure hook
- normalize value type in navbar project selector
- update ProjectStructurePage to pass string value

## Testing
- `npm run lint` *(fails: Parsing error due to minimal config)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852454ded68832e9781dde3ee44ba37