### PR TITLE
Improve admin user role and project editors

### DIFF
--- a/src/features/user/UserProjectsSelect.tsx
+++ b/src/features/user/UserProjectsSelect.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Select, Tag, Skeleton } from 'antd';
+import { useUpdateUserProjects } from '@/entities/user';
+import type { User } from '@/shared/types/user';
+import type { Project } from '@/shared/types/project';
+
+interface UserProjectsSelectProps {
+  user: User;
+  projects: Project[];
+  loading?: boolean;
+}
+
+/**
+ * Множественный выбор проектов для пользователя.
+ * Отображает теги выбранных проектов и позволяет быстро изменять список.
+ */
+export default function UserProjectsSelect({
+  user,
+  projects,
+  loading = false,
+}: UserProjectsSelectProps) {
+  const updateProjects = useUpdateUserProjects();
+  const [editing, setEditing] = React.useState(false);
+
+  const options = React.useMemo(
+    () => projects.map((p) => ({ label: p.name, value: p.id })),
+    [projects],
+  );
+
+  const handleChange = (vals: number[]) => {
+    updateProjects.mutate({ id: user.id, projectIds: vals });
+    setEditing(false);
+  };
+
+  const tags = user.project_ids
+    .map((id) => projects.find((p) => p.id === id)?.name)
+    .filter(Boolean) as string[];
+
+  if (loading) return <Skeleton.Button active size="small" style={{ width: 160 }} />;
+
+  if (!editing) {
+    return (
+      <div onClick={() => setEditing(true)} style={{ cursor: 'pointer' }}>
+        {tags.length ? tags.map((t) => <Tag key={t}>{t}</Tag>) : <Tag>—</Tag>}
+      </div>
+    );
+  }
+
+  return (
+    <Select
+      mode="multiple"
+      size="small"
+      autoFocus
+      open
+      style={{ width: '100%' }}
+      defaultValue={user.project_ids}
+      onBlur={() => setEditing(false)}
+      onChange={handleChange}
+      options={options}
+      loading={updateProjects.isPending}
+    />
+  );
+}

--- a/src/widgets/UsersTable.tsx
+++ b/src/widgets/UsersTable.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 import { GridActionsCellItem } from "@mui/x-data-grid";
 import DeleteIcon from "@mui/icons-material/Delete";
-import { MenuItem, Select, CircularProgress } from "@mui/material";
 
-import { useUsers, useDeleteUser, useUpdateUserProjects } from "@/entities/user";
+import { useUsers, useDeleteUser } from "@/entities/user";
 import { useRoles } from "@/entities/role";
 import { useProjects } from "@/entities/project";
 import AdminDataGrid from "@/shared/ui/AdminDataGrid";
 import { useNotify } from "@/shared/hooks/useNotify";
 import RoleSelect from "@/features/user/RoleSelect";
+import UserProjectsSelect from "@/features/user/UserProjectsSelect";
 
 // Интерфейс для пропсов с пагинацией
 interface UsersTableProps {
@@ -26,10 +26,6 @@ export default function UsersTable({
   const { data: projects = [], isPending: pLoad } = useProjects();
   const delUser = useDeleteUser();
 
-
-  // Мутация для обновления списка проектов пользователя
-  const updateProjects = useUpdateUserProjects();
-
   // Таблица
   const columns = [
     { field: "id", headerName: "ID", width: 70 },
@@ -39,38 +35,17 @@ export default function UsersTable({
       field: "role",
       headerName: "Роль",
       flex: 0.7,
-      renderCell: ({ row }) => <RoleSelect user={row} roles={roles} />,
+      renderCell: ({ row }) => (
+        <RoleSelect user={row} roles={roles} loading={rLoad} />
+      ),
     },
     {
-      field: "project_ids",
-      headerName: "Проекты",
+      field: 'project_ids',
+      headerName: 'Проекты',
       flex: 1,
-      renderCell: ({ row }) => {
-        if (pLoad) return <CircularProgress size={18} />;
-        return (
-          <Select
-            multiple
-            size="small"
-            variant="standard"
-            value={row.project_ids || []}
-            onChange={(e) =>
-              updateProjects.mutate({ id: row.id, projectIds: e.target.value as number[] })
-            }
-            sx={{ minWidth: 160 }}
-            renderValue={(selected) =>
-              (selected as number[])
-                .map((id) => projects.find((p) => p.id === id)?.name)
-                .join(', ')
-            }
-          >
-            {projects.map((proj) => (
-              <MenuItem key={proj.id} value={proj.id}>
-                {proj.name}
-              </MenuItem>
-            ))}
-          </Select>
-        );
-      },
+      renderCell: ({ row }) => (
+        <UserProjectsSelect user={row} projects={projects} loading={pLoad} />
+      ),
     },
     {
       field: "actions",


### PR DESCRIPTION
## Summary
- refine `RoleSelect` with Ant Design and skeleton
- add new `UserProjectsSelect` feature for managing user projects
- update `UsersTable` to use new role and project editors

## Testing
- `npm run lint` *(fails: Parsing error due to missing plugins)*

------
https://chatgpt.com/codex/tasks/task_e_6853185b4394832ebf3e6389c106f5d8