### PR TITLE
Display assigned projects in navbar

### DIFF
--- a/src/widgets/NavBar.tsx
+++ b/src/widgets/NavBar.tsx
@@ -18,6 +18,7 @@ import { supabase } from "@/shared/api/supabaseClient";
 import { useAuthStore } from "@/shared/store/authStore";
 import { useVisibleProjects } from "@/entities/project";
 import { useRolePermission } from "@/entities/rolePermission";
+import { Skeleton } from "antd";
 
 const NavBar = () => {
   const profile = useAuthStore((s) => s.profile);
@@ -129,6 +130,16 @@ const NavBar = () => {
             <Typography variant="body2">
               {profile.name ?? profile.email}
             </Typography>
+
+            {perm?.only_assigned_project && (
+              isPending ? (
+                <Skeleton active title={false} paragraph={false} style={{ width: 120, marginTop: 2 }} />
+              ) : (
+                <Typography variant="caption" sx={{ color: "inherit", opacity: 0.8 }}>
+                  {projects.map((p) => p.name).join("; ") || "—"}
+                </Typography>
+              )
+            )}
 
             {/* выпадающий список проектов */}
             {isPending ? (


### PR DESCRIPTION
## Summary
- show skeleton then list of assigned projects in navbar when role has *only_assigned_project*

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68531bbbfef0832ea8d6fe3ab728a2d7