### PR TITLE
Fix ticket list update for assigned projects

### DIFF
--- a/src/features/ticket/TicketListDialog.tsx
+++ b/src/features/ticket/TicketListDialog.tsx
@@ -27,6 +27,8 @@ import { useQueryClient } from "@tanstack/react-query";
 import TicketForm from "@/features/ticket/TicketForm";
 import { signedUrl } from "@/entities/ticket";
 import { addTicketAttachments, getAttachmentsByIds } from "@/entities/attachment";
+import { useProjectFilter } from "@/shared/hooks/useProjectFilter";
+import { ticketsKey } from "@/shared/utils/queryKeys";
 
 export default function TicketListDialog({
   open,
@@ -36,6 +38,7 @@ export default function TicketListDialog({
 }) {
   const notify = useNotify();
   const queryClient = useQueryClient();
+  const { projectIds } = useProjectFilter();
   const [tickets, setTickets] = useState([]);
   const [statuses, setStatuses] = useState([]);
   const [attachments, setAttachments] = useState({});
@@ -96,11 +99,8 @@ export default function TicketListDialog({
     );
     notify.success("Статус обновлён");
     // Инвалидируем кэш тикетов
-    if (unit?.project_id) {
-      queryClient.invalidateQueries({ queryKey: ["tickets", unit.project_id] });
-    } else {
-      queryClient.invalidateQueries({ queryKey: ["tickets"] });
-    }
+    const pid = unit?.project_id ?? null;
+    queryClient.invalidateQueries({ queryKey: ticketsKey(pid, projectIds) });
     // ЯВНО ТРИГГЕРИМ ОБНОВЛЕНИЕ ВНЕШНЕГО ХРАНИЛИЩА (шахматки)
     if (onTicketsChanged) onTicketsChanged();
   };

--- a/src/shared/hooks/useRealtimeUpdates.ts
+++ b/src/shared/hooks/useRealtimeUpdates.ts
@@ -5,6 +5,7 @@ import { useProjectId } from '@/shared/hooks/useProjectId';
 import { useAuthStore } from '@/shared/store/authStore';
 import { useRolePermission } from '@/entities/rolePermission';
 import type { RoleName } from '@/shared/types/rolePermission';
+import { ticketsKey } from '@/shared/utils/queryKeys';
 
 /**
  * Подписка на создание записей в ключевых таблицах.
@@ -34,17 +35,17 @@ export function useRealtimeUpdates() {
         .on(
           'postgres_changes',
           { event: 'INSERT', schema: 'public', table: 'tickets', filter: `project_id=eq.${pid}` },
-          () => qc.invalidateQueries({ queryKey: ['tickets', pid] }),
+          () => qc.invalidateQueries({ queryKey: ticketsKey(projectId, projectIds) }),
         )
         .on(
           'postgres_changes',
           { event: 'UPDATE', schema: 'public', table: 'tickets', filter: `project_id=eq.${pid}` },
-          () => qc.invalidateQueries({ queryKey: ['tickets', pid] }),
+          () => qc.invalidateQueries({ queryKey: ticketsKey(projectId, projectIds) }),
         )
         .on(
           'postgres_changes',
           { event: 'DELETE', schema: 'public', table: 'tickets', filter: `project_id=eq.${pid}` },
-          () => qc.invalidateQueries({ queryKey: ['tickets', pid] }),
+          () => qc.invalidateQueries({ queryKey: ticketsKey(projectId, projectIds) }),
         )
         .on(
           'postgres_changes',

--- a/src/shared/utils/queryKeys.ts
+++ b/src/shared/utils/queryKeys.ts
@@ -1,0 +1,25 @@
+/**
+ * Хелперы для формирования ключей React Query.
+ */
+
+/**
+ * Ключ запросов списка замечаний.
+ * @param projectId ID выбранного проекта
+ * @param projectIds Список проектов пользователя
+ */
+export const ticketsKey = (projectId: number | null, projectIds: number[]) => [
+  'tickets',
+  projectId,
+  projectIds.join(',')
+];
+
+/**
+ * Ключ запросов короткого списка замечаний.
+ * @param projectId ID выбранного проекта
+ * @param projectIds Список проектов пользователя
+ */
+export const ticketsSimpleKey = (
+  projectId: number | null,
+  projectIds: number[],
+) => ['tickets-simple', projectId, projectIds.join(',')];
+


### PR DESCRIPTION
## Summary
- add `ticketsKey` helpers for consistent query invalidation
- use new keys when creating, updating or deleting tickets
- refresh ticket list in realtime hook
- update ticket dialog invalidation

## Testing
- `npm run lint` *(fails: Parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68538e6acf98832ea4e40f5a6b6a8216