### PR TITLE
Fix tickets filtering by project

### DIFF
--- a/src/features/ticket/TicketListDialog.tsx
+++ b/src/features/ticket/TicketListDialog.tsx
@@ -38,7 +38,7 @@ export default function TicketListDialog({
 }) {
   const notify = useNotify();
   const queryClient = useQueryClient();
-  const { projectIds } = useProjectFilter();
+  const { projectId, projectIds, onlyAssigned } = useProjectFilter();
   const [tickets, setTickets] = useState([]);
   const [statuses, setStatuses] = useState([]);
   const [attachments, setAttachments] = useState({});
@@ -99,8 +99,8 @@ export default function TicketListDialog({
     );
     notify.success("Статус обновлён");
     // Инвалидируем кэш тикетов
-    const pid = unit?.project_id ?? null;
-    queryClient.invalidateQueries({ queryKey: ticketsKey(pid, projectIds) });
+    const keyPid = onlyAssigned ? projectId : null;
+    queryClient.invalidateQueries({ queryKey: ticketsKey(keyPid, projectIds) });
     // ЯВНО ТРИГГЕРИМ ОБНОВЛЕНИЕ ВНЕШНЕГО ХРАНИЛИЩА (шахматки)
     if (onTicketsChanged) onTicketsChanged();
   };

--- a/src/shared/hooks/useRealtimeUpdates.ts
+++ b/src/shared/hooks/useRealtimeUpdates.ts
@@ -35,17 +35,26 @@ export function useRealtimeUpdates() {
         .on(
           'postgres_changes',
           { event: 'INSERT', schema: 'public', table: 'tickets', filter: `project_id=eq.${pid}` },
-          () => qc.invalidateQueries({ queryKey: ticketsKey(projectId, projectIds) }),
+          () => {
+            const keyPid = perm?.only_assigned_project ? projectId : null;
+            qc.invalidateQueries({ queryKey: ticketsKey(keyPid, projectIds) });
+          },
         )
         .on(
           'postgres_changes',
           { event: 'UPDATE', schema: 'public', table: 'tickets', filter: `project_id=eq.${pid}` },
-          () => qc.invalidateQueries({ queryKey: ticketsKey(projectId, projectIds) }),
+          () => {
+            const keyPid = perm?.only_assigned_project ? projectId : null;
+            qc.invalidateQueries({ queryKey: ticketsKey(keyPid, projectIds) });
+          },
         )
         .on(
           'postgres_changes',
           { event: 'DELETE', schema: 'public', table: 'tickets', filter: `project_id=eq.${pid}` },
-          () => qc.invalidateQueries({ queryKey: ticketsKey(projectId, projectIds) }),
+          () => {
+            const keyPid = perm?.only_assigned_project ? projectId : null;
+            qc.invalidateQueries({ queryKey: ticketsKey(keyPid, projectIds) });
+          },
         )
         .on(
           'postgres_changes',


### PR DESCRIPTION
## Summary
- allow viewing tickets from all projects when the role doesn't restrict by project
- keep invalidation keys consistent in ticket-related mutations and realtime updates
- adjust ticket list dialog cache invalidation accordingly

## Testing
- `npm run lint` *(fails: eslint dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68539aaf5d90832e8fab63d346c80cb1