### PR TITLE
Add letter direction editing in table

### DIFF
--- a/src/entities/correspondence/index.ts
+++ b/src/entities/correspondence/index.ts
@@ -368,6 +368,35 @@ export function useUpdateLetterStatus() {
   });
 }
 
+export function useUpdateLetterDirection() {
+  const qc = useQueryClient();
+  const notify = useNotify();
+  return useMutation({
+    mutationFn: async ({
+      id,
+      direction,
+    }: {
+      id: string;
+      direction: 'incoming' | 'outgoing';
+    }) => {
+      const { data, error } = await supabase
+        .from(LETTERS_TABLE)
+        .update({ direction })
+        .eq('id', Number(id))
+        .select('id, direction')
+        .single();
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: [LETTERS_TABLE] });
+      notify.success('Тип письма обновлён');
+    },
+    onError: (e: any) =>
+      notify.error(`Ошибка обновления типа письма: ${e.message}`),
+  });
+}
+
 export function useLetter(letterId: number | string | undefined) {
   const id = Number(letterId);
   return useQuery({

--- a/src/features/correspondence/LetterDirectionSelect.tsx
+++ b/src/features/correspondence/LetterDirectionSelect.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Select, Tag } from 'antd';
+import type { CorrespondenceLetter } from '@/shared/types/correspondence';
+import { useUpdateLetterDirection } from '@/entities/correspondence';
+
+interface Props {
+  /** ID письма */
+  letterId: string;
+  /** Текущий тип письма */
+  type: CorrespondenceLetter['type'];
+}
+
+/**
+ * Выпадающий список для смены типа письма (входящее/исходящее)
+ * непосредственно в таблице.
+ */
+export default function LetterDirectionSelect({ letterId, type }: Props) {
+  const update = useUpdateLetterDirection();
+  const [editing, setEditing] = React.useState(false);
+
+  const handleChange = (value: 'incoming' | 'outgoing') => {
+    update.mutate({ id: letterId, direction: value });
+    setEditing(false);
+  };
+
+  if (!editing) {
+    return (
+      <Tag
+        color={type === 'incoming' ? 'success' : 'processing'}
+        onClick={() => setEditing(true)}
+        style={{ cursor: 'pointer' }}
+      >
+        {type === 'incoming' ? 'Входящее' : 'Исходящее'}
+      </Tag>
+    );
+  }
+
+  return (
+    <Select
+      size="small"
+      autoFocus
+      open
+      defaultValue={type}
+      onBlur={() => setEditing(false)}
+      onChange={handleChange}
+      loading={update.isPending}
+      options={[
+        { label: 'Входящее', value: 'incoming' },
+        { label: 'Исходящее', value: 'outgoing' },
+      ]}
+      style={{ width: '100%' }}
+    />
+  );
+}

--- a/src/widgets/CorrespondenceTable.tsx
+++ b/src/widgets/CorrespondenceTable.tsx
@@ -1,10 +1,11 @@
 import React, { useMemo, useState, useEffect } from 'react';
 import dayjs from 'dayjs';
-import { Table, Space, Button, Popconfirm, Tag, Tooltip } from 'antd';
+import { Table, Space, Button, Popconfirm, Tooltip } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { DeleteOutlined, PlusOutlined, MailOutlined, BranchesOutlined, LinkOutlined, EyeOutlined } from '@ant-design/icons';
 import { CorrespondenceLetter } from '@/shared/types/correspondence';
 import LetterStatusSelect from '@/features/correspondence/LetterStatusSelect';
+import LetterDirectionSelect from '@/features/correspondence/LetterDirectionSelect';
 
 interface Option { id: number | string; name: string; }
 
@@ -149,12 +150,10 @@ export default function CorrespondenceTable({
     {
       title: 'Тип',
       dataIndex: 'type',
-      width: 100,
+      width: 120,
       sorter: (a, b) => a.type.localeCompare(b.type),
-      render: (v: string) => (
-          <Tag color={v === 'incoming' ? 'success' : 'processing'}>
-            {v === 'incoming' ? 'Входящее' : 'Исходящее'}
-          </Tag>
+      render: (_: string, row: CorrespondenceLetter) => (
+        <LetterDirectionSelect letterId={row.id} type={row.type} />
       ),
     },
     {


### PR DESCRIPTION
## Summary
- allow changing letter direction inline
- add LetterDirectionSelect component
- connect the new component in CorrespondenceTable
- expose mutation to update letter direction

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685454073bdc832eb67ca11e35fdd3a6