### PR TITLE
Add Claims management page

### DIFF
--- a/src/app/Router.tsx
+++ b/src/app/Router.tsx
@@ -9,6 +9,7 @@ import { Backdrop, CircularProgress } from "@mui/material";
 import { useAuthStore } from "@/shared/store/authStore";
 import DashboardPage from "@/pages/DashboardPage/DashboardPage";
 import TicketsPage from "@/pages/TicketsPage/TicketsPage";
+import ClaimsPage from "@/pages/ClaimsPage/ClaimsPage";
 import TicketFormPage from "@/pages/TicketsPage/TicketFormPage";
 import CourtCasesPage from "@/pages/CourtCasesPage/CourtCasesPage";
 import CorrespondencePage from "@/pages/CorrespondencePage/CorrespondencePage";
@@ -84,6 +85,16 @@ export default function AppRouter() {
         data-oid="41m4r4h"
       />
 
+      <Route
+        path="/claims"
+        element={
+          <RequireAuth>
+            <RequirePermission page="claims">
+              <ClaimsPage />
+            </RequirePermission>
+          </RequireAuth>
+        }
+      />
       <Route
         path="/defects"
         element={

--- a/src/entities/claim.ts
+++ b/src/entities/claim.ts
@@ -1,0 +1,94 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/shared/api/supabaseClient';
+import { useProjectFilter } from '@/shared/hooks/useProjectFilter';
+import { useProjectId } from '@/shared/hooks/useProjectId';
+import { useAuthStore } from '@/shared/store/authStore';
+import { filterByProjects } from '@/shared/utils/projectQuery';
+import type { Claim } from '@/shared/types/claim';
+
+const TABLE = 'claims';
+
+export function useClaims() {
+  const { projectId, projectIds, onlyAssigned } = useProjectFilter();
+  return useQuery({
+    queryKey: [TABLE, projectId, projectIds.join(',')],
+    queryFn: async () => {
+      let q = supabase.from(TABLE).select('*');
+      q = filterByProjects(q, projectId, projectIds, onlyAssigned);
+      q = q.order('created_at', { ascending: false });
+      const { data, error } = await q;
+      if (error) throw error;
+      return (data ?? []) as Claim[];
+    },
+    staleTime: 5 * 60_000,
+  });
+}
+
+export function useClaim(id?: number | string) {
+  const { projectId, projectIds, onlyAssigned } = useProjectFilter();
+  const claimId = Number(id);
+  return useQuery({
+    queryKey: [TABLE, claimId],
+    enabled: !!claimId,
+    queryFn: async () => {
+      let q = supabase.from(TABLE).select('*').eq('id', claimId);
+      q = filterByProjects(q, projectId, projectIds, onlyAssigned);
+      q = q.single();
+      const { data, error } = await q;
+      if (error) throw error;
+      return data as Claim;
+    },
+    staleTime: 5 * 60_000,
+  });
+}
+
+export function useCreateClaim() {
+  const projectId = useProjectId();
+  const userId = useAuthStore((s) => s.profile?.id ?? null);
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: Omit<Claim, 'id'>) => {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .insert({ ...payload, project_id: payload.project_id ?? projectId, created_by: userId })
+        .select('*')
+        .single();
+      if (error) throw error;
+      return data as Claim;
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: [TABLE] }),
+  });
+}
+
+export function useUpdateClaim() {
+  const qc = useQueryClient();
+  const { projectId, projectIds, onlyAssigned } = useProjectFilter();
+  return useMutation({
+    mutationFn: async ({ id, updates }: { id: number; updates: Partial<Claim>; }) => {
+      let q = supabase.from(TABLE).update(updates).eq('id', id);
+      q = filterByProjects(q, projectId, projectIds, onlyAssigned);
+      const { data, error } = await q.select('*').single();
+      if (error) throw error;
+      return data as Claim;
+    },
+    onSuccess: (_, { id }) => {
+      qc.invalidateQueries({ queryKey: [TABLE] });
+      qc.invalidateQueries({ queryKey: [TABLE, id] });
+    },
+  });
+}
+
+export function useDeleteClaim() {
+  const qc = useQueryClient();
+  const { projectId, projectIds, onlyAssigned } = useProjectFilter();
+  return useMutation({
+    mutationFn: async (id: number) => {
+      let q = supabase.from(TABLE).delete().eq('id', id);
+      q = filterByProjects(q, projectId, projectIds, onlyAssigned);
+      const { error } = await q;
+      if (error) throw error;
+      return id;
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: [TABLE] }),
+  });
+}

--- a/src/entities/claimStatus.ts
+++ b/src/entities/claimStatus.ts
@@ -1,0 +1,34 @@
+import { supabase } from '@/shared/api/supabaseClient';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { ClaimStatus } from '@/shared/types/claimStatus';
+
+const TABLE = 'claim_statuses';
+
+export const useClaimStatuses = () => {
+  return useQuery({
+    queryKey: [TABLE],
+    queryFn: async () => {
+      const { data, error } = await supabase.from(TABLE).select('*').order('id');
+      if (error) throw error;
+      return data as ClaimStatus[];
+    },
+    staleTime: 5 * 60_000,
+  });
+};
+
+export const useUpdateClaimStatus = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, updates }: { id: number; updates: Partial<ClaimStatus>; }) => {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .update(updates)
+        .eq('id', id)
+        .select('*')
+        .single();
+      if (error) throw error;
+      return data as ClaimStatus;
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: [TABLE] }),
+  });
+};

--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -1,0 +1,153 @@
+import React, { useEffect } from 'react';
+import { Form, Input, Select, DatePicker, Button, Row, Col } from 'antd';
+import dayjs from 'dayjs';
+import { useVisibleProjects } from '@/entities/project';
+import { useUnitsByProject } from '@/entities/unit';
+import { useUsers } from '@/entities/user';
+import { useClaimStatuses } from '@/entities/claimStatus';
+import { useCreateClaim } from '@/entities/claim';
+import { useProjectId } from '@/shared/hooks/useProjectId';
+import { useNotify } from '@/shared/hooks/useNotify';
+import DefectEditableTable from '@/widgets/DefectEditableTable';
+import { useCreateDefects, type NewDefect } from '@/entities/defect';
+
+export interface ClaimFormAntdProps {
+  onCreated?: () => void;
+  initialValues?: Partial<{ project_id: number; unit_ids: number[]; responsible_engineer_id: string }>;
+}
+
+export interface ClaimFormValues {
+  project_id: number | null;
+  unit_ids: number[];
+  status_id: number | null;
+  number: string;
+  claim_date: dayjs.Dayjs | null;
+  received_by_developer_at: dayjs.Dayjs | null;
+  received_by_me_at: dayjs.Dayjs | null;
+  fixed_at: dayjs.Dayjs | null;
+  responsible_engineer_id: string | null;
+  defects?: Array<{ type_id: number | null; fixed_at: dayjs.Dayjs | null; brigade_id: number | null; contractor_id: number | null; description?: string; status_id?: number | null; received_at?: dayjs.Dayjs | null; }>;
+}
+
+export default function ClaimFormAntd({ onCreated, initialValues = {} }: ClaimFormAntdProps) {
+  const [form] = Form.useForm<ClaimFormValues>();
+  const globalProjectId = useProjectId();
+  const projectIdWatch = Form.useWatch('project_id', form) ?? globalProjectId;
+  const projectId = projectIdWatch != null ? Number(projectIdWatch) : null;
+
+  const { data: projects = [] } = useVisibleProjects();
+  const { data: units = [] } = useUnitsByProject(projectId);
+  const { data: users = [] } = useUsers();
+  const { data: statuses = [] } = useClaimStatuses();
+  const create = useCreateClaim();
+  const notify = useNotify();
+  const createDefects = useCreateDefects();
+
+  useEffect(() => {
+    if (initialValues.project_id != null) form.setFieldValue('project_id', initialValues.project_id);
+    else if (globalProjectId) form.setFieldValue('project_id', Number(globalProjectId));
+    if (initialValues.unit_ids) form.setFieldValue('unit_ids', initialValues.unit_ids);
+    if (initialValues.responsible_engineer_id) form.setFieldValue('responsible_engineer_id', initialValues.responsible_engineer_id);
+  }, [globalProjectId, form, initialValues]);
+
+  const onFinish = async (values: ClaimFormValues) => {
+    const { defects: defs, ...rest } = values;
+    if (!defs || defs.length === 0) {
+      notify.error('Добавьте хотя бы один дефект');
+      return;
+    }
+    const newDefs: NewDefect[] = defs.map((d) => ({
+      description: d.description || '',
+      defect_type_id: d.type_id ?? null,
+      defect_status_id: d.status_id ?? null,
+      brigade_id: d.brigade_id ?? null,
+      contractor_id: d.contractor_id ?? null,
+      received_at: d.received_at ? d.received_at.format('YYYY-MM-DD') : null,
+      fixed_at: d.fixed_at ? d.fixed_at.format('YYYY-MM-DD') : null,
+    }));
+    const defectIds = await createDefects.mutateAsync(newDefs);
+    await create.mutateAsync({
+      ...rest,
+      defect_ids: defectIds,
+      project_id: values.project_id ?? globalProjectId,
+      claim_date: values.claim_date ? values.claim_date.format('YYYY-MM-DD') : null,
+      received_by_developer_at: values.received_by_developer_at ? values.received_by_developer_at.format('YYYY-MM-DD') : null,
+      received_by_me_at: values.received_by_me_at ? values.received_by_me_at.format('YYYY-MM-DD') : null,
+      fixed_at: values.fixed_at ? values.fixed_at.format('YYYY-MM-DD') : null,
+    } as any);
+    form.resetFields();
+    onCreated?.();
+  };
+
+  return (
+    <Form form={form} layout="vertical" onFinish={onFinish} autoComplete="off">
+      <Row gutter={16}>
+        <Col span={8}>
+          <Form.Item name="project_id" label="Проект" rules={[{ required: true }]}> 
+            <Select allowClear showSearch options={projects.map((p) => ({ value: p.id, label: p.name }))} />
+          </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item name="unit_ids" label="Объекты" rules={[{ required: true }]}> 
+            <Select
+              mode="multiple"
+              showSearch
+              filterOption={(i, o) => (o?.label ?? '').toLowerCase().includes(i.toLowerCase())}
+              options={units.map((u) => ({ value: u.id, label: u.name }))}
+              disabled={!projectId}
+            />
+          </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item name="responsible_engineer_id" label="Ответственный инженер" rules={[{ required: true }]}> 
+            <Select allowClear showSearch options={users.map((u) => ({ value: u.id, label: u.name }))} />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={8}>
+          <Form.Item name="status_id" label="Статус" rules={[{ required: true }]}> 
+            <Select showSearch options={statuses.map((s) => ({ value: s.id, label: s.name }))} />
+          </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item name="number" label="№ претензии" rules={[{ required: true }]}> 
+            <Input />
+          </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item name="claim_date" label="Дата претензии"> 
+            <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={8}>
+          <Form.Item name="received_by_developer_at" label="Дата получения претензии Застройщиком"> 
+            <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+          </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item name="received_by_me_at" label="Дата получения претензии мною"> 
+            <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+          </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item name="fixed_at" label="Дата устранения претензии"> 
+            <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Form.List name="defects">
+        {(fields, { add, remove }) => (
+          <DefectEditableTable fields={fields} add={add} remove={remove} projectId={projectId} />
+        )}
+      </Form.List>
+      <Form.Item style={{ textAlign: 'right' }}>
+        <Button type="primary" htmlType="submit" loading={create.isPending}>
+          Создать
+        </Button>
+      </Form.Item>
+    </Form>
+  );
+}

--- a/src/features/claim/ClaimStatusSelect.tsx
+++ b/src/features/claim/ClaimStatusSelect.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Select, Tag } from 'antd';
+import { useClaimStatuses } from '@/entities/claimStatus';
+import { useUpdateClaim } from '@/entities/claim';
+
+interface ClaimStatusSelectProps {
+  claimId: number;
+  statusId: number | null;
+  statusColor?: string | null;
+  statusName?: string | null;
+}
+
+export default function ClaimStatusSelect({
+  claimId,
+  statusId,
+  statusColor,
+  statusName,
+}: ClaimStatusSelectProps) {
+  const { data: statuses = [], isLoading } = useClaimStatuses();
+  const update = useUpdateClaim();
+  const [editing, setEditing] = React.useState(false);
+
+  const options = React.useMemo(
+    () => statuses.map((s) => ({ label: <Tag color={s.color ?? undefined}>{s.name}</Tag>, value: s.id })),
+    [statuses],
+  );
+
+  const current = React.useMemo(
+    () =>
+      statuses.find((s) => s.id === statusId) ||
+      (statusId ? { id: statusId, name: statusName ?? String(statusId), color: statusColor ?? undefined } : null),
+    [statuses, statusId, statusName, statusColor],
+  );
+
+  const handleChange = (value: number) => {
+    update.mutate({ id: claimId, updates: { status_id: value } });
+    setEditing(false);
+  };
+
+  if (!editing) {
+    return (
+      <Tag color={current?.color} onClick={() => setEditing(true)} style={{ cursor: 'pointer' }}>
+        {current?.name ?? '—'}
+      </Tag>
+    );
+  }
+
+  return (
+    <Select
+      size="small"
+      autoFocus
+      open
+      defaultValue={statusId ?? undefined}
+      onBlur={() => setEditing(false)}
+      onChange={handleChange}
+      loading={isLoading || update.isPending}
+      optionLabelProp="label"
+      options={options}
+      style={{ width: '100%' }}
+    />
+  );
+}

--- a/src/features/claim/ClaimViewModal.tsx
+++ b/src/features/claim/ClaimViewModal.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Modal, Skeleton, Typography } from 'antd';
+import { useClaim } from '@/entities/claim';
+import ClaimFormAntd from './ClaimFormAntd';
+
+interface Props {
+  open: boolean;
+  claimId: string | number | null;
+  onClose: () => void;
+}
+
+export default function ClaimViewModal({ open, claimId, onClose }: Props) {
+  const { data: claim } = useClaim(claimId ?? undefined);
+  if (!open || !claimId) return null;
+  const titleText = claim
+    ? `Претензия №${claim.number}`
+    : 'Претензия';
+
+  return (
+    <Modal open={open} onCancel={onClose} footer={null} width="80%" title={<Typography.Title level={4} style={{ margin: 0 }}>{titleText}</Typography.Title>}>
+      {claim ? (
+        <ClaimFormAntd initialValues={claim as any} onCreated={onClose} />
+      ) : (
+        <Skeleton active />
+      )}
+    </Modal>
+  );
+}

--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -1,0 +1,123 @@
+import React, { useState, useMemo } from 'react';
+import { ConfigProvider, Alert, Card, Button, Tooltip } from 'antd';
+import ruRU from 'antd/locale/ru_RU';
+import { SettingOutlined, EyeOutlined } from '@ant-design/icons';
+import { useSnackbar } from 'notistack';
+import { useClaims } from '@/entities/claim';
+import { useUsers } from '@/entities/user';
+import { useUnitsByIds } from '@/entities/unit';
+import ClaimsTable from '@/widgets/ClaimsTable';
+import ClaimsFilters from '@/widgets/ClaimsFilters';
+import ClaimFormAntd from '@/features/claim/ClaimFormAntd';
+import ClaimViewModal from '@/features/claim/ClaimViewModal';
+import ClaimStatusSelect from "@/features/claim/ClaimStatusSelect";
+import dayjs from "dayjs";
+import TableColumnsDrawer from '@/widgets/TableColumnsDrawer';
+import type { TableColumnSetting } from '@/shared/types/tableColumnSetting';
+import type { ColumnsType } from 'antd/es/table';
+import type { ClaimWithNames } from '@/shared/types/claimWithNames';
+
+export default function ClaimsPage() {
+  const { enqueueSnackbar } = useSnackbar();
+  const { data: claims = [], isLoading, error } = useClaims();
+  const { data: users = [] } = useUsers();
+  const unitIds = useMemo(() => Array.from(new Set(claims.flatMap((t) => t.unit_ids))), [claims]);
+  const { data: units = [] } = useUnitsByIds(unitIds);
+  const [filters, setFilters] = useState({});
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [viewId, setViewId] = useState<number | null>(null);
+  const [showColumnsDrawer, setShowColumnsDrawer] = useState(false);
+  const [columnsState, setColumnsState] = useState<TableColumnSetting[]>(() => {
+    const base = getBaseColumns();
+    const defaults = Object.keys(base).map((key) => ({ key, title: base[key].title as string, visible: true }));
+    return defaults;
+  });
+
+  const userMap = useMemo(() => {
+    const map = {} as Record<string, string>;
+    (users ?? []).forEach((u) => {
+      map[u.id] = u.name;
+    });
+    return map;
+  }, [users]);
+
+  const unitMap = useMemo(() => {
+    const map = {} as Record<number, string>;
+    (units ?? []).forEach((u) => {
+      map[u.id] = u.name;
+    });
+    return map;
+  }, [units]);
+
+  const claimsWithNames: ClaimWithNames[] = useMemo(
+    () =>
+      claims.map((c) => ({
+        ...c,
+        unitNames: c.unit_ids.map((id) => unitMap[id]).filter(Boolean).join(', '),
+        responsibleEngineerName: userMap[c.responsible_engineer_id] ?? null,
+      })),
+    [claims, unitMap, userMap],
+  );
+
+  const options = useMemo(() => {
+    const uniq = (arr: any[], key: string) => Array.from(new Set(arr.map((i) => i[key]).filter(Boolean))).map((v) => ({ label: v, value: v }));
+    return {
+      projects: uniq(claimsWithNames, 'projectName'),
+      units: uniq(claimsWithNames, 'unitNames'),
+      statuses: uniq(claimsWithNames, 'statusName'),
+      responsibleEngineers: uniq(claimsWithNames, 'responsibleEngineerName'),
+      ids: uniq(claimsWithNames, 'id'),
+    };
+  }, [claimsWithNames]);
+
+  function getBaseColumns() {
+    return {
+      id: { title: 'ID', dataIndex: 'id', width: 80, sorter: (a: any, b: any) => a.id - b.id },
+      projectName: { title: 'Проект', dataIndex: 'projectName', width: 180, sorter: (a: any, b: any) => a.projectName.localeCompare(b.projectName) },
+      unitNames: { title: 'Объекты', dataIndex: 'unitNames', width: 160, sorter: (a: any, b: any) => a.unitNames.localeCompare(b.unitNames) },
+      statusId: { title: 'Статус', dataIndex: 'statusId', width: 160, sorter: (a: any, b: any) => a.statusName.localeCompare(b.statusName), render: (_: any, row: any) => <ClaimStatusSelect claimId={row.id} statusId={row.statusId} statusColor={row.statusColor} statusName={row.statusName} /> },
+      number: { title: '№ претензии', dataIndex: 'number', width: 160, sorter: (a: any, b: any) => a.number.localeCompare(b.number) },
+      claimDate: { title: 'Дата претензии', dataIndex: 'claimDate', width: 120, sorter: (a: any, b: any) => (a.claimDate ? a.claimDate.valueOf() : 0) - (b.claimDate ? b.claimDate.valueOf() : 0), render: (v: any) => fmt(v) },
+      receivedByDeveloperAt: { title: 'Дата получения Застройщиком', dataIndex: 'receivedByDeveloperAt', width: 120, sorter: (a: any, b: any) => (a.receivedByDeveloperAt ? a.receivedByDeveloperAt.valueOf() : 0) - (b.receivedByDeveloperAt ? b.receivedByDeveloperAt.valueOf() : 0), render: (v: any) => fmt(v) },
+      receivedByMeAt: { title: 'Дата получения мной', dataIndex: 'receivedByMeAt', width: 120, sorter: (a: any, b: any) => (a.receivedByMeAt ? a.receivedByMeAt.valueOf() : 0) - (b.receivedByMeAt ? b.receivedByMeAt.valueOf() : 0), render: (v: any) => fmt(v) },
+      fixedAt: { title: 'Дата устранения', dataIndex: 'fixedAt', width: 120, sorter: (a: any, b: any) => (a.fixedAt ? a.fixedAt.valueOf() : 0) - (b.fixedAt ? b.fixedAt.valueOf() : 0), render: (v: any) => fmt(v) },
+      responsibleEngineerName: { title: 'Ответственный инженер', dataIndex: 'responsibleEngineerName', width: 180, sorter: (a: any, b: any) => (a.responsibleEngineerName || '').localeCompare(b.responsibleEngineerName || '') },
+      actions: { title: 'Действия', key: 'actions', width: 80, render: (_: any, record: any) => (
+        <Tooltip title="Просмотр">
+          <Button size="small" type="text" icon={<EyeOutlined />} onClick={() => setViewId(record.id)} />
+        </Tooltip>
+      ) },
+    } as Record<string, ColumnsType<any>[number]>;
+  }
+
+  const baseColumns = useMemo(getBaseColumns, []);
+  const columns: ColumnsType<any> = useMemo(() => columnsState.filter((c) => c.visible).map((c) => baseColumns[c.key]), [columnsState, baseColumns]);
+
+  return (
+    <ConfigProvider locale={ruRU}>
+      <>
+        <Button type="primary" onClick={() => setShowAddForm((p) => !p)} style={{ marginTop: 16, marginRight: 8 }}>
+          {showAddForm ? 'Скрыть форму' : 'Добавить претензию'}
+        </Button>
+        <Button icon={<SettingOutlined />} style={{ marginTop: 16, marginLeft: 8 }} onClick={() => setShowColumnsDrawer(true)} />
+        {showAddForm && (
+          <div style={{ marginTop: 16 }}>
+            <ClaimFormAntd onCreated={() => setShowAddForm(false)} />
+          </div>
+        )}
+        <TableColumnsDrawer open={showColumnsDrawer} columns={columnsState} onChange={setColumnsState} onClose={() => setShowColumnsDrawer(false)} />
+        <div style={{ marginTop: 24 }}>
+          <Card style={{ marginBottom: 24 }}>
+            <ClaimsFilters options={options} onChange={setFilters} />
+          </Card>
+          {error ? <Alert type="error" message={error.message} /> : <ClaimsTable claims={claimsWithNames} filters={filters} loading={isLoading} columns={columns} onView={(id) => setViewId(id)} />}
+        </div>
+        <ClaimViewModal open={viewId !== null} claimId={viewId} onClose={() => setViewId(null)} />
+      </>
+    </ConfigProvider>
+  );
+}
+
+function fmt(d: any) {
+  return d && dayjs.isDayjs(d) && d.isValid() ? d.format('DD.MM.YYYY') : '—';
+}

--- a/src/shared/types/claim.ts
+++ b/src/shared/types/claim.ts
@@ -1,0 +1,13 @@
+export interface Claim {
+  id: number;
+  project_id: number;
+  unit_ids: number[];
+  status_id: number | null;
+  number: string;
+  claim_date: string | null;
+  received_by_developer_at: string | null;
+  received_by_me_at: string | null;
+  fixed_at: string | null;
+  responsible_engineer_id: string | null;
+  defect_ids?: number[];
+}

--- a/src/shared/types/claimFilters.ts
+++ b/src/shared/types/claimFilters.ts
@@ -1,0 +1,11 @@
+import { Dayjs } from 'dayjs';
+
+export interface ClaimFilters {
+  id?: number[];
+  project?: string;
+  units?: string[];
+  status?: string;
+  responsible?: string;
+  number?: string;
+  period?: [Dayjs, Dayjs];
+}

--- a/src/shared/types/claimStatus.ts
+++ b/src/shared/types/claimStatus.ts
@@ -1,0 +1,5 @@
+export interface ClaimStatus {
+  id: number;
+  name: string;
+  color: string | null;
+}

--- a/src/shared/types/claimWithNames.ts
+++ b/src/shared/types/claimWithNames.ts
@@ -1,0 +1,5 @@
+import type { Claim } from '@/shared/types/claim';
+
+export interface ClaimWithNames extends Claim {
+  responsibleEngineerName: string | null;
+}

--- a/src/widgets/ClaimsFilters.tsx
+++ b/src/widgets/ClaimsFilters.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect } from 'react';
+import { Form, DatePicker, Select, Input, Button } from 'antd';
+import type { ClaimFilters } from '@/shared/types/claimFilters';
+
+const { RangePicker } = DatePicker;
+
+export default function ClaimsFilters({ options, onChange, initialValues = {} }: { options: any; onChange: (v: ClaimFilters) => void; initialValues?: Partial<ClaimFilters>; }) {
+  const [form] = Form.useForm();
+  useEffect(() => {
+    form.setFieldsValue(initialValues);
+  }, [initialValues, form]);
+
+  useEffect(() => {
+    onChange(form.getFieldsValue());
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleValuesChange = (_, values: any) => {
+    onChange(values);
+  };
+
+  const reset = () => {
+    form.resetFields();
+    onChange({});
+  };
+
+  return (
+    <Form form={form} layout="vertical" onValuesChange={handleValuesChange} className="filter-grid" style={{ marginBottom: 20 }}>
+      <Form.Item name="period" label="Период получения претензий">
+        <RangePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+      </Form.Item>
+      <Form.Item name="project" label="Проект">
+        <Select allowClear options={options.projects} />
+      </Form.Item>
+      <Form.Item name="units" label="Объекты">
+        <Select mode="multiple" allowClear options={options.units} />
+      </Form.Item>
+      <Form.Item name="id" label="ID">
+        <Select mode="multiple" allowClear options={options.ids} />
+      </Form.Item>
+      <Form.Item name="status" label="Статусы">
+        <Select allowClear options={options.statuses} />
+      </Form.Item>
+      <Form.Item name="number" label="№ претензии">
+        <Input />
+      </Form.Item>
+      <Form.Item name="responsible" label="Ответственный инженер">
+        <Select allowClear options={options.responsibleEngineers} />
+      </Form.Item>
+      <Form.Item>
+        <Button onClick={reset} block>
+          Сброс
+        </Button>
+      </Form.Item>
+    </Form>
+  );
+}

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -1,0 +1,60 @@
+import React, { useMemo } from 'react';
+import dayjs from 'dayjs';
+import { Table, Tooltip, Space, Button, Tag } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { EyeOutlined } from '@ant-design/icons';
+import type { ClaimFilters } from '@/shared/types/claimFilters';
+import type { ClaimWithNames } from '@/shared/types/claimWithNames';
+import ClaimStatusSelect from '@/features/claim/ClaimStatusSelect';
+
+const fmt = (d: any) => (d && dayjs.isDayjs(d) && d.isValid() ? d.format('DD.MM.YYYY') : '—');
+
+interface Props {
+  claims: ClaimWithNames[];
+  filters: ClaimFilters;
+  loading?: boolean;
+  columns?: ColumnsType<any>;
+  onView?: (id: number) => void;
+}
+
+export default function ClaimsTable({ claims, filters, loading, columns: columnsProp, onView }: Props) {
+  const defaultColumns: ColumnsType<any> = useMemo(
+    () => [
+      { title: 'ID', dataIndex: 'id', width: 80, sorter: (a, b) => a.id - b.id },
+      { title: 'Проект', dataIndex: 'projectName', width: 180, sorter: (a, b) => a.projectName.localeCompare(b.projectName) },
+      { title: 'Объекты', dataIndex: 'unitNames', width: 160, sorter: (a, b) => a.unitNames.localeCompare(b.unitNames) },
+      { title: 'Статус', dataIndex: 'statusId', width: 160, sorter: (a, b) => a.statusName.localeCompare(b.statusName), render: (_: any, row: any) => <ClaimStatusSelect claimId={row.id} statusId={row.statusId} statusColor={row.statusColor} statusName={row.statusName} /> },
+      { title: '№ претензии', dataIndex: 'number', width: 160, sorter: (a, b) => a.number.localeCompare(b.number) },
+      { title: 'Дата претензии', dataIndex: 'claimDate', width: 120, sorter: (a, b) => (a.claimDate ? a.claimDate.valueOf() : 0) - (b.claimDate ? b.claimDate.valueOf() : 0), render: (v) => fmt(v) },
+      { title: 'Дата получения Застройщиком', dataIndex: 'receivedByDeveloperAt', width: 120, sorter: (a, b) => (a.receivedByDeveloperAt ? a.receivedByDeveloperAt.valueOf() : 0) - (b.receivedByDeveloperAt ? b.receivedByDeveloperAt.valueOf() : 0), render: (v) => fmt(v) },
+      { title: 'Дата получения мной', dataIndex: 'receivedByMeAt', width: 120, sorter: (a, b) => (a.receivedByMeAt ? a.receivedByMeAt.valueOf() : 0) - (b.receivedByMeAt ? b.receivedByMeAt.valueOf() : 0), render: (v) => fmt(v) },
+      { title: 'Дата устранения', dataIndex: 'fixedAt', width: 120, sorter: (a, b) => (a.fixedAt ? a.fixedAt.valueOf() : 0) - (b.fixedAt ? b.fixedAt.valueOf() : 0), render: (v) => fmt(v) },
+      { title: 'Ответственный инженер', dataIndex: 'responsibleEngineerName', width: 180, sorter: (a, b) => (a.responsibleEngineerName || '').localeCompare(b.responsibleEngineerName || '') },
+      { title: 'Действия', key: 'actions', width: 80, render: (_: any, record) => (
+        <Space size="middle">
+          <Tooltip title="Просмотр">
+            <Button size="small" type="text" icon={<EyeOutlined />} onClick={() => onView && onView(record.id)} />
+          </Tooltip>
+        </Space>
+      ) },
+    ],
+    [onView],
+  );
+
+  const columns = columnsProp ?? defaultColumns;
+
+  const filtered = useMemo(() => {
+    return claims.filter((c) => {
+      const matchesProject = !filters.project || c.projectName === filters.project;
+      const matchesUnits = !filters.units || filters.units.every((u) => c.unitNames.includes(u));
+      const matchesStatus = !filters.status || c.statusName === filters.status;
+      const matchesResponsible = !filters.responsible || c.responsibleEngineerName === filters.responsible;
+      const matchesNumber = !filters.number || c.number.includes(filters.number);
+      const matchesIds = !filters.id || filters.id.includes(c.id);
+      const matchesPeriod = !filters.period || (c.receivedByMeAt && c.receivedByMeAt.isSameOrAfter(filters.period[0], 'day') && c.receivedByMeAt.isSameOrBefore(filters.period[1], 'day'));
+      return matchesProject && matchesUnits && matchesStatus && matchesResponsible && matchesNumber && matchesIds && matchesPeriod;
+    });
+  }, [claims, filters]);
+
+  return <Table rowKey="id" columns={columns} dataSource={filtered} loading={loading} pagination={{ pageSize: 25, showSizeChanger: true }} size="middle" />;
+}


### PR DESCRIPTION
## Summary
- implement claims entities and statuses
- add claim creation form and viewing modal
- add claims table and filters widgets
- create ClaimsPage and integrate into router

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68545a091a38832e92a62e5cdb9397a6