### PR TITLE
Fix default contractor toggle

### DIFF
--- a/src/features/correspondence/AddLetterForm.tsx
+++ b/src/features/correspondence/AddLetterForm.tsx
@@ -61,7 +61,7 @@ export default function AddLetterForm({ onSubmit, parentId = null, initialValues
   const receiverValue = Form.useWatch('receiver', form);
 
   const { files, addFiles, setType, removeFile, reset: resetFiles } = useLetterFiles();
-  const [senderType, setSenderType] = React.useState<'person' | 'contractor'>('person');
+  const [senderType, setSenderType] = React.useState<'person' | 'contractor'>('contractor');
   const [receiverType, setReceiverType] = React.useState<'person' | 'contractor'>('contractor');
   const [personModal, setPersonModal] = React.useState<{ target: 'sender' | 'receiver'; data?: any } | null>(null);
   const [contractorModal, setContractorModal] = React.useState<{ target: 'sender' | 'receiver'; data?: any } | null>(null);
@@ -180,8 +180,8 @@ export default function AddLetterForm({ onSubmit, parentId = null, initialValues
             <Form.Item label="Отправитель" style={{ marginBottom: 0 }}>
               <Space direction="vertical" style={{ width: '100%' }}>
                 <Radio.Group value={senderType} onChange={(e) => setSenderType(e.target.value)}>
-                  <Radio.Button value="person">Физлицо</Radio.Button>
                   <Radio.Button value="contractor">Контрагент</Radio.Button>
+                  <Radio.Button value="person">Физлицо</Radio.Button>
                 </Radio.Group>
                 <Space.Compact style={{ width: '100%' }}>
                   <Form.Item name="sender" noStyle>
@@ -243,8 +243,8 @@ export default function AddLetterForm({ onSubmit, parentId = null, initialValues
             <Form.Item label="Получатель" style={{ marginBottom: 0 }}>
               <Space direction="vertical" style={{ width: '100%' }}>
                 <Radio.Group value={receiverType} onChange={(e) => setReceiverType(e.target.value)}>
-                  <Radio.Button value="person">Физлицо</Radio.Button>
                   <Radio.Button value="contractor">Контрагент</Radio.Button>
+                  <Radio.Button value="person">Физлицо</Radio.Button>
                 </Radio.Group>
                 <Space.Compact style={{ width: '100%' }}>
                   <Form.Item name="receiver" noStyle>

--- a/src/features/correspondence/LetterFormAntdEdit.tsx
+++ b/src/features/correspondence/LetterFormAntdEdit.tsx
@@ -67,7 +67,7 @@ export default function LetterFormAntdEdit({ letterId, onCancel, onSaved, embedd
 
   const senderValue = Form.useWatch('sender', form);
   const receiverValue = Form.useWatch('receiver', form);
-  const [senderType, setSenderType] = React.useState<'person' | 'contractor'>('person');
+  const [senderType, setSenderType] = React.useState<'person' | 'contractor'>('contractor');
   const [receiverType, setReceiverType] = React.useState<'person' | 'contractor'>('contractor');
   const [personModal, setPersonModal] = React.useState<{ target: 'sender' | 'receiver'; data?: any } | null>(null);
   const [contractorModal, setContractorModal] = React.useState<{ target: 'sender' | 'receiver'; data?: any } | null>(null);
@@ -253,8 +253,8 @@ export default function LetterFormAntdEdit({ letterId, onCancel, onSaved, embedd
           <Form.Item label="Отправитель" style={{ marginBottom: 0, ...highlight('sender') }}>
             <Space direction="vertical" style={{ width: '100%' }}>
               <Radio.Group value={senderType} onChange={(e) => setSenderType(e.target.value)}>
-                <Radio.Button value="person">Физлицо</Radio.Button>
                 <Radio.Button value="contractor">Контрагент</Radio.Button>
+                <Radio.Button value="person">Физлицо</Radio.Button>
               </Radio.Group>
               <Space.Compact style={{ width: '100%' }}>
                 <Form.Item name="sender" noStyle>
@@ -324,8 +324,8 @@ export default function LetterFormAntdEdit({ letterId, onCancel, onSaved, embedd
           <Form.Item label="Получатель" style={{ marginBottom: 0, ...highlight('receiver') }}>
             <Space direction="vertical" style={{ width: '100%' }}>
               <Radio.Group value={receiverType} onChange={(e) => setReceiverType(e.target.value)}>
-                <Radio.Button value="person">Физлицо</Radio.Button>
                 <Radio.Button value="contractor">Контрагент</Radio.Button>
+                <Radio.Button value="person">Физлицо</Radio.Button>
               </Radio.Group>
               <Space.Compact style={{ width: '100%' }}>
                 <Form.Item name="receiver" noStyle>


### PR DESCRIPTION
## Summary
- default sender/receiver type to `contractor`
- show contractor first in radio buttons

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68545bffea14832e84ed3d332a73cb79