### PR TITLE
Add claim status admin and permissions

### DIFF
--- a/src/entities/claimStatus.ts
+++ b/src/entities/claimStatus.ts
@@ -38,3 +38,37 @@ export const useUpdateClaimStatus = () => {
     onSuccess: () => qc.invalidateQueries({ queryKey: [TABLE] }),
   });
 };
+
+/**
+ * Хук добавления статуса претензии.
+ */
+export const useAddClaimStatus = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (values: Omit<ClaimStatus, 'id'>) => {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .insert(values)
+        .select('*')
+        .single();
+      if (error) throw error;
+      return data as ClaimStatus;
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: [TABLE] }),
+  });
+};
+
+/**
+ * Хук удаления статуса претензии.
+ */
+export const useDeleteClaimStatus = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: number) => {
+      const { error } = await supabase.from(TABLE).delete().eq('id', id);
+      if (error) throw error;
+      return id;
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: [TABLE] }),
+  });
+};

--- a/src/features/claimStatus/ClaimStatusForm.tsx
+++ b/src/features/claimStatus/ClaimStatusForm.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { Stack, TextField, Button, DialogActions } from '@mui/material';
+
+interface ClaimStatusFormProps {
+  initialData?: { id?: number; name?: string; color?: string | null };
+  onSubmit: (values: { name: string; color: string }) => void;
+  onCancel: () => void;
+}
+
+export default function ClaimStatusForm({ initialData, onSubmit, onCancel }: ClaimStatusFormProps) {
+  const {
+    control,
+    handleSubmit,
+    formState: { isSubmitting },
+  } = useForm({
+    defaultValues: {
+      name: initialData?.name ?? '',
+      color: initialData?.color ?? '#1976d2',
+    },
+  });
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} noValidate>
+      <Stack spacing={2} sx={{ minWidth: 320 }}>
+        <Controller
+          name="name"
+          control={control}
+          rules={{ required: 'Название обязательно' }}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              label="Название статуса"
+              fullWidth
+              required
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+              autoFocus
+            />
+          )}
+        />
+        <Controller
+          name="color"
+          control={control}
+          rules={{ required: 'Цвет обязателен' }}
+          render={({ field }) => (
+            <TextField
+              {...field}
+              label="Цвет статуса"
+              type="color"
+              fullWidth
+              inputProps={{ style: { height: 48, padding: 0 } }}
+            />
+          )}
+        />
+        <DialogActions sx={{ px: 0 }}>
+          <Button onClick={onCancel}>Отмена</Button>
+          <Button type="submit" variant="contained" disabled={isSubmitting}>
+            Сохранить
+          </Button>
+        </DialogActions>
+      </Stack>
+    </form>
+  );
+}

--- a/src/pages/UnitsPage/AdminPage.tsx
+++ b/src/pages/UnitsPage/AdminPage.tsx
@@ -5,6 +5,7 @@ import ProjectsTable from "../../widgets/ProjectsTable";
 import ContractorAdmin from "../../widgets/ContractorAdmin";
 import BrigadesAdmin from "../../widgets/BrigadesAdmin";
 import TicketStatusesAdmin from "../../widgets/TicketStatusesAdmin";
+import ClaimStatusesAdmin from "../../widgets/ClaimStatusesAdmin";
 import DefectTypesAdmin from "../../widgets/DefectTypesAdmin";
 import DefectStatusesAdmin from "../../widgets/DefectStatusesAdmin";
 import DefectDeadlinesAdmin from "../../widgets/DefectDeadlinesAdmin";
@@ -25,6 +26,11 @@ export default function AdminPage() {
         <BrigadesAdmin pageSize={25} rowsPerPageOptions={[10, 25, 50, 100]} />
 
         <TicketStatusesAdmin
+          pageSize={25}
+          rowsPerPageOptions={[10, 25, 50, 100]}
+        />
+
+        <ClaimStatusesAdmin
           pageSize={25}
           rowsPerPageOptions={[10, 25, 50, 100]}
         />

--- a/src/widgets/ClaimStatusesAdmin.tsx
+++ b/src/widgets/ClaimStatusesAdmin.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import {
+  useClaimStatuses,
+  useAddClaimStatus,
+  useUpdateClaimStatus,
+  useDeleteClaimStatus,
+} from '@/entities/claimStatus';
+import { Button, Stack, Dialog, DialogTitle, DialogContent, IconButton, Box } from '@mui/material';
+import AdminDataGrid from '@/shared/ui/AdminDataGrid';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import ClaimStatusForm from '@/features/claimStatus/ClaimStatusForm';
+
+interface Props {
+  pageSize?: number;
+  rowsPerPageOptions?: number[];
+}
+
+export default function ClaimStatusesAdmin({ pageSize = 25, rowsPerPageOptions = [10, 25, 50, 100] }: Props) {
+  const { data = [], isLoading } = useClaimStatuses();
+  const addMutation = useAddClaimStatus();
+  const updateMutation = useUpdateClaimStatus();
+  const deleteMutation = useDeleteClaimStatus();
+
+  const [open, setOpen] = React.useState(false);
+  const [editRow, setEditRow] = React.useState<any>(null);
+
+  const handleAdd = () => { setEditRow(null); setOpen(true); };
+  const handleEdit = (row: any) => { setEditRow(row); setOpen(true); };
+  const handleDelete = (id: number) => {
+    if (window.confirm('Удалить статус претензии?')) deleteMutation.mutate(id);
+  };
+
+  const handleSubmit = async (values: { name: string; color: string }) => {
+    if (editRow) {
+      await (updateMutation.mutateAsync as any)({ id: editRow.id, updates: values });
+    } else {
+      await (addMutation.mutateAsync as any)(values);
+    }
+    setOpen(false);
+  };
+
+  const columns = [
+    { field: 'id', headerName: 'ID', width: 80 },
+    { field: 'name', headerName: 'Название статуса', flex: 1 },
+    {
+      field: 'color',
+      headerName: 'Цвет',
+      width: 90,
+      renderCell: (params: any) => (
+        <Box
+          sx={{
+            width: 32,
+            height: 24,
+            bgcolor: params.value,
+            border: '1px solid #bbb',
+            borderRadius: 0.5,
+          }}
+        />
+      ),
+    },
+    {
+      field: 'actions',
+      headerName: '',
+      width: 100,
+      sortable: false,
+      renderCell: (params: any) => (
+        <Stack direction="row" spacing={0}>
+          <IconButton size="small" onClick={() => handleEdit(params.row)} color="primary">
+            <EditIcon fontSize="small" />
+          </IconButton>
+          <IconButton size="small" color="error" onClick={() => handleDelete(params.row.id)}>
+            <DeleteIcon fontSize="small" />
+          </IconButton>
+        </Stack>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <Dialog open={open} onClose={() => setOpen(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>{editRow ? 'Редактировать статус' : 'Добавить статус'}</DialogTitle>
+        <DialogContent>
+          <ClaimStatusForm
+            initialData={editRow}
+            onSubmit={handleSubmit}
+            onCancel={() => setOpen(false)}
+          />
+        </DialogContent>
+      </Dialog>
+      <AdminDataGrid
+        title="Статусы претензий"
+        rows={data}
+        columns={columns}
+        loading={isLoading}
+        onAdd={handleAdd}
+        pageSize={pageSize}
+        rowsPerPageOptions={rowsPerPageOptions}
+      />
+    </>
+  );
+}

--- a/src/widgets/RolePermissionsAdmin.tsx
+++ b/src/widgets/RolePermissionsAdmin.tsx
@@ -12,6 +12,7 @@ const PAGES = [
   'dashboard',
   'structure',
   'tickets',
+  'claims',
   'defects',
   'court-cases',
   'correspondence',


### PR DESCRIPTION
## Summary
- manage claim statuses in admin
- display claim page toggle in role permissions
- show admin form for claim statuses

## Testing
- `npm run lint` *(fails: eslint plugins missing)*

------
https://chatgpt.com/codex/tasks/task_e_685462bf4020832e8995041aec088e4b