### PR TITLE
Add lawsuit claim types admin

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -1224,4 +1224,18 @@
     "is_nullable": "YES",
     "column_default": null
   }
+  {
+    "table_name": "lawsuit_claim_types",
+    "column_name": "id",
+    "data_type": "bigint",
+    "is_nullable": "NO",
+    "column_default": "nextval('lawsuit_claim_types_id_seq'::regclass)"
+  },
+  {
+    "table_name": "lawsuit_claim_types",
+    "column_name": "name",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": null
+  },
 ]

--- a/src/entities/lawsuitClaimType.ts
+++ b/src/entities/lawsuitClaimType.ts
@@ -1,0 +1,67 @@
+import { supabase } from '@/shared/api/supabaseClient';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { LawsuitClaimType } from '@/shared/types/lawsuitClaimType';
+
+const TABLE = 'lawsuit_claim_types';
+const KEY = [TABLE];
+
+export const useLawsuitClaimTypes = () =>
+  useQuery<LawsuitClaimType[]>({
+    queryKey: KEY,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select('id, name')
+        .order('id');
+      if (error) throw error;
+      return data ?? [];
+    },
+    staleTime: 5 * 60_000,
+  });
+
+const invalidate = (qc: ReturnType<typeof useQueryClient>) =>
+  qc.invalidateQueries({ queryKey: KEY });
+
+export const useAddLawsuitClaimType = () => {
+  const qc = useQueryClient();
+  return useMutation<LawsuitClaimType, Error, string>({
+    mutationFn: async (name: string): Promise<LawsuitClaimType> => {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .insert({ name })
+        .select('id, name')
+        .single();
+      if (error) throw error;
+      return data as LawsuitClaimType;
+    },
+    onSuccess: () => invalidate(qc),
+  });
+};
+
+export const useUpdateLawsuitClaimType = () => {
+  const qc = useQueryClient();
+  return useMutation<LawsuitClaimType, Error, { id: number; name: string }>({
+    mutationFn: async ({ id, name }): Promise<LawsuitClaimType> => {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .update({ name })
+        .eq('id', id)
+        .select('id, name')
+        .single();
+      if (error) throw error;
+      return data as LawsuitClaimType;
+    },
+    onSuccess: () => invalidate(qc),
+  });
+};
+
+export const useDeleteLawsuitClaimType = () => {
+  const qc = useQueryClient();
+  return useMutation<void, Error, number>({
+    mutationFn: async (id: number): Promise<void> => {
+      const { error } = await supabase.from(TABLE).delete().eq('id', id);
+      if (error) throw error;
+    },
+    onSuccess: () => invalidate(qc),
+  });
+};

--- a/src/features/lawsuitClaimType/LawsuitClaimTypeForm.tsx
+++ b/src/features/lawsuitClaimType/LawsuitClaimTypeForm.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import {
+  Stack,
+  TextField,
+  DialogActions,
+  Button,
+  CircularProgress,
+} from '@mui/material';
+
+interface LawsuitClaimTypeFormProps {
+  initialData?: { id?: number; name?: string };
+  onSubmit: (values: { name: string }) => void;
+  onCancel: () => void;
+}
+
+export default function LawsuitClaimTypeForm({
+  initialData,
+  onSubmit,
+  onCancel,
+}: LawsuitClaimTypeFormProps) {
+  const {
+    control,
+    handleSubmit,
+    formState: { isSubmitting },
+  } = useForm({
+    defaultValues: { name: initialData?.name ?? '' },
+  });
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} noValidate>
+      <Stack spacing={2} sx={{ minWidth: 320 }}>
+        <Controller
+          name="name"
+          control={control}
+          rules={{ required: 'Название обязательно' }}
+          render={({ field, fieldState }) => (
+            <TextField
+              {...field}
+              label="Название требования"
+              fullWidth
+              required
+              error={!!fieldState.error}
+              helperText={fieldState.error?.message}
+              autoFocus
+            />
+          )}
+        />
+
+        <DialogActions sx={{ px: 0 }}>
+          <Button onClick={onCancel}>Отмена</Button>
+          <Button
+            type="submit"
+            variant="contained"
+            disabled={isSubmitting}
+            startIcon={
+              isSubmitting && <CircularProgress size={18} color="inherit" />
+            }
+          >
+            Сохранить
+          </Button>
+        </DialogActions>
+      </Stack>
+    </form>
+  );
+}

--- a/src/pages/UnitsPage/AdminPage.tsx
+++ b/src/pages/UnitsPage/AdminPage.tsx
@@ -11,6 +11,7 @@ import DefectStatusesAdmin from "../../widgets/DefectStatusesAdmin";
 import DefectDeadlinesAdmin from "../../widgets/DefectDeadlinesAdmin";
 import UsersTable from "../../widgets/UsersTable";
 import CourtCaseStatusesAdmin from "../../widgets/CourtCaseStatusesAdmin";
+import LawsuitClaimTypesAdmin from "../../widgets/LawsuitClaimTypesAdmin";
 import LetterTypesAdmin from "../../widgets/LetterTypesAdmin";
 import AttachmentTypesAdmin from "../../widgets/AttachmentTypesAdmin";
 import LetterStatusesAdmin from "../../widgets/LetterStatusesAdmin";
@@ -51,6 +52,11 @@ export default function AdminPage() {
         />
 
         <CourtCaseStatusesAdmin
+          pageSize={25}
+          rowsPerPageOptions={[10, 25, 50, 100]}
+        />
+
+        <LawsuitClaimTypesAdmin
           pageSize={25}
           rowsPerPageOptions={[10, 25, 50, 100]}
         />

--- a/src/shared/types/lawsuitClaimType.ts
+++ b/src/shared/types/lawsuitClaimType.ts
@@ -1,0 +1,4 @@
+export interface LawsuitClaimType {
+  id: number;
+  name: string;
+}

--- a/src/widgets/LawsuitClaimTypesAdmin.tsx
+++ b/src/widgets/LawsuitClaimTypesAdmin.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react';
+import { GridActionsCellItem } from '@mui/x-data-grid';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import AdminDataGrid from '@/shared/ui/AdminDataGrid';
+import {
+  useLawsuitClaimTypes,
+  useAddLawsuitClaimType,
+  useUpdateLawsuitClaimType,
+  useDeleteLawsuitClaimType,
+} from '@/entities/lawsuitClaimType';
+import LawsuitClaimTypeForm from '@/features/lawsuitClaimType/LawsuitClaimTypeForm';
+import { Dialog, DialogTitle, DialogContent } from '@mui/material';
+import { useNotify } from '@/shared/hooks/useNotify';
+
+interface LawsuitClaimTypesAdminProps {
+  pageSize?: number;
+  rowsPerPageOptions?: number[];
+}
+
+export default function LawsuitClaimTypesAdmin({
+  pageSize = 25,
+  rowsPerPageOptions = [10, 25, 50, 100],
+}: LawsuitClaimTypesAdminProps) {
+  const notify = useNotify();
+  const { data = [], isPending } = useLawsuitClaimTypes();
+  const add = useAddLawsuitClaimType();
+  const update = useUpdateLawsuitClaimType();
+  const remove = useDeleteLawsuitClaimType();
+
+  const [modal, setModal] = useState<null | { mode: 'add' | 'edit'; data?: any }>(null);
+
+  const columns = [
+    { field: 'id', headerName: 'ID', width: 80 },
+    { field: 'name', headerName: 'Название требования', flex: 1 },
+    {
+      field: 'actions',
+      type: 'actions',
+      width: 110,
+      getActions: ({ row }: any) => [
+        <GridActionsCellItem
+          key="edit"
+          icon={<EditIcon />}
+          label="Редактировать"
+          onClick={() => setModal({ mode: 'edit', data: row })}
+        />,
+        <GridActionsCellItem
+          key="del"
+          icon={<DeleteIcon color="error" />}
+          label="Удалить"
+          onClick={() => {
+            if (!window.confirm('Удалить запись?')) return;
+            remove.mutate(row.id, {
+              onSuccess: () => notify.success('Запись удалена'),
+              onError: (e) => notify.error(e.message),
+            });
+          }}
+        />,
+      ],
+    },
+  ];
+
+  const close = () => setModal(null);
+  const ok = (msg: string) => {
+    close();
+    notify.success(msg);
+  };
+
+  return (
+    <>
+      {modal && (
+        <Dialog open onClose={close} maxWidth="xs" fullWidth>
+          <DialogTitle>
+            {modal.mode === 'add' ? 'Новый вид требования' : 'Редактировать вид требования'}
+          </DialogTitle>
+          <DialogContent dividers>
+            <LawsuitClaimTypeForm
+              initialData={modal.mode === 'edit' ? modal.data : undefined}
+              onSubmit={(d) =>
+                modal.mode === 'add'
+                  ? add.mutate(d.name, {
+                      onSuccess: () => ok('Запись создана'),
+                      onError: (e) => notify.error(e.message),
+                    })
+                  : update.mutate(
+                      { id: modal.data.id, name: d.name },
+                      {
+                        onSuccess: () => ok('Запись обновлена'),
+                        onError: (e) => notify.error(e.message),
+                      },
+                    )
+              }
+              onCancel={close}
+            />
+          </DialogContent>
+        </Dialog>
+      )}
+
+      <AdminDataGrid
+        title="Виды исковых требований"
+        rows={data}
+        columns={columns}
+        loading={isPending}
+        onAdd={() => setModal({ mode: 'add' })}
+        pageSize={pageSize}
+        rowsPerPageOptions={rowsPerPageOptions}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add `lawsuit_claim_types` table to DB structure
- implement entity hooks for lawsuit claim types
- add form and admin widget
- register widget on admin page

## Testing
- `npm run lint` *(fails: parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_685471281b2c832e826d8d83899e5154