### PR TITLE
Update claims page layout and attachments

### DIFF
--- a/src/features/claim/ExportClaimsButton.tsx
+++ b/src/features/claim/ExportClaimsButton.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Button, Tooltip } from 'antd';
+import { DownloadOutlined } from '@ant-design/icons';
+import ExcelJS from 'exceljs';
+import { saveAs } from 'file-saver';
+import dayjs from 'dayjs';
+import type { ClaimWithNames } from '@/shared/types/claimWithNames';
+import type { ClaimFilters } from '@/shared/types/claimFilters';
+import { filterClaims } from '@/shared/utils/claimFilter';
+
+export interface ExportClaimsButtonProps {
+  claims: ClaimWithNames[];
+  filters: ClaimFilters;
+}
+
+export default function ExportClaimsButton({ claims, filters }: ExportClaimsButtonProps) {
+  const handleClick = React.useCallback(async () => {
+    const rows = filterClaims(claims, filters).map((c) => ({
+      ID: c.id,
+      Проект: c.projectName,
+      Объекты: c.unitNames,
+      '№ претензии': c.number,
+      'Дата претензии': c.claimDate ? c.claimDate.format('DD.MM.YYYY') : '',
+      'Дата получения Застройщиком': c.receivedByDeveloperAt
+        ? c.receivedByDeveloperAt.format('DD.MM.YYYY')
+        : '',
+      'Дата регистрации претензии': c.registeredAt ? c.registeredAt.format('DD.MM.YYYY') : '',
+      'Дата устранения претензии': c.fixedAt ? c.fixedAt.format('DD.MM.YYYY') : '',
+      Статус: c.statusName,
+      'Ответственный инженер': c.responsibleEngineerName ?? '',
+    }));
+    const wb = new ExcelJS.Workbook();
+    const ws = wb.addWorksheet('Claims');
+    if (rows.length) {
+      ws.columns = Object.keys(rows[0]).map((k) => ({ header: k, key: k }));
+      rows.forEach((r) => ws.addRow(r));
+    }
+    const buffer = await wb.xlsx.writeBuffer();
+    saveAs(new Blob([buffer], { type: 'application/octet-stream' }), 'claims.xlsx');
+  }, [claims, filters]);
+
+  return (
+    <Tooltip title="Выгрузить в Excel">
+      <Button icon={<DownloadOutlined />} onClick={handleClick} />
+    </Tooltip>
+  );
+}

--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo } from 'react';
 import { ConfigProvider, Alert, Card, Button, Tooltip } from 'antd';
 import ruRU from 'antd/locale/ru_RU';
 import { SettingOutlined, EyeOutlined } from '@ant-design/icons';
+import ExportClaimsButton from '@/features/claim/ExportClaimsButton';
 import { useSnackbar } from 'notistack';
 import { useClaims } from '@/entities/claim';
 import { useUsers } from '@/entities/user';
@@ -112,7 +113,13 @@ export default function ClaimsPage() {
         <Button type="primary" onClick={() => setShowAddForm((p) => !p)} style={{ marginTop: 16, marginRight: 8 }}>
           {showAddForm ? 'Скрыть форму' : 'Добавить претензию'}
         </Button>
+        <Button onClick={() => setShowFilters((p) => !p)} style={{ marginTop: 16 }}>
+          {showFilters ? 'Скрыть фильтры' : 'Показать фильтры'}
+        </Button>
         <Button icon={<SettingOutlined />} style={{ marginTop: 16, marginLeft: 8 }} onClick={() => setShowColumnsDrawer(true)} />
+        <span style={{ marginTop: 16, marginLeft: 8, display: 'inline-block' }}>
+          <ExportClaimsButton claims={claimsWithNames} filters={filters} />
+        </span>
         {showAddForm && (
           <div style={{ marginTop: 16 }}>
             <ClaimFormAntd onCreated={() => setShowAddForm(false)} />
@@ -120,9 +127,6 @@ export default function ClaimsPage() {
         )}
         <TableColumnsDrawer open={showColumnsDrawer} columns={columnsState} onChange={setColumnsState} onClose={() => setShowColumnsDrawer(false)} />
         <div style={{ marginTop: 24 }}>
-          <Button onClick={() => setShowFilters((p) => !p)} style={{ marginBottom: 8 }}>
-            {showFilters ? 'Скрыть фильтры' : 'Показать фильтры'}
-          </Button>
           {showFilters && (
             <Card style={{ marginBottom: 24 }}>
               <ClaimsFilters options={options} onChange={setFilters} />

--- a/src/shared/types/claim.ts
+++ b/src/shared/types/claim.ts
@@ -11,4 +11,5 @@ export interface Claim {
   fixed_at: string | null;
   responsible_engineer_id: string | null;
   defect_ids?: number[];
+  attachment_ids?: number[];
 }

--- a/src/shared/types/claimFile.ts
+++ b/src/shared/types/claimFile.ts
@@ -1,0 +1,17 @@
+/** Вложение претензии, загруженное на сервер */
+export interface RemoteClaimFile {
+  id: string | number;
+  name: string;
+  original_name?: string | null;
+  path: string;
+  url: string;
+  type: string;
+  attachment_type_id: number | null;
+  attachment_type_name?: string;
+}
+
+/** Новый файл для вложения претензии */
+export interface NewClaimFile {
+  file: File;
+  type_id: number | null;
+}

--- a/src/shared/utils/claimFilter.ts
+++ b/src/shared/utils/claimFilter.ts
@@ -1,0 +1,31 @@
+import { ClaimFilters } from '@/shared/types/claimFilters';
+import { Dayjs } from 'dayjs';
+
+export function filterClaims<T extends {
+  id: number;
+  projectName?: string;
+  unitNames?: string;
+  statusName?: string;
+  responsibleEngineerName?: string | null;
+  number?: string;
+  registeredAt?: Dayjs | null;
+}>(rows: T[], f: ClaimFilters): T[] {
+  return rows.filter((r) => {
+    if (f.id && f.id.length > 0 && !f.id.includes(r.id)) return false;
+    if (f.project && r.projectName !== f.project) return false;
+    if (f.units && f.units.length > 0 && r.unitNames) {
+      const units = r.unitNames.split(',').map((u) => u.trim());
+      const ok = f.units.every((u) => units.includes(u));
+      if (!ok) return false;
+    }
+    if (f.status && r.statusName !== f.status) return false;
+    if (f.responsible && r.responsibleEngineerName !== f.responsible) return false;
+    if (f.number && (!r.number || !r.number.includes(f.number))) return false;
+    if (f.period && f.period.length === 2) {
+      const [from, to] = f.period;
+      if (!r.registeredAt) return false;
+      if (r.registeredAt.isBefore(from, 'day') || r.registeredAt.isAfter(to, 'day')) return false;
+    }
+    return true;
+  });
+}


### PR DESCRIPTION
## Summary
- add Excel export for claims
- reorder fields in claim form and add +45 days helper
- add file upload for claims and support attachments in create hook
- hide defect file uploads on claims
- align claims page controls with tickets page

## Testing
- `npm run lint` *(fails: eslint not configured)*
- `npm run build` *(fails: vite not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68547329900c832eaee8172b492e9d5d