### PR TITLE
feat(admin): allow claims edit/delete

### DIFF
--- a/src/shared/types/rolePermission.ts
+++ b/src/shared/types/rolePermission.ts
@@ -22,15 +22,17 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<RoleName, RolePermission> = {
       'correspondence',
       'admin',
     ],
-    edit_tables: ['tickets', 'defects', 'court_cases', 'letters'],
-    delete_tables: ['tickets', 'defects', 'court_cases', 'letters'],
+    // Администратор имеет полные права на все справочники
+    edit_tables: ['tickets', 'defects', 'court_cases', 'letters', 'claims'],
+    delete_tables: ['tickets', 'defects', 'court_cases', 'letters', 'claims'],
     only_assigned_project: false,
   },
   ENGINEER: {
     role_name: 'ENGINEER',
     pages: ['dashboard', 'structure', 'tickets', 'claims', 'defects', 'court-cases', 'correspondence'],
-    edit_tables: ['tickets', 'defects', 'letters'],
-    delete_tables: ['tickets', 'defects', 'letters'],
+    // Инженер теперь может управлять претензиями
+    edit_tables: ['tickets', 'defects', 'letters', 'claims'],
+    delete_tables: ['tickets', 'defects', 'letters', 'claims'],
     only_assigned_project: false,
   },
   LAWYER: {

--- a/src/widgets/RolePermissionsAdmin.tsx
+++ b/src/widgets/RolePermissionsAdmin.tsx
@@ -19,7 +19,9 @@ const PAGES = [
   'admin',
 ];
 
-const TABLES = ['tickets', 'defects', 'court_cases', 'letters'];
+// Список таблиц, для которых можно настроить права на редактирование и удаление
+// Дополнен таблицей "claims" для управления претензиями
+const TABLES = ['tickets', 'defects', 'court_cases', 'letters', 'claims'];
 
 export default function RolePermissionsAdmin() {
   const { data = [], isLoading } = useRolePermissions();


### PR DESCRIPTION
## Summary
- add claims table to editable tables in RolePermissionsAdmin
- update default role permissions for claims editing/deleting

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685477e5590c832eb8dfdb4a4407ebce