### PR TITLE
Fix claims page fields and table

### DIFF
--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -55,10 +55,21 @@ export default function ClaimFormAntd({ onCreated, initialValues = {} }: ClaimFo
   const removeFile = (idx: number) => setFiles((p) => p.filter((_, i) => i !== idx));
 
   useEffect(() => {
-    if (initialValues.project_id != null) form.setFieldValue('project_id', initialValues.project_id);
-    else if (globalProjectId) form.setFieldValue('project_id', Number(globalProjectId));
+    if (initialValues.project_id != null) {
+      form.setFieldValue('project_id', initialValues.project_id);
+    } else if (globalProjectId) {
+      form.setFieldValue('project_id', Number(globalProjectId));
+    }
     if (initialValues.unit_ids) form.setFieldValue('unit_ids', initialValues.unit_ids);
-    if (initialValues.responsible_engineer_id) form.setFieldValue('responsible_engineer_id', initialValues.responsible_engineer_id);
+    if (initialValues.responsible_engineer_id)
+      form.setFieldValue('responsible_engineer_id', initialValues.responsible_engineer_id);
+    if (initialValues.status_id != null) form.setFieldValue('status_id', initialValues.status_id);
+    if (initialValues.number) form.setFieldValue('number', initialValues.number);
+    if (initialValues.claim_date) form.setFieldValue('claim_date', dayjs(initialValues.claim_date));
+    if (initialValues.received_by_developer_at)
+      form.setFieldValue('received_by_developer_at', dayjs(initialValues.received_by_developer_at));
+    if (initialValues.registered_at) form.setFieldValue('registered_at', dayjs(initialValues.registered_at));
+    if (initialValues.fixed_at) form.setFieldValue('fixed_at', dayjs(initialValues.fixed_at));
   }, [globalProjectId, form, initialValues]);
 
   const onFinish = async (values: ClaimFormValues) => {
@@ -140,21 +151,28 @@ export default function ClaimFormAntd({ onCreated, initialValues = {} }: ClaimFo
       </Row>
       <Row gutter={16}>
         <Col span={8}>
-          <Form.Item name="registered_at" label="Дата регистрации претензии">
+          <Form.Item
+            name="registered_at"
+            label={
+              <span>
+                Дата регистрации претензии
+                <Tag
+                  color="blue"
+                  onClick={() => {
+                    const val = form.getFieldValue('registered_at');
+                    if (val) {
+                      form.setFieldValue('fixed_at', dayjs(val).add(45, 'day'));
+                    }
+                  }}
+                  style={{ cursor: 'pointer', marginLeft: 8 }}
+                >
+                  +45 дней
+                </Tag>
+              </span>
+            }
+          >
             <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
           </Form.Item>
-          <Tag
-            color="blue"
-            onClick={() => {
-              const val = form.getFieldValue('registered_at');
-              if (val) {
-                form.setFieldValue('fixed_at', dayjs(val).add(45, 'day'));
-              }
-            }}
-            style={{ cursor: 'pointer', marginTop: 4 }}
-          >
-            +45 дней
-          </Tag>
         </Col>
         <Col span={8}>
           <Form.Item name="fixed_at" label="Дата устранения претензии">

--- a/src/shared/types/claimWithNames.ts
+++ b/src/shared/types/claimWithNames.ts
@@ -1,5 +1,23 @@
 import type { Claim } from '@/shared/types/claim';
+import type { Dayjs } from 'dayjs';
 
 export interface ClaimWithNames extends Claim {
+  /** Название проекта, к которому относится претензия */
+  projectName: string;
+  /** Наименование статуса претензии */
+  statusName: string;
+  /** Цвет статуса для отображения */
+  statusColor: string | null;
+  /** ФИО ответственного инженера */
   responsibleEngineerName: string | null;
+  /** Список объектов одной строкой */
+  unitNames?: string;
+  /** Дата претензии */
+  claimDate: Dayjs | null;
+  /** Дата получения претензии застройщиком */
+  receivedByDeveloperAt: Dayjs | null;
+  /** Дата регистрации претензии */
+  registeredAt: Dayjs | null;
+  /** Дата устранения претензии */
+  fixedAt: Dayjs | null;
 }

--- a/src/widgets/DefectEditableTable.tsx
+++ b/src/widgets/DefectEditableTable.tsx
@@ -303,11 +303,7 @@ export default function DefectEditableTable({ fields, add, remove, projectId, fi
         ),
       },
       {
-        title: (
-          <span>
-            Кем устраняется<span style={{ color: 'red' }}>*</span>
-          </span>
-        ),
+        title: 'Кем устраняется',
         dataIndex: 'executor',
         width: 180,
         ellipsis: true,


### PR DESCRIPTION
## Summary
- show `+45 дней` chip beside registration date label
- allow missing executor field for defects
- load project and status info in claims queries
- fill claim form fields when viewing a claim
- extend `ClaimWithNames` type with extra fields

## Testing
- `npm run lint` *(fails: Parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68547a5897f0832e9ce6b0d645370e85