### PR TITLE
Fix court case claims UX

### DIFF
--- a/src/features/courtCase/AddCourtCaseFormAntd.tsx
+++ b/src/features/courtCase/AddCourtCaseFormAntd.tsx
@@ -125,6 +125,12 @@ export default function AddCourtCaseFormAntd({
   const [showClaims, setShowClaims] = useState(false);
   const { caseFiles, addFiles: addCaseFiles, setType: setCaseFileType, removeFile: removeCaseFile, reset: resetCaseFiles } = useCaseFiles();
 
+  useEffect(() => {
+    if (showClaims && !(form.getFieldValue('claims')?.length)) {
+      form.setFieldValue('claims', [{}]);
+    }
+  }, [showClaims, form]);
+
   const { data: projectPersons = [], isPending: personsLoading } = useQuery({
     queryKey: ['projectPersons'],
     queryFn: async () => {

--- a/src/features/courtCase/CourtCaseFormAntdEdit.tsx
+++ b/src/features/courtCase/CourtCaseFormAntdEdit.tsx
@@ -16,6 +16,7 @@ import { useNotify } from '@/shared/hooks/useNotify';
 import { downloadZip } from '@/shared/utils/downloadZip';
 import { signedUrl } from '@/entities/courtCase';
 import { useChangedFields } from '@/shared/hooks/useChangedFields';
+import CaseClaimsEditorTable from '@/widgets/CaseClaimsEditorTable';
 
 export interface CourtCaseFormAntdEditProps {
   caseId: string;
@@ -341,6 +342,9 @@ export default function CourtCaseFormAntdEdit({
           </Form.Item>
         </Col>
       </Row>
+      <div style={{ marginBottom: 16 }}>
+        <CaseClaimsEditorTable caseId={Number(caseId)} />
+      </div>
       <Form.Item label="Файлы" style={attachments.attachmentsChanged ? { background: '#fffbe6', padding: 4, borderRadius: 2 } : {}}>
         <FileDropZone onFiles={handleFiles} />
         <Button

--- a/src/widgets/CaseClaimsEditorTable.tsx
+++ b/src/widgets/CaseClaimsEditorTable.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { Table, Select, InputNumber, Button, Tooltip, Popconfirm, Skeleton } from 'antd';
+import { PlusOutlined, DeleteOutlined } from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import { useLawsuitClaimTypes } from '@/entities/lawsuitClaimType';
+import { useCaseClaims, useAddCaseClaims, useUpdateCaseClaim, useDeleteCaseClaim } from '@/entities/courtCaseClaim';
+import type { CourtCaseClaim } from '@/shared/types/courtCaseClaim';
+
+interface Props {
+  caseId: number;
+}
+
+/**
+ * Editable table of lawsuit claims for court case editing form.
+ */
+export default function CaseClaimsEditorTable({ caseId }: Props) {
+  const { data: claimTypes = [], isPending: typesLoading } = useLawsuitClaimTypes();
+  const { data: claims = [], isPending: claimsLoading } = useCaseClaims(caseId);
+  const addClaim = useAddCaseClaims();
+  const updateClaim = useUpdateCaseClaim();
+  const deleteClaim = useDeleteCaseClaim();
+
+  const totals = React.useMemo(() => {
+    return claims.reduce(
+      (acc, c) => {
+        acc.claimed += Number(c.claimed_amount) || 0;
+        acc.confirmed += Number(c.confirmed_amount) || 0;
+        acc.paid += Number(c.paid_amount) || 0;
+        acc.agreed += Number(c.agreed_amount) || 0;
+        return acc;
+      },
+      { claimed: 0, confirmed: 0, paid: 0, agreed: 0 },
+    );
+  }, [claims]);
+
+  const handleAdd = async () => {
+    if (!claimTypes.length) return;
+    await addClaim.mutateAsync([
+      {
+        case_id: caseId,
+        claim_type_id: claimTypes[0].id,
+        claimed_amount: null,
+        confirmed_amount: null,
+        paid_amount: null,
+        agreed_amount: null,
+      },
+    ]);
+  };
+
+  const columns: ColumnsType<CourtCaseClaim> = [
+    {
+      title: 'Требование',
+      dataIndex: 'claim_type_id',
+      width: 280,
+      render: (v: number, row) => (
+        <Select
+          size="small"
+          style={{ width: '100%' }}
+          loading={typesLoading}
+          value={v}
+          options={claimTypes.map((t) => ({ value: t.id, label: t.name }))}
+          onChange={(val) => updateClaim.mutate({ id: row.id, updates: { claim_type_id: val } })}
+        />
+      ),
+    },
+    {
+      title: 'Заявлено',
+      dataIndex: 'claimed_amount',
+      width: 150,
+      render: (v: number | null, row) => (
+        <InputNumber
+          min={0}
+          style={{ width: '100%' }}
+          value={v ?? undefined}
+          onChange={(val) => updateClaim.mutate({ id: row.id, updates: { claimed_amount: val ?? null } })}
+        />
+      ),
+    },
+    {
+      title: 'Подтверждено',
+      dataIndex: 'confirmed_amount',
+      width: 150,
+      render: (v: number | null, row) => (
+        <InputNumber
+          min={0}
+          style={{ width: '100%' }}
+          value={v ?? undefined}
+          onChange={(val) => updateClaim.mutate({ id: row.id, updates: { confirmed_amount: val ?? null } })}
+        />
+      ),
+    },
+    {
+      title: 'Оплачено',
+      dataIndex: 'paid_amount',
+      width: 150,
+      render: (v: number | null, row) => (
+        <InputNumber
+          min={0}
+          style={{ width: '100%' }}
+          value={v ?? undefined}
+          onChange={(val) => updateClaim.mutate({ id: row.id, updates: { paid_amount: val ?? null } })}
+        />
+      ),
+    },
+    {
+      title: 'Согласовано',
+      dataIndex: 'agreed_amount',
+      width: 150,
+      render: (v: number | null, row) => (
+        <InputNumber
+          min={0}
+          style={{ width: '100%' }}
+          value={v ?? undefined}
+          onChange={(val) => updateClaim.mutate({ id: row.id, updates: { agreed_amount: val ?? null } })}
+        />
+      ),
+    },
+    {
+      title: '',
+      dataIndex: 'actions',
+      width: 60,
+      render: (_: unknown, row) => (
+        <Popconfirm
+          title="Удалить требование?"
+          okText="Да"
+          cancelText="Нет"
+          onConfirm={() => deleteClaim.mutate(row.id)}
+        >
+          <Tooltip title="Удалить">
+            <Button size="small" type="text" danger icon={<DeleteOutlined />} />
+          </Tooltip>
+        </Popconfirm>
+      ),
+    },
+  ];
+
+  if (claimsLoading) {
+    return <Skeleton active paragraph={{ rows: 3 }} />;
+  }
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
+        <span style={{ fontWeight: 500 }}>Исковые требования</span>
+        <Button type="dashed" icon={<PlusOutlined />} onClick={handleAdd}>
+          Добавить требование
+        </Button>
+      </div>
+      <Table
+        size="small"
+        pagination={false}
+        rowKey="id"
+        columns={columns}
+        dataSource={claims}
+        summary={() => (
+          <Table.Summary.Row>
+            <Table.Summary.Cell index={0}>Итого</Table.Summary.Cell>
+            <Table.Summary.Cell index={1}>{totals.claimed}</Table.Summary.Cell>
+            <Table.Summary.Cell index={2}>{totals.confirmed}</Table.Summary.Cell>
+            <Table.Summary.Cell index={3}>{totals.paid}</Table.Summary.Cell>
+            <Table.Summary.Cell index={4}>{totals.agreed}</Table.Summary.Cell>
+            <Table.Summary.Cell index={5} />
+          </Table.Summary.Row>
+        )}
+      />
+    </div>
+  );
+}

--- a/src/widgets/CourtCaseClaimsTable.tsx
+++ b/src/widgets/CourtCaseClaimsTable.tsx
@@ -35,7 +35,7 @@ export default function CourtCaseClaimsTable({ fields, add, remove }: Props) {
     {
       title: 'Требование',
       dataIndex: 'type',
-      width: 200,
+      width: 280,
       render: (_: unknown, field: any) => (
         <Form.Item name={[field.name, 'claim_type_id']} rules={[{ required: true, message: 'Выберите вид' }]} noStyle>
           <Select options={claimTypes.map((t) => ({ value: t.id, label: t.name }))} />


### PR DESCRIPTION
## Summary
- auto-add first claim row when showing claims form
- widen claim type column
- allow editing case claims
- display editable claims table when viewing a case

## Testing
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_6854db91a8dc832e97039ddc0c6b4522