### PR TITLE
Format claim amounts as rubles

### DIFF
--- a/src/shared/utils/formatCurrency.ts
+++ b/src/shared/utils/formatCurrency.ts
@@ -1,0 +1,21 @@
+export const currencyFormatter = new Intl.NumberFormat('ru-RU', {
+  style: 'currency',
+  currency: 'RUB',
+});
+
+/**
+ * Форматирует число в валюту рубли с разделением разрядов.
+ */
+export function formatRub(value: number | null | undefined): string {
+  if (value == null) return '';
+  return currencyFormatter.format(value);
+}
+
+/**
+ * Парсит строку из поля ввода рублевой суммы.
+ */
+export function parseRub(value?: string | null): number | undefined {
+  if (!value) return undefined;
+  const num = parseFloat(value.replace(/[\s₽]/g, '').replace(',', '.'));
+  return Number.isNaN(num) ? undefined : num;
+}

--- a/src/widgets/CaseClaimsEditorTable.tsx
+++ b/src/widgets/CaseClaimsEditorTable.tsx
@@ -1,5 +1,14 @@
 import React from 'react';
-import { Table, Select, InputNumber, Button, Tooltip, Popconfirm, Skeleton } from 'antd';
+import {
+  Table,
+  Select,
+  InputNumber,
+  Button,
+  Tooltip,
+  Popconfirm,
+  Skeleton,
+} from 'antd';
+import { formatRub, parseRub } from '@/shared/utils/formatCurrency';
 import { PlusOutlined, DeleteOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import { useLawsuitClaimTypes } from '@/entities/lawsuitClaimType';
@@ -72,7 +81,11 @@ export default function CaseClaimsEditorTable({ caseId }: Props) {
           min={0}
           style={{ width: '100%' }}
           value={v ?? undefined}
-          onChange={(val) => updateClaim.mutate({ id: row.id, updates: { claimed_amount: val ?? null } })}
+          formatter={(val) => formatRub(Number(val))}
+          parser={parseRub}
+          onChange={(val) =>
+            updateClaim.mutate({ id: row.id, updates: { claimed_amount: val ?? null } })
+          }
         />
       ),
     },
@@ -85,7 +98,11 @@ export default function CaseClaimsEditorTable({ caseId }: Props) {
           min={0}
           style={{ width: '100%' }}
           value={v ?? undefined}
-          onChange={(val) => updateClaim.mutate({ id: row.id, updates: { confirmed_amount: val ?? null } })}
+          formatter={(val) => formatRub(Number(val))}
+          parser={parseRub}
+          onChange={(val) =>
+            updateClaim.mutate({ id: row.id, updates: { confirmed_amount: val ?? null } })
+          }
         />
       ),
     },
@@ -98,6 +115,8 @@ export default function CaseClaimsEditorTable({ caseId }: Props) {
           min={0}
           style={{ width: '100%' }}
           value={v ?? undefined}
+          formatter={(val) => formatRub(Number(val))}
+          parser={parseRub}
           onChange={(val) => updateClaim.mutate({ id: row.id, updates: { paid_amount: val ?? null } })}
         />
       ),
@@ -111,7 +130,11 @@ export default function CaseClaimsEditorTable({ caseId }: Props) {
           min={0}
           style={{ width: '100%' }}
           value={v ?? undefined}
-          onChange={(val) => updateClaim.mutate({ id: row.id, updates: { agreed_amount: val ?? null } })}
+          formatter={(val) => formatRub(Number(val))}
+          parser={parseRub}
+          onChange={(val) =>
+            updateClaim.mutate({ id: row.id, updates: { agreed_amount: val ?? null } })
+          }
         />
       ),
     },
@@ -155,10 +178,10 @@ export default function CaseClaimsEditorTable({ caseId }: Props) {
         summary={() => (
           <Table.Summary.Row>
             <Table.Summary.Cell index={0}>Итого</Table.Summary.Cell>
-            <Table.Summary.Cell index={1}>{totals.claimed}</Table.Summary.Cell>
-            <Table.Summary.Cell index={2}>{totals.confirmed}</Table.Summary.Cell>
-            <Table.Summary.Cell index={3}>{totals.paid}</Table.Summary.Cell>
-            <Table.Summary.Cell index={4}>{totals.agreed}</Table.Summary.Cell>
+            <Table.Summary.Cell index={1}>{formatRub(totals.claimed)}</Table.Summary.Cell>
+            <Table.Summary.Cell index={2}>{formatRub(totals.confirmed)}</Table.Summary.Cell>
+            <Table.Summary.Cell index={3}>{formatRub(totals.paid)}</Table.Summary.Cell>
+            <Table.Summary.Cell index={4}>{formatRub(totals.agreed)}</Table.Summary.Cell>
             <Table.Summary.Cell index={5} />
           </Table.Summary.Row>
         )}

--- a/src/widgets/CourtCaseClaimsTable.tsx
+++ b/src/widgets/CourtCaseClaimsTable.tsx
@@ -1,5 +1,15 @@
 import React from 'react';
-import { Table, Form, Select, InputNumber, Button, Tooltip, Skeleton, Typography } from 'antd';
+import {
+  Table,
+  Form,
+  Select,
+  InputNumber,
+  Button,
+  Tooltip,
+  Skeleton,
+  Typography,
+} from 'antd';
+import { formatRub, parseRub } from '@/shared/utils/formatCurrency';
 import { PlusOutlined, DeleteOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import { useLawsuitClaimTypes } from '@/entities/lawsuitClaimType';
@@ -48,7 +58,12 @@ export default function CourtCaseClaimsTable({ fields, add, remove }: Props) {
       width: 150,
       render: (_: unknown, field: any) => (
         <Form.Item name={[field.name, 'claimed_amount']} noStyle>
-          <InputNumber min={0} style={{ width: '100%' }} />
+          <InputNumber
+            min={0}
+            style={{ width: '100%' }}
+            formatter={(v) => formatRub(Number(v))}
+            parser={parseRub}
+          />
         </Form.Item>
       ),
     },
@@ -58,7 +73,12 @@ export default function CourtCaseClaimsTable({ fields, add, remove }: Props) {
       width: 150,
       render: (_: unknown, field: any) => (
         <Form.Item name={[field.name, 'confirmed_amount']} noStyle>
-          <InputNumber min={0} style={{ width: '100%' }} />
+          <InputNumber
+            min={0}
+            style={{ width: '100%' }}
+            formatter={(v) => formatRub(Number(v))}
+            parser={parseRub}
+          />
         </Form.Item>
       ),
     },
@@ -68,7 +88,12 @@ export default function CourtCaseClaimsTable({ fields, add, remove }: Props) {
       width: 150,
       render: (_: unknown, field: any) => (
         <Form.Item name={[field.name, 'paid_amount']} noStyle>
-          <InputNumber min={0} style={{ width: '100%' }} />
+          <InputNumber
+            min={0}
+            style={{ width: '100%' }}
+            formatter={(v) => formatRub(Number(v))}
+            parser={parseRub}
+          />
         </Form.Item>
       ),
     },
@@ -78,7 +103,12 @@ export default function CourtCaseClaimsTable({ fields, add, remove }: Props) {
       width: 150,
       render: (_: unknown, field: any) => (
         <Form.Item name={[field.name, 'agreed_amount']} noStyle>
-          <InputNumber min={0} style={{ width: '100%' }} />
+          <InputNumber
+            min={0}
+            style={{ width: '100%' }}
+            formatter={(v) => formatRub(Number(v))}
+            parser={parseRub}
+          />
         </Form.Item>
       ),
     },
@@ -117,10 +147,10 @@ export default function CourtCaseClaimsTable({ fields, add, remove }: Props) {
             <Table.Summary.Cell index={0}>
               <Typography.Text strong>Итого</Typography.Text>
             </Table.Summary.Cell>
-            <Table.Summary.Cell index={1}>{totals.claimed}</Table.Summary.Cell>
-            <Table.Summary.Cell index={2}>{totals.confirmed}</Table.Summary.Cell>
-            <Table.Summary.Cell index={3}>{totals.paid}</Table.Summary.Cell>
-            <Table.Summary.Cell index={4}>{totals.agreed}</Table.Summary.Cell>
+            <Table.Summary.Cell index={1}>{formatRub(totals.claimed)}</Table.Summary.Cell>
+            <Table.Summary.Cell index={2}>{formatRub(totals.confirmed)}</Table.Summary.Cell>
+            <Table.Summary.Cell index={3}>{formatRub(totals.paid)}</Table.Summary.Cell>
+            <Table.Summary.Cell index={4}>{formatRub(totals.agreed)}</Table.Summary.Cell>
             <Table.Summary.Cell index={5} />
           </Table.Summary.Row>
         )}


### PR DESCRIPTION
## Summary
- show ruble currency formatting for claim amounts
- add currency helper

## Testing
- `npm run lint` *(fails: missing eslint plugins)*

------
https://chatgpt.com/codex/tasks/task_e_6854de4ff2d0832eaf3a268fb893bdc0