### PR TITLE
Fix claims table actions and view defects

### DIFF
--- a/src/features/claim/ClaimViewModal.tsx
+++ b/src/features/claim/ClaimViewModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Modal, Skeleton, Typography } from 'antd';
 import { useClaim } from '@/entities/claim';
+import TicketDefectsTable from '@/widgets/TicketDefectsTable';
 import ClaimFormAntd from './ClaimFormAntd';
 
 interface Props {
@@ -19,7 +20,14 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
   return (
     <Modal open={open} onCancel={onClose} footer={null} width="80%" title={<Typography.Title level={4} style={{ margin: 0 }}>{titleText}</Typography.Title>}>
       {claim ? (
-        <ClaimFormAntd initialValues={claim as any} onCreated={onClose} />
+        <>
+          <ClaimFormAntd initialValues={claim as any} onCreated={onClose} />
+          {claim.defect_ids?.length ? (
+            <div style={{ marginTop: 16, overflowX: 'auto' }}>
+              <TicketDefectsTable defectIds={claim.defect_ids} />
+            </div>
+          ) : null}
+        </>
       ) : (
         <Skeleton active />
       )}


### PR DESCRIPTION
## Summary
- show delete button on claims table and pass correct status field
- enable deleting claims from columns drawer logic
- render claim defects table in view modal with scroll

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854dd7d352c832e8dd14d548f7f5a74