### PR TITLE
Fix claim view modal

### DIFF
--- a/src/entities/claim.ts
+++ b/src/entities/claim.ts
@@ -6,7 +6,7 @@ import { useAuthStore } from '@/shared/store/authStore';
 import { filterByProjects } from '@/shared/utils/projectQuery';
 import type { Claim } from '@/shared/types/claim';
 import type { ClaimWithNames } from '@/shared/types/claimWithNames';
-import { addClaimAttachments } from '@/entities/attachment';
+import { addClaimAttachments, ATTACH_BUCKET } from '@/entities/attachment';
 import dayjs from 'dayjs';
 
 const TABLE = 'claims';
@@ -164,4 +164,21 @@ export function useDeleteClaim() {
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: [TABLE] }),
   });
+}
+
+export async function getClaimAttachments(id: number) {
+  const { data, error } = await supabase
+    .from('attachments')
+    .select('id, storage_path, file_url, file_type, attachment_type_id, original_name')
+    .like('storage_path', `claims/${id}/%`);
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function signedUrl(path: string, filename = ''): Promise<string> {
+  const { data, error } = await supabase.storage
+    .from(ATTACH_BUCKET)
+    .createSignedUrl(path, 60, { download: filename || undefined });
+  if (error) throw error;
+  return data.signedUrl;
 }

--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -11,11 +11,19 @@ import { useCreateClaim } from '@/entities/claim';
 import { useProjectId } from '@/shared/hooks/useProjectId';
 import { useNotify } from '@/shared/hooks/useNotify';
 import DefectEditableTable from '@/widgets/DefectEditableTable';
+import TicketDefectsTable from '@/widgets/TicketDefectsTable';
 import { useCreateDefects, type NewDefect } from '@/entities/defect';
+import { signedUrl as claimSignedUrl } from '@/entities/claim';
 
 export interface ClaimFormAntdProps {
   onCreated?: () => void;
   initialValues?: Partial<{ project_id: number; unit_ids: number[]; responsible_engineer_id: string }>;
+  /** Отображать форму в режиме просмотра */
+  viewMode?: boolean;
+  /** Идентификаторы связанных дефектов */
+  defectIds?: number[];
+  /** Существующие файлы претензии */
+  attachments?: any[];
 }
 
 export interface ClaimFormValues {
@@ -31,7 +39,13 @@ export interface ClaimFormValues {
   defects?: Array<{ type_id: number | null; fixed_at: dayjs.Dayjs | null; brigade_id: number | null; contractor_id: number | null; description?: string; status_id?: number | null; received_at?: dayjs.Dayjs | null; }>;
 }
 
-export default function ClaimFormAntd({ onCreated, initialValues = {} }: ClaimFormAntdProps) {
+export default function ClaimFormAntd({
+  onCreated,
+  initialValues = {},
+  viewMode = false,
+  defectIds = [],
+  attachments = [],
+}: ClaimFormAntdProps) {
   const [form] = Form.useForm<ClaimFormValues>();
   const [files, setFiles] = useState<{ file: File; type_id: number | null }[]>([]);
   const { data: attachmentTypes = [] } = useAttachmentTypes();
@@ -73,6 +87,7 @@ export default function ClaimFormAntd({ onCreated, initialValues = {} }: ClaimFo
   }, [globalProjectId, form, initialValues]);
 
   const onFinish = async (values: ClaimFormValues) => {
+    if (viewMode) return;
     const { defects: defs, ...rest } = values;
     if (!defs || defs.length === 0) {
       notify.error('Добавьте хотя бы один дефект');
@@ -158,7 +173,9 @@ export default function ClaimFormAntd({ onCreated, initialValues = {} }: ClaimFo
                 Дата регистрации претензии
                 <Tag
                   color="blue"
-                  onClick={() => {
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={(e) => {
+                    e.stopPropagation();
                     const val = form.getFieldValue('registered_at');
                     if (val) {
                       form.setFieldValue('fixed_at', dayjs(val).add(45, 'day'));
@@ -185,52 +202,92 @@ export default function ClaimFormAntd({ onCreated, initialValues = {} }: ClaimFo
           </Form.Item>
         </Col>
       </Row>
-      <Form.List name="defects">
-        {(fields, { add, remove }) => (
-          <DefectEditableTable
-            fields={fields}
-            add={add}
-            remove={remove}
-            projectId={projectId}
-            showFiles={false}
-          />
-        )}
-      </Form.List>
-      <Form.Item label="Файлы">
-        <FileDropZone onFiles={handleDropFiles} />
-        {files.map((f, i) => (
-          <Row key={i} gutter={8} align="middle" style={{ marginTop: 4 }}>
-            <Col flex="auto">
-              <span>{f.file.name}</span>
-            </Col>
-            <Col flex="160px">
-              <Select
-                style={{ width: '100%' }}
-                placeholder="Тип файла"
-                value={f.type_id ?? undefined}
-                onChange={(v) => setType(i, v)}
-                allowClear
-              >
-                {attachmentTypes.map((t) => (
-                  <Select.Option key={t.id} value={t.id}>
-                    {t.name}
-                  </Select.Option>
-                ))}
-              </Select>
-            </Col>
-            <Col>
-              <Button type="text" danger onClick={() => removeFile(i)}>
-                Удалить
-              </Button>
-            </Col>
-          </Row>
-        ))}
-      </Form.Item>
-      <Form.Item style={{ textAlign: 'right' }}>
-        <Button type="primary" htmlType="submit" loading={create.isPending}>
-          Создать
-        </Button>
-      </Form.Item>
+      {viewMode ? (
+        defectIds.length ? <TicketDefectsTable defectIds={defectIds} /> : null
+      ) : (
+        <Form.List name="defects">
+          {(fields, { add, remove }) => (
+            <DefectEditableTable
+              fields={fields}
+              add={add}
+              remove={remove}
+              projectId={projectId}
+              showFiles={false}
+            />
+          )}
+        </Form.List>
+      )}
+      {viewMode ? (
+        attachments.length ? (
+          <div style={{ marginTop: 16 }}>
+            <b>Файлы:</b>
+            <ul style={{ paddingLeft: 20 }}>
+              {attachments.map((f: any) => (
+                <li key={f.id}>
+                  <a
+                    href="#"
+                    onClick={async (e) => {
+                      e.preventDefault();
+                      const url = await claimSignedUrl(
+                        f.storage_path,
+                        f.original_name ?? 'file',
+                      );
+                      const a = document.createElement('a');
+                      a.href = url;
+                      a.download = f.original_name ?? 'file';
+                      document.body.appendChild(a);
+                      a.click();
+                      a.remove();
+                    }}
+                  >
+                    {f.original_name ?? f.storage_path.split('/').pop()}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null
+      ) : (
+        <>
+          <Form.Item label="Файлы">
+            <FileDropZone onFiles={handleDropFiles} />
+            {files.map((f, i) => (
+              <Row key={i} gutter={8} align="middle" style={{ marginTop: 4 }}>
+                <Col flex="auto">
+                  <span>{f.file.name}</span>
+                </Col>
+                <Col flex="160px">
+                  <Select
+                    style={{ width: '100%' }}
+                    placeholder="Тип файла"
+                    value={f.type_id ?? undefined}
+                    onChange={(v) => setType(i, v)}
+                    allowClear
+                  >
+                    {attachmentTypes.map((t) => (
+                      <Select.Option key={t.id} value={t.id}>
+                        {t.name}
+                      </Select.Option>
+                    ))}
+                  </Select>
+                </Col>
+                <Col>
+                  <Button type="text" danger onClick={() => removeFile(i)}>
+                    Удалить
+                  </Button>
+                </Col>
+              </Row>
+            ))}
+          </Form.Item>
+        </>
+      )}
+      {!viewMode && (
+        <Form.Item style={{ textAlign: 'right' }}>
+          <Button type="primary" htmlType="submit" loading={create.isPending}>
+            Создать
+          </Button>
+        </Form.Item>
+      )}
     </Form>
   );
 }

--- a/src/features/claim/ClaimViewModal.tsx
+++ b/src/features/claim/ClaimViewModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Modal, Skeleton, Typography } from 'antd';
-import { useClaim } from '@/entities/claim';
-import TicketDefectsTable from '@/widgets/TicketDefectsTable';
+import { useClaim, getClaimAttachments } from '@/entities/claim';
+import { useQuery } from '@tanstack/react-query';
 import ClaimFormAntd from './ClaimFormAntd';
 
 interface Props {
@@ -12,6 +12,7 @@ interface Props {
 
 export default function ClaimViewModal({ open, claimId, onClose }: Props) {
   const { data: claim } = useClaim(claimId ?? undefined);
+  const { data: files = [] } = useQuery(['claim-files', claimId], () => getClaimAttachments(Number(claimId)), { enabled: !!claimId });
   if (!open || !claimId) return null;
   const titleText = claim
     ? `Претензия №${claim.number}`
@@ -20,14 +21,13 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
   return (
     <Modal open={open} onCancel={onClose} footer={null} width="80%" title={<Typography.Title level={4} style={{ margin: 0 }}>{titleText}</Typography.Title>}>
       {claim ? (
-        <>
-          <ClaimFormAntd initialValues={claim as any} onCreated={onClose} />
-          {claim.defect_ids?.length ? (
-            <div style={{ marginTop: 16, overflowX: 'auto' }}>
-              <TicketDefectsTable defectIds={claim.defect_ids} />
-            </div>
-          ) : null}
-        </>
+        <ClaimFormAntd
+          initialValues={claim as any}
+          onCreated={onClose}
+          viewMode
+          defectIds={claim.defect_ids}
+          attachments={files}
+        />
       ) : (
         <Skeleton active />
       )}


### PR DESCRIPTION
## Summary
- prevent date picker from opening when clicking the `+45 дней` tag
- support view mode in `ClaimFormAntd`
- display claim defects and attachments inside view modal
- add helpers to fetch claim attachments and create signed URLs

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npx tsc --noEmit` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6854e1c219c8832e960229fc5a3d087f