### PR TITLE
Fix claim view defects and attachments

### DIFF
--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -158,6 +158,7 @@ export default function ClaimFormAntd({ onCreated, initialValues = {} }: ClaimFo
                 Дата регистрации претензии
                 <Tag
                   color="blue"
+                  onMouseDown={(e) => e.preventDefault()}
                   onClick={() => {
                     const val = form.getFieldValue('registered_at');
                     if (val) {

--- a/src/features/claim/ClaimViewModal.tsx
+++ b/src/features/claim/ClaimViewModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Modal, Skeleton, Typography } from 'antd';
-import { useClaim } from '@/entities/claim';
+import { useClaim, useClaimAttachments, signedUrl } from '@/entities/claim';
 import TicketDefectsTable from '@/widgets/TicketDefectsTable';
 import ClaimFormAntd from './ClaimFormAntd';
 
@@ -12,6 +12,7 @@ interface Props {
 
 export default function ClaimViewModal({ open, claimId, onClose }: Props) {
   const { data: claim } = useClaim(claimId ?? undefined);
+  const { data: files = [] } = useClaimAttachments(claim?.id);
   if (!open || !claimId) return null;
   const titleText = claim
     ? `Претензия №${claim.number}`
@@ -23,8 +24,37 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
         <>
           <ClaimFormAntd initialValues={claim as any} onCreated={onClose} />
           {claim.defect_ids?.length ? (
-            <div style={{ marginTop: 16, overflowX: 'auto' }}>
+            <div style={{ marginTop: 16 }}>
               <TicketDefectsTable defectIds={claim.defect_ids} />
+            </div>
+          ) : null}
+          {files.length ? (
+            <div style={{ marginTop: 16 }}>
+              <b>Файлы:</b>
+              <ul style={{ paddingLeft: 20 }}>
+                {files.map((f: any) => (
+                  <li key={f.id}>
+                    <a
+                      href="#"
+                      onClick={async (e) => {
+                        e.preventDefault();
+                        const url = await signedUrl(
+                          f.storage_path,
+                          f.original_name ?? 'file',
+                        );
+                        const a = document.createElement('a');
+                        a.href = url;
+                        a.download = f.original_name ?? 'file';
+                        document.body.appendChild(a);
+                        a.click();
+                        a.remove();
+                      }}
+                    >
+                      {f.original_name ?? f.storage_path.split('/').pop()}
+                    </a>
+                  </li>
+                ))}
+              </ul>
             </div>
           ) : null}
         </>


### PR DESCRIPTION
## Summary
- prevent datepicker focus when clicking `+45 дней`
- display defects and attachments in claim view
- support fetching claim attachments

## Testing
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_6854e1c219c8832e960229fc5a3d087f