### PR TITLE
Fix undefined variable in ticket deletion

### DIFF
--- a/src/entities/ticket.ts
+++ b/src/entities/ticket.ts
@@ -487,6 +487,7 @@ export function useDeleteTicket() {
   const projectIds = useAuthStore((s) => s.profile?.project_ids) ?? [];
   const role = useAuthStore((s) => s.profile?.role as RoleName | undefined);
   const { data: perm } = useRolePermission(role);
+  const { onlyAssigned } = useProjectFilter();
   const qc = useQueryClient();
   const notify = useNotify();
 


### PR DESCRIPTION
## Summary
- retrieve `onlyAssigned` in `useDeleteTicket` so cache invalidation works

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854e7378ee8832ebd5c102128e4b52e