### PR TITLE
feat(defects): show claim links

### DIFF
--- a/src/entities/claim.ts
+++ b/src/entities/claim.ts
@@ -99,6 +99,44 @@ export function useClaim(id?: number | string) {
 }
 
 /**
+ * Получить список претензий по всем проектам (минимальный набор полей).
+ */
+export function useClaimsSimpleAll() {
+  return useQuery<Array<{ id: number; project_id: number; unit_ids: number[]; defect_ids: number[] }>>({
+    queryKey: ['claims-simple-all'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select('id, project_id, unit_ids, defect_ids');
+      if (error) throw error;
+      return (data ?? []) as Array<{ id: number; project_id: number; unit_ids: number[]; defect_ids: number[] }>;
+    },
+    staleTime: 5 * 60_000,
+  });
+}
+
+/**
+ * Получить список претензий текущего проекта (минимальный набор полей).
+ */
+export function useClaimsSimple() {
+  const { projectId, projectIds, onlyAssigned, enabled } = useProjectFilter();
+  return useQuery<Array<{ id: number; project_id: number; unit_ids: number[]; defect_ids: number[] }>>({
+    queryKey: ['claims-simple', projectId, projectIds.join(',')],
+    enabled,
+    queryFn: async () => {
+      let q = supabase
+        .from(TABLE)
+        .select('id, project_id, unit_ids, defect_ids');
+      q = filterByProjects(q, projectId, projectIds, onlyAssigned);
+      const { data, error } = await q;
+      if (error) throw error;
+      return (data ?? []) as Array<{ id: number; project_id: number; unit_ids: number[]; defect_ids: number[] }>;
+    },
+    staleTime: 5 * 60_000,
+  });
+}
+
+/**
  * Хук создания новой претензии.
  */
 export function useCreateClaim() {

--- a/src/shared/types/defect.ts
+++ b/src/shared/types/defect.ts
@@ -28,6 +28,8 @@ export interface DefectRecord {
 export interface DefectWithInfo extends DefectRecord {
   /** ID замечаний, содержащих данный дефект */
   ticketIds: number[];
+  /** ID претензий, связанных с дефектом */
+  claimIds: number[];
   /** Идентификаторы объектов, связанные с замечаниями */
   unitIds: number[];
   /** Названия объектов, объединённые в строку */

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -55,6 +55,13 @@ export default function DefectsTable({
       render: (v: number[]) => v.join(", "),
     },
     {
+      title: "ID претензии",
+      dataIndex: "claimIds",
+      sorter: (a, b) =>
+        a.claimIds.join(",").localeCompare(b.claimIds.join(",")),
+      render: (v: number[]) => v.join(", "),
+    },
+    {
       title: (
         <span>
           Прошло дней


### PR DESCRIPTION
## Summary
- extend defect data to include claim IDs
- provide hooks to load claims for lookup
- merge claim info into defect list
- add claim column to defects tables

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6854e6c71b54832eb315221bea6e16dc