### PR TITLE
Fix claims deletion with defect cleanup

### DIFF
--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -107,7 +107,7 @@ export default function ClaimsPage() {
             okText="Да"
             cancelText="Нет"
             onConfirm={async () => {
-              await deleteClaimMutation.mutateAsync(record.id);
+              await deleteClaimMutation.mutateAsync({ id: record.id, defectIds: record.defect_ids });
               message.success('Удалено');
             }}
             disabled={deleteClaimMutation.isPending}

--- a/src/shared/types/claimDelete.ts
+++ b/src/shared/types/claimDelete.ts
@@ -1,0 +1,7 @@
+/** Параметры удаления претензии */
+export interface ClaimDeleteParams {
+  /** Идентификатор претензии */
+  id: number;
+  /** Идентификаторы связанных дефектов */
+  defectIds?: number[];
+}

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -42,7 +42,7 @@ export default function ClaimsTable({ claims, filters, loading, columns: columns
             okText="Да"
             cancelText="Нет"
             onConfirm={async () => {
-              await remove(record.id);
+              await remove({ id: record.id, defectIds: record.defect_ids });
               message.success('Удалено');
             }}
             disabled={isPending}


### PR DESCRIPTION
## Summary
- add `ClaimDeleteParams` type for deletion payload
- remove defects when deleting claims
- pass defect IDs when deleting claims from table and page

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit` *(fails: numerous type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6854e7b41938832e87b4a07787b01cf6