### PR TITLE
Fix deletion filter

### DIFF
--- a/src/entities/ticket.ts
+++ b/src/entities/ticket.ts
@@ -487,6 +487,7 @@ export function useDeleteTicket() {
   const projectIds = useAuthStore((s) => s.profile?.project_ids) ?? [];
   const role = useAuthStore((s) => s.profile?.role as RoleName | undefined);
   const { data: perm } = useRolePermission(role);
+  const onlyAssigned = !!perm?.only_assigned_project;
   const qc = useQueryClient();
   const notify = useNotify();
 


### PR DESCRIPTION
## Summary
- fix ticket removal by defining `onlyAssigned` when deleting tickets

## Testing
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_6854eae6dc00832e919d76fba5f4aeee