### PR TITLE
Set default status for new claims

### DIFF
--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -72,6 +72,19 @@ export default function ClaimFormAntd({ onCreated, initialValues = {} }: ClaimFo
     if (initialValues.fixed_at) form.setFieldValue('fixed_at', dayjs(initialValues.fixed_at));
   }, [globalProjectId, form, initialValues]);
 
+  /**
+   * Если статус не указан, подставляем первым из списка.
+   */
+  useEffect(() => {
+    if (
+      statuses.length &&
+      !initialValues.status_id &&
+      !form.getFieldValue('status_id')
+    ) {
+      form.setFieldValue('status_id', statuses[0].id);
+    }
+  }, [statuses, form, initialValues.status_id]);
+
   const onFinish = async (values: ClaimFormValues) => {
     const { defects: defs, ...rest } = values;
     if (!defs || defs.length === 0) {


### PR DESCRIPTION
## Summary
- set default claim status to first available option

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6854ed2e56fc832eb662ece606d2f7e8