### PR TITLE
Add claim attachments support

### DIFF
--- a/sql/add_claim_attachment_ids.sql
+++ b/sql/add_claim_attachment_ids.sql
@@ -1,0 +1,2 @@
+ALTER TABLE claims
+ADD COLUMN IF NOT EXISTS attachment_ids integer[] DEFAULT ARRAY[]::integer[];

--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -1,6 +1,16 @@
 import React, { useEffect, useState } from 'react';
-import { Form, Input, Select, DatePicker, Button, Row, Col, Tag } from 'antd';
+import {
+  Form,
+  Input,
+  Select,
+  DatePicker,
+  Button,
+  Row,
+  Col,
+  Tag,
+} from 'antd';
 import FileDropZone from '@/shared/ui/FileDropZone';
+import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
 import { useAttachmentTypes } from '@/entities/attachmentType';
 import dayjs from 'dayjs';
 import { useVisibleProjects } from '@/entities/project';
@@ -217,33 +227,12 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
       )}
       <Form.Item label="Файлы">
         <FileDropZone onFiles={handleDropFiles} />
-        {files.map((f, i) => (
-          <Row key={i} gutter={8} align="middle" style={{ marginTop: 4 }}>
-            <Col flex="auto">
-              <span>{f.file.name}</span>
-            </Col>
-            <Col flex="160px">
-              <Select
-                style={{ width: '100%' }}
-                placeholder="Тип файла"
-                value={f.type_id ?? undefined}
-                onChange={(v) => setType(i, v)}
-                allowClear
-              >
-                {attachmentTypes.map((t) => (
-                  <Select.Option key={t.id} value={t.id}>
-                    {t.name}
-                  </Select.Option>
-                ))}
-              </Select>
-            </Col>
-            <Col>
-              <Button type="text" danger onClick={() => removeFile(i)}>
-                Удалить
-              </Button>
-            </Col>
-          </Row>
-        ))}
+        <AttachmentEditorTable
+          newFiles={files.map((f) => ({ file: f.file, typeId: f.type_id, mime: f.file.type }))}
+          attachmentTypes={attachmentTypes.map((t) => ({ id: t.id, name: t.name }))}
+          onRemoveNew={removeFile}
+          onChangeNewType={setType}
+        />
       </Form.Item>
       {showDefectsForm && (
         <Form.Item style={{ textAlign: 'right' }}>

--- a/src/features/claim/ClaimViewModal.tsx
+++ b/src/features/claim/ClaimViewModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Modal, Skeleton, Typography } from 'antd';
-import { useClaim, useClaimAttachments, signedUrl } from '@/entities/claim';
+import { useClaim, signedUrl } from '@/entities/claim';
+import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
 import TicketDefectsTable from '@/widgets/TicketDefectsTable';
 import ClaimFormAntd from './ClaimFormAntd';
 
@@ -12,7 +13,6 @@ interface Props {
 
 export default function ClaimViewModal({ open, claimId, onClose }: Props) {
   const { data: claim } = useClaim(claimId ?? undefined);
-  const { data: files = [] } = useClaimAttachments(claim?.id);
   if (!open || !claimId) return null;
   const titleText = claim
     ? `Претензия №${claim.number}`
@@ -32,33 +32,20 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
               <TicketDefectsTable defectIds={claim.defect_ids} />
             </div>
           ) : null}
-          {files.length ? (
+          {claim.attachments?.length ? (
             <div style={{ marginTop: 16 }}>
-              <b>Файлы:</b>
-              <ul style={{ paddingLeft: 20 }}>
-                {files.map((f: any) => (
-                  <li key={f.id}>
-                    <a
-                      href="#"
-                      onClick={async (e) => {
-                        e.preventDefault();
-                        const url = await signedUrl(
-                          f.storage_path,
-                          f.original_name ?? 'file',
-                        );
-                        const a = document.createElement('a');
-                        a.href = url;
-                        a.download = f.original_name ?? 'file';
-                        document.body.appendChild(a);
-                        a.click();
-                        a.remove();
-                      }}
-                    >
-                      {f.original_name ?? f.storage_path.split('/').pop()}
-                    </a>
-                  </li>
-                ))}
-              </ul>
+              <AttachmentEditorTable
+                remoteFiles={claim.attachments.map((f) => ({
+                  id: String(f.id),
+                  name: f.original_name ?? f.name,
+                  path: f.path ?? f.storage_path,
+                  typeId: f.attachment_type_id,
+                  typeName: f.attachment_type_name,
+                  mime: f.type,
+                }))}
+                attachmentTypes={[]}
+                getSignedUrl={(path, name) => signedUrl(path, name)}
+              />
             </div>
           ) : null}
         </>

--- a/src/shared/types/claim.ts
+++ b/src/shared/types/claim.ts
@@ -10,5 +10,7 @@ export interface Claim {
   registered_at: string | null;
   fixed_at: string | null;
   responsible_engineer_id: string | null;
+  /** Массив идентификаторов вложений претензии */
+  attachment_ids?: number[];
   defect_ids?: number[];
 }

--- a/src/shared/types/claimWithNames.ts
+++ b/src/shared/types/claimWithNames.ts
@@ -20,4 +20,6 @@ export interface ClaimWithNames extends Claim {
   registeredAt: Dayjs | null;
   /** Дата устранения претензии */
   fixedAt: Dayjs | null;
+  /** Загруженные файлы */
+  attachments?: import('./claimFile').RemoteClaimFile[];
 }


### PR DESCRIPTION
## Summary
- support attachment_ids for claims
- show claim files in view modal
- use attachment editor table in claim form
- add SQL migration for new column

## Testing
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_6854f0618750832eb7a813721ce73ffc