### PR TITLE
Highlight claims with defects on check

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -110,6 +110,9 @@ body {
 .defect-confirmed-row {
   background: #f6ffed !important;
 }
+.claim-checking-row {
+  background: #f6ffed !important;
+}
 .defect-closed-row {
   color: #aaa;
   background: inherit !important;

--- a/src/shared/types/claimWithNames.ts
+++ b/src/shared/types/claimWithNames.ts
@@ -22,4 +22,6 @@ export interface ClaimWithNames extends Claim {
   fixedAt: Dayjs | null;
   /** Загруженные файлы */
   attachments?: import('./claimFile').RemoteClaimFile[];
+  /** Есть связанные дефекты со статусом "На проверке" */
+  hasCheckingDefect?: boolean;
 }

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -70,5 +70,18 @@ export default function ClaimsTable({ claims, filters, loading, columns: columns
     });
   }, [claims, filters]);
 
-  return <Table rowKey="id" columns={columns} dataSource={filtered} loading={loading} pagination={{ pageSize: 25, showSizeChanger: true }} size="middle" />;
+  const rowClassName = (row: ClaimWithNames) =>
+    row.hasCheckingDefect ? 'claim-checking-row' : '';
+
+  return (
+    <Table
+      rowKey="id"
+      columns={columns}
+      dataSource={filtered}
+      loading={loading}
+      pagination={{ pageSize: 25, showSizeChanger: true }}
+      size="middle"
+      rowClassName={rowClassName}
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- flag claims with defects set to checking status
- highlight these claims in the table

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854f54bfc08832eba1094531af3953d