### PR TITLE
Fix drawer crash on defects page

### DIFF
--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -364,11 +364,19 @@ export default function DefectsPage() {
     "actions",
   ] as const;
 
+  const getTitleText = (t: React.ReactNode): string => {
+    if (typeof t === 'string') return t;
+    if (React.isValidElement(t)) {
+      return React.Children.toArray(t.props.children).join(' ');
+    }
+    return String(t);
+  };
+
   const [columnsState, setColumnsState] = useState<TableColumnSetting[]>(() => {
     const base = baseColumns;
     const defaults = columnOrder.map((key) => ({
       key,
-      title: base[key].title as string,
+      title: getTitleText(base[key].title),
       visible: true,
     }));
     try {
@@ -389,7 +397,7 @@ export default function DefectsPage() {
     const base = baseColumns;
     const defaults = columnOrder.map((key) => ({
       key,
-      title: base[key].title as string,
+      title: getTitleText(base[key].title),
       visible: true,
     }));
     setColumnsState(defaults);


### PR DESCRIPTION
## Summary
- avoid storing React elements when saving table column settings
- regenerate column titles using helper

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68553703ef40832eb64ffc402db7de7d