### PR TITLE
Fix ticket status update filter

### DIFF
--- a/src/entities/ticket.d.ts
+++ b/src/entities/ticket.d.ts
@@ -62,7 +62,7 @@ export function useAllTicketsSimple(): UseQueryResult<Array<{ id: number; status
 export function useTicketsSimpleAll(): UseQueryResult<Array<{ id: number; project_id: number; unit_ids: number[]; defect_ids: number[] }>>;
 export function useTicketsSimple(): UseQueryResult<Array<{ id: number; project_id: number; unit_ids: number[]; defect_ids: number[] }>>;
 export function useUpdateTicket(): UseMutationResult<any, Error, { id: number; updates: object }>;
-export function useUpdateTicketStatus(): UseMutationResult<any, Error, { id: number; statusId: number }>;
+export function useUpdateTicketStatus(): UseMutationResult<any, Error, { id: number; statusId: number; projectId?: number }>;
 
 export function useTicketLinks(): UseQueryResult<TicketLink[]>;
 

--- a/src/features/ticket/TicketStatusSelect.tsx
+++ b/src/features/ticket/TicketStatusSelect.tsx
@@ -11,6 +11,8 @@ interface TicketStatusSelectProps {
   statusColor?: string | null;
   /** имя статуса, используется до загрузки списка */
   statusName?: string | null;
+  /** идентификатор проекта замечания */
+  projectId?: number;
 }
 
 /**
@@ -22,6 +24,7 @@ export default function TicketStatusSelect({
   statusId,
   statusColor,
   statusName,
+  projectId,
 }: TicketStatusSelectProps) {
   const { data: statuses = [], isLoading } = useTicketStatuses();
   const update = useUpdateTicketStatus();
@@ -47,7 +50,7 @@ export default function TicketStatusSelect({
   );
 
   const handleChange = (value: number) => {
-    (update as any).mutate({ id: ticketId, statusId: value });
+    (update as any).mutate({ id: ticketId, statusId: value, projectId });
     setEditing(false);
   };
 

--- a/src/pages/TicketsPage/TicketsPage.tsx
+++ b/src/pages/TicketsPage/TicketsPage.tsx
@@ -287,6 +287,7 @@ export default function TicketsPage() {
             statusId={row.statusId}
             statusColor={row.statusColor}
             statusName={row.statusName}
+            projectId={row.projectId}
           />
         ),
       },

--- a/src/widgets/TicketsTable.tsx
+++ b/src/widgets/TicketsTable.tsx
@@ -142,6 +142,7 @@ export default function TicketsTable({
             statusId={row.statusId}
             statusColor={row.statusColor}
             statusName={row.statusName}
+            projectId={row.projectId}
           />
         ),
       },


### PR DESCRIPTION
## Summary
- pass ticket projectId to the status update mutation
- consider project ID of ticket when updating status
- expose projectId param in typings

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855a519fe98832e9b664981055a19eb