### PR TITLE
Add realtime updates for Project Structure

### DIFF
--- a/src/entities/unit.ts
+++ b/src/entities/unit.ts
@@ -9,6 +9,7 @@ import {
 import { useProjectFilter } from '@/shared/hooks/useProjectFilter';
 import { useAuthStore } from '@/shared/store/authStore';
 import { filterByProjects } from '@/shared/utils/projectQuery';
+import { useNotify } from '@/shared/hooks/useNotify';
 
 /* ---------- базовый SELECT ---------- */
 const SELECT = `
@@ -203,5 +204,48 @@ export const useDeleteUnit = () => {
             if (error) throw error;
         },
         onSuccess: () => qc.invalidateQueries({ queryKey: ['units'] }),
+    });
+};
+
+/** Удалить все квартиры в корпусе */
+export const useDeleteUnitsByBuilding = () => {
+    const qc = useQueryClient();
+    const notify = useNotify();
+    return useMutation({
+        mutationFn: async ({ projectId, building }: { projectId: string | number; building: string }) => {
+            const { error } = await supabase
+                .from('units')
+                .delete()
+                .eq('project_id', projectId)
+                .eq('building', building);
+            if (error) throw error;
+        },
+        onSuccess: () => {
+            qc.invalidateQueries({ queryKey: ['units'] });
+            notify.success('Корпус удалён');
+        },
+        onError: (e: Error) => notify.error(e.message),
+    });
+};
+
+/** Удалить все квартиры в секции корпуса */
+export const useDeleteUnitsBySection = () => {
+    const qc = useQueryClient();
+    const notify = useNotify();
+    return useMutation({
+        mutationFn: async ({ projectId, building, section }: { projectId: string | number; building: string; section: string }) => {
+            const { error } = await supabase
+                .from('units')
+                .delete()
+                .eq('project_id', projectId)
+                .eq('building', building)
+                .eq('section', section);
+            if (error) throw error;
+        },
+        onSuccess: () => {
+            qc.invalidateQueries({ queryKey: ['units'] });
+            notify.success('Секция удалена');
+        },
+        onError: (e: Error) => notify.error(e.message),
     });
 };

--- a/src/features/addBuildingOrSection/AddBuildingOrSectionDialog.tsx
+++ b/src/features/addBuildingOrSection/AddBuildingOrSectionDialog.tsx
@@ -47,7 +47,7 @@ export default function AddBuildingOrSectionDialog({
       ]);
     }
     onClose();
-    afterAdd && afterAdd();
+    afterAdd && afterAdd(value.trim());
   };
 
   return (

--- a/src/shared/hooks/useProjectStructure.ts
+++ b/src/shared/hooks/useProjectStructure.ts
@@ -86,6 +86,22 @@ export default function useProjectStructure() {
         refreshAll();
     }, [refreshAll]);
 
+    // --- Подписка на изменения в units для мгновенного обновления ---
+    useEffect(() => {
+        if (!projectId) return;
+        const channel = supabase
+            .channel('units-structure-' + projectId)
+            .on(
+                'postgres_changes',
+                { event: '*', schema: 'public', table: 'units', filter: `project_id=eq.${projectId}` },
+                () => refreshAll(),
+            );
+        channel.subscribe();
+        return () => {
+            channel.unsubscribe();
+        };
+    }, [projectId, refreshAll]);
+
     // --- Автоматическое сохранение выбранных значений при изменении ---
     useEffect(() => {
         saveToLS({ projectId, building, section });
@@ -116,6 +132,8 @@ export default function useProjectStructure() {
         buildings, building, setBuilding,
         sections, section, setSection,
         refreshAll,
+        setBuildings,
+        setSections,
     };
 }
 


### PR DESCRIPTION
## Summary
- add hooks to remove units by building or section
- update project structure logic to update lists immediately
- enhance add building/section dialog callback
- subscribe to realtime units changes

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6855acf711ec832e9d6112e20943886b