### PR TITLE
Remove attachment type table

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -22,14 +22,14 @@
   },
   {
     "table_name": "attachments",
-    "column_name": "file_url",
+    "column_name": "path",
     "data_type": "text",
     "is_nullable": "NO",
     "column_default": null
   },
   {
     "table_name": "attachments",
-    "column_name": "file_type",
+    "column_name": "mime_type",
     "data_type": "text",
     "is_nullable": "NO",
     "column_default": null
@@ -37,6 +37,20 @@
   {
     "table_name": "attachments",
     "column_name": "uploaded_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "now()"
+  },
+  {
+    "table_name": "attachments",
+    "column_name": "uploaded_by",
+    "data_type": "uuid",
+    "is_nullable": "YES",
+    "column_default": null
+  },
+  {
+    "table_name": "attachments",
+    "column_name": "updated_at",
     "data_type": "timestamp with time zone",
     "is_nullable": "YES",
     "column_default": "now()"

--- a/src/entities/attachment.js
+++ b/src/entities/attachment.js
@@ -119,17 +119,16 @@ export async function addCaseAttachments(files, caseId) {
     );
 
     const rows = uploaded.map((u, idx) => ({
-        file_url: u.url,
-        file_type: u.type,
+        path: u.path,
+        mime_type: u.type,
         original_name: files[idx].file.name,
         storage_path: u.path,
-        attachment_type_id: files[idx].type_id ?? null,
     }));
 
     const { data, error } = await supabase
         .from('attachments')
         .insert(rows)
-        .select('id, storage_path, file_url, file_type, attachment_type_id, original_name');
+        .select('id, storage_path, path, mime_type, original_name');
 
     if (error) throw error;
     return data ?? [];
@@ -146,17 +145,16 @@ export async function addLetterAttachments(files, letterId) {
     );
 
     const rows = uploaded.map((u, idx) => ({
-        file_url: u.url,
-        file_type: u.type,
+        path: u.path,
+        mime_type: u.type,
         original_name: files[idx].file.name,
         storage_path: u.path,
-        attachment_type_id: files[idx].type_id ?? null,
     }));
 
     const { data, error } = await supabase
         .from('attachments')
         .insert(rows)
-        .select('id, storage_path, file_url, file_type, attachment_type_id, original_name');
+        .select('id, storage_path, path, mime_type, original_name');
 
     if (error) throw error;
     return data ?? [];
@@ -175,17 +173,16 @@ export async function addTicketAttachments(files, projectId, ticketId) {
     );
 
     const rows = uploaded.map((u, idx) => ({
-        file_url: u.url,
-        file_type: u.type,
+        path: u.path,
+        mime_type: u.type,
         original_name: files[idx].file.name,
         storage_path: u.path,
-        attachment_type_id: files[idx].type_id ?? null,
     }));
 
     const { data, error } = await supabase
         .from('attachments')
         .insert(rows)
-        .select('id, storage_path, file_url, file_type, attachment_type_id, original_name');
+        .select('id, storage_path, path, mime_type, original_name');
 
     if (error) throw error;
     return data ?? [];
@@ -203,17 +200,16 @@ export async function addClaimAttachments(files, claimId) {
     );
 
     const rows = uploaded.map((u, idx) => ({
-        file_url: u.url,
-        file_type: u.type,
+        path: u.path,
+        mime_type: u.type,
         original_name: files[idx].file.name,
         storage_path: u.path,
-        attachment_type_id: files[idx].type_id ?? null,
     }));
 
     const { data, error } = await supabase
         .from('attachments')
         .insert(rows)
-        .select('id, storage_path, file_url, file_type, attachment_type_id, original_name');
+        .select('id, storage_path, path, mime_type, original_name');
 
     if (error) throw error;
     return data ?? [];
@@ -231,17 +227,16 @@ export async function addDefectAttachments(files, defectId) {
     );
 
     const rows = uploaded.map((u, idx) => ({
-        file_url: u.url,
-        file_type: u.type,
+        path: u.path,
+        mime_type: u.type,
         original_name: files[idx].file.name,
         storage_path: u.path,
-        attachment_type_id: files[idx].type_id ?? null,
     }));
 
     const { data, error } = await supabase
         .from('attachments')
         .insert(rows)
-        .select('id, storage_path, file_url, file_type, attachment_type_id, original_name');
+        .select('id, storage_path, path, mime_type, original_name');
 
     if (error) throw error;
     return data ?? [];
@@ -255,7 +250,7 @@ export async function getAttachmentsByIds(ids) {
     if (!ids.length) return [];
     const { data, error } = await supabase
         .from('attachments')
-        .select('id, storage_path, file_url, file_type, attachment_type_id, original_name')
+        .select('id, storage_path, path, mime_type, original_name')
         .in('id', ids);
 
     if (error) throw error;

--- a/src/entities/claim.ts
+++ b/src/entities/claim.ts
@@ -39,9 +39,8 @@ function mapClaim(r: any): ClaimWithNames {
           path: a.storage_path,
           original_name: a.original_name ?? null,
           name,
-          url: a.file_url,
-          type: a.file_type,
-          attachment_type_id: a.attachment_type_id ?? null,
+          path: a.path,
+          mime_type: a.mime_type,
         } as import('@/shared/types/claimFile').RemoteClaimFile;
       })
     : [];
@@ -104,9 +103,8 @@ export function useClaims() {
             id: f.id,
             storage_path: f.storage_path,
             original_name: f.original_name,
-            file_url: f.file_url,
-            file_type: f.file_type,
-            attachment_type_id: f.attachment_type_id ?? null,
+            path: f.path,
+            mime_type: f.mime_type,
           };
         });
       }
@@ -164,9 +162,8 @@ export function useClaim(id?: number | string) {
           id: f.id,
           storage_path: f.storage_path,
           original_name: f.original_name,
-          file_url: f.file_url,
-          file_type: f.file_type,
-          attachment_type_id: f.attachment_type_id ?? null,
+          path: f.path,
+          mime_type: f.mime_type,
         }));
         const existIds = files.map((f) => f.id);
         if (existIds.length !== data.attachment_ids.length) {

--- a/src/entities/ticket.ts
+++ b/src/entities/ticket.ts
@@ -142,9 +142,8 @@ function mapTicket(r) {
       path: a.storage_path,
       original_name: a.original_name ?? null,
       name,
-      url: a.file_url,
-      type: a.file_type,
-      attachment_type_id: a.attachment_type_id ?? null,
+      path: a.path,
+      mime_type: a.mime_type,
     };
   });
 
@@ -212,9 +211,8 @@ export function useTickets() {
             id: f.id,
             storage_path: f.storage_path,
             original_name: f.original_name,
-            file_url: f.file_url,
-            file_type: f.file_type,
-            attachment_type_id: f.attachment_type_id ?? null,
+            path: f.path,
+            mime_type: f.mime_type,
           };
         });
       }
@@ -350,9 +348,8 @@ export function useTicket(ticketId) {
           id: f.id,
           storage_path: f.storage_path,
           original_name: f.original_name,
-          file_url: f.file_url,
-          file_type: f.file_type,
-          attachment_type_id: f.attachment_type_id ?? null,
+          path: f.path,
+          mime_type: f.mime_type,
         }));
         const existIds = files.map((f) => f.id);
         if (existIds.length !== data.attachment_ids.length) {

--- a/src/features/ticket/TicketForm.tsx
+++ b/src/features/ticket/TicketForm.tsx
@@ -24,7 +24,6 @@ import { useUnitsByProject } from "@/entities/unit";
 import { useUsers } from "@/entities/user";
 import { useVisibleProjects } from "@/entities/project";
 import { useDefectDeadlines } from "@/entities/defectDeadline";
-import { useAttachmentTypes } from "@/entities/attachmentType";
 import { useCreateTicket, useTicket, signedUrl } from "@/entities/ticket";
 import { useProjectId } from "@/shared/hooks/useProjectId";
 import { useUnsavedChangesWarning } from "@/shared/hooks/useUnsavedChangesWarning";
@@ -38,15 +37,11 @@ interface Attachment {
   id: string | number;
   name: string;
   path: string;
-  url: string;
-  type: string;
-  attachment_type_id: number | null;
-  attachment_type_name?: string;
+  mime_type: string;
 }
 
 interface NewFile {
   file: File;
-  type_id: number | null;
 }
 
 interface TicketFormProps {
@@ -114,7 +109,6 @@ export default function TicketForm({
   const { data: types = [] } = useDefectTypes();
   const { data: statuses = [] } = useTicketStatuses();
   const { data: users = [] } = useUsers();
-  const { data: attachmentTypes = [] } = useAttachmentTypes();
   const { data: deadlines = [] } = useDefectDeadlines();
   const projectIdWatch =
     watch("project_id") ?? (globalProjectId != null ? Number(globalProjectId) : null);
@@ -138,18 +132,15 @@ export default function TicketForm({
   const {
     remoteFiles,
     newFiles,
-    changedTypes,
     removedIds,
     addFiles,
     removeNew,
     removeRemote,
-    changeRemoteType,
-    changeNewType,
     appendRemote,
     markPersisted,
     attachmentsChanged,
     reset: resetAttachments,
-  } = useTicketAttachments({ ticket, attachmentTypes });
+  } = useTicketAttachments({ ticket });
 
   useEffect(() => {
     if (ticket) {
@@ -201,13 +192,6 @@ export default function TicketForm({
 
 
   const submit = async (values: TicketFormValues) => {
-    if (
-      newFiles.some((f) => f.type_id == null) ||
-      remoteFiles.some((f) => (changedTypes[f.id] ?? null) == null)
-    ) {
-      notify.error('Выберите тип файла для всех документов');
-      return;
-    }
     const payload = {
       project_id:
         values.project_id ?? (globalProjectId != null ? Number(globalProjectId) : null),
@@ -233,10 +217,7 @@ export default function TicketForm({
         ...payload,
         newAttachments: newFiles,
         removedAttachmentIds: removedIds,
-        updatedAttachments: Object.entries(changedTypes).map(([id, type]) => ({
-          id,
-          type_id: type,
-        })),
+        updatedAttachments: [],
       });
         if (uploaded?.length) {
           appendRemote(
@@ -248,9 +229,7 @@ export default function TicketForm({
                 "file",
               original_name: u.original_name ?? null,
               path: u.storage_path,
-              url: u.file_url,
-              type: u.file_type,
-              attachment_type_id: u.attachment_type_id ?? null,
+              mime_type: u.mime_type,
             }))
           );
         }
@@ -259,7 +238,7 @@ export default function TicketForm({
     } else {
       await (create.mutateAsync as any)({
         ...payload,
-        attachments: newFiles.map((f) => ({ file: f.file, type_id: f.type_id })),
+        attachments: newFiles.map((f) => ({ file: f.file })),
       });
       onCreated?.();
       reset();
@@ -604,20 +583,14 @@ export default function TicketForm({
               id: String(f.id),
               name: f.original_name ?? f.name,
               path: f.path,
-              typeId: changedTypes[f.id] ?? f.attachment_type_id,
-              typeName: f.attachment_type_name,
-              mime: f.type,
+              mime: f.mime_type,
             }))}
             newFiles={newFiles.map((f) => ({
               file: f.file,
-              typeId: f.type_id,
               mime: f.file.type,
             }))}
-            attachmentTypes={attachmentTypes}
             onRemoveRemote={(id) => removeRemote(String(id))}
             onRemoveNew={removeNew}
-            onChangeRemoteType={changeRemoteType}
-            onChangeNewType={changeNewType}
             getSignedUrl={(path, name) => signedUrl(path, name)}
           />
           <Button variant="outlined" size="small" component="label" sx={{ mt: 1 }}>

--- a/src/features/ticket/TicketFormAntdEdit.tsx
+++ b/src/features/ticket/TicketFormAntdEdit.tsx
@@ -16,7 +16,6 @@ import { useUnitsByProject } from '@/entities/unit';
 import { useUsers } from '@/entities/user';
 import { useVisibleProjects } from '@/entities/project';
 import { useCreateTicket, useTicket } from '@/entities/ticket';
-import { useAttachmentTypes } from '@/entities/attachmentType';
 import { useProjectId } from '@/shared/hooks/useProjectId';
 import { useAuthStore } from '@/shared/store/authStore';
 import FileDropZone from '@/shared/ui/FileDropZone';
@@ -72,7 +71,6 @@ export default function TicketFormAntdEdit({
   const projectIdWatch = Form.useWatch('project_id', form) ?? globalProjectId;
   const projectId = projectIdWatch != null ? Number(projectIdWatch) : null;
   const { data: units = [] } = useUnitsByProject(projectId);
-  const { data: attachmentTypes = [] } = useAttachmentTypes();
   const create = useCreateTicket();
   const notify = useNotify();
   const profileId = useAuthStore((s) => s.profile?.id);
@@ -86,18 +84,15 @@ export default function TicketFormAntdEdit({
   const {
     remoteFiles,
     newFiles,
-    changedTypes,
     removedIds,
     addFiles,
     removeNew,
     removeRemote,
-    changeRemoteType,
-    changeNewType,
     appendRemote,
     markPersisted,
     attachmentsChanged,
     reset: resetAttachments,
-  } = useTicketAttachments({ ticket, attachmentTypes });
+  } = useTicketAttachments({ ticket });
 
   const highlight = (name: keyof TicketFormAntdEditValues) =>
     changedFields[name as string]
@@ -165,13 +160,6 @@ export default function TicketFormAntdEdit({
   };
 
   const handleSubmit = async (values: TicketFormAntdEditValues) => {
-    if (
-      newFiles.some((f) => f.type_id == null) ||
-      remoteFiles.some((f) => (changedTypes[f.id] ?? null) == null)
-    ) {
-      notify.error('Выберите тип файла для всех документов');
-      return;
-    }
 
     const payload = {
       project_id: values.project_id ?? globalProjectId,
@@ -197,10 +185,7 @@ export default function TicketFormAntdEdit({
           ...payload,
           newAttachments: newFiles,
           removedAttachmentIds: removedIds,
-          updatedAttachments: Object.entries(changedTypes).map(([id, type]) => ({
-            id,
-            type_id: type,
-          })),
+          updatedAttachments: [],
         });
         if (uploaded?.length) {
           appendRemote(
@@ -209,9 +194,7 @@ export default function TicketFormAntdEdit({
               name: u.original_name || u.storage_path.split('/').pop() || 'file',
               original_name: u.original_name ?? null,
               path: u.storage_path,
-              url: u.file_url,
-              type: u.file_type,
-              attachment_type_id: u.attachment_type_id ?? null,
+              mime_type: u.mime_type,
             })),
           );
         }
@@ -221,7 +204,7 @@ export default function TicketFormAntdEdit({
       } else {
         await create.mutateAsync({
           ...payload,
-          attachments: newFiles.map((f) => ({ file: f.file, type_id: f.type_id })),
+          attachments: newFiles.map((f) => ({ file: f.file })),
         } as any);
         try {
           localStorage.setItem(
@@ -399,16 +382,11 @@ export default function TicketFormAntdEdit({
             id: String(f.id),
             name: f.original_name ?? f.name,
             path: f.path,
-            typeId: changedTypes[f.id] ?? f.attachment_type_id,
-            typeName: f.attachment_type_name,
-            mime: f.type,
+            mime: f.mime_type,
           }))}
-          newFiles={newFiles.map((f) => ({ file: f.file, typeId: f.type_id, mime: f.file.type }))}
-          attachmentTypes={attachmentTypes}
+          newFiles={newFiles.map((f) => ({ file: f.file, mime: f.file.type }))}
           onRemoveRemote={removeRemote}
           onRemoveNew={removeNew}
-          onChangeRemoteType={changeRemoteType}
-          onChangeNewType={changeNewType}
           getSignedUrl={(path, name) => signedUrl(path, name)}
         />
       </Form.Item>

--- a/src/features/ticket/model/useTicketAttachments.ts
+++ b/src/features/ticket/model/useTicketAttachments.ts
@@ -1,30 +1,21 @@
 import { useState, useEffect, useCallback } from 'react';
-import type { AttachmentType } from '@/shared/types/attachmentType';
 import type { Ticket } from '@/entities/ticket';
 import type { RemoteTicketFile, NewTicketFile } from '@/shared/types/ticketFile';
 
 /**
  * Хук управления списком вложений замечания.
  */
-export function useTicketAttachments(options: {
-  ticket?: Ticket | null;
-  attachmentTypes: AttachmentType[];
-}) {
-  const { ticket, attachmentTypes } = options;
+export function useTicketAttachments(options: { ticket?: Ticket | null }) {
+  const { ticket } = options;
 
   const [remoteFiles, setRemoteFiles] = useState<RemoteTicketFile[]>([]);
-  const [changedTypes, setChangedTypes] = useState<Record<string, number | null>>({});
-  const [initialTypes, setInitialTypes] = useState<Record<string, number | null>>({});
   const [newFiles, setNewFiles] = useState<NewTicketFile[]>([]);
   const [removedIds, setRemovedIds] = useState<string[]>([]);
 
   useEffect(() => {
     if (!ticket) return;
-    const attachmentsWithType = (ticket.attachments || []).map((file) => {
-      const typeObj = attachmentTypes.find((t) => t.id === file.attachment_type_id);
+    const files = (ticket.attachments || []).map((file) => {
       const storagePath = 'storage_path' in file ? (file as any).storage_path : (file as any).path;
-      const fileUrl = (file as any).file_url ?? (file as any).url ?? '';
-      const fileType = (file as any).file_type ?? (file as any).type ?? '';
       const originalName = (file as any).original_name ?? null;
       const name =
         originalName ||
@@ -35,20 +26,11 @@ export function useTicketAttachments(options: {
         name,
         original_name: originalName,
         path: storagePath ?? '',
-        url: fileUrl,
-        type: fileType,
-        attachment_type_id: file.attachment_type_id ?? null,
-        attachment_type_name: typeObj?.name || fileType || '',
+        mime_type: (file as any).mime_type ?? (file as any).type ?? '',
       } as RemoteTicketFile;
     });
-    setRemoteFiles(attachmentsWithType);
-    const map: Record<string, number | null> = {};
-    attachmentsWithType.forEach((f) => {
-      map[f.id] = f.attachment_type_id ?? null;
-    });
-    setChangedTypes(map);
-    setInitialTypes(map);
-  }, [ticket, attachmentTypes]);
+    setRemoteFiles(files);
+  }, [ticket]);
 
   const addFiles = useCallback(
     (files: File[]) =>
@@ -66,65 +48,33 @@ export function useTicketAttachments(options: {
     setRemovedIds((p) => [...p, id]);
   }, []);
 
-  const changeRemoteType = useCallback(
-    (id: string, type: number | null) =>
-      setChangedTypes((p) => ({ ...p, [id]: type })),
-    [],
-  );
-
-  const changeNewType = useCallback(
-    (idx: number, type: number | null) =>
-      setNewFiles((p) => p.map((f, i) => (i === idx ? { ...f, type_id: type } : f))),
-    [],
-  );
+  const changeRemoteType = undefined;
+  const changeNewType = undefined;
 
   const appendRemote = useCallback((files: RemoteTicketFile[]) => {
     setRemoteFiles((p) => [...p, ...files]);
-    setChangedTypes((prev) => {
-      const copy = { ...prev };
-      files.forEach((f) => {
-        copy[f.id] = f.attachment_type_id ?? null;
-      });
-      return copy;
-    });
-    setInitialTypes((prev) => {
-      const copy = { ...prev };
-      files.forEach((f) => {
-        copy[f.id] = f.attachment_type_id ?? null;
-      });
-      return copy;
-    });
   }, []);
 
   const markPersisted = useCallback(() => {
     setNewFiles([]);
     setRemovedIds([]);
-    setInitialTypes((prev) => ({ ...prev, ...changedTypes }));
-  }, [changedTypes]);
+  }, []);
 
-  const attachmentsChanged =
-    newFiles.length > 0 ||
-    removedIds.length > 0 ||
-    Object.keys(changedTypes).some((id) => changedTypes[id] !== initialTypes[id]);
+  const attachmentsChanged = newFiles.length > 0 || removedIds.length > 0;
 
   const resetAll = useCallback(() => {
     setNewFiles([]);
     setRemoteFiles([]);
-    setChangedTypes({});
-    setInitialTypes({});
     setRemovedIds([]);
   }, []);
 
   return {
     remoteFiles,
     newFiles,
-    changedTypes,
     removedIds,
     addFiles,
     removeNew,
     removeRemote,
-    changeRemoteType,
-    changeNewType,
     appendRemote,
     markPersisted,
     attachmentsChanged,

--- a/src/shared/types/attachment.ts
+++ b/src/shared/types/attachment.ts
@@ -2,12 +2,14 @@ export interface Attachment {
   id: number;
   /** Путь к файлу в Storage */
   storage_path: string;
-  /** Публичная ссылка на файл */
-  file_url: string;
+  /** Путь к файлу */
+  path: string;
   /** MIME‑тип файла */
-  file_type: string;
-  /** Тип вложения */
-  attachment_type_id: number | null;
+  mime_type: string;
   /** Исходное имя файла */
   original_name: string | null;
+  /** Кто загрузил */
+  uploaded_by?: string | null;
+  uploaded_at?: string | null;
+  updated_at?: string | null;
 }

--- a/src/shared/types/caseFile.ts
+++ b/src/shared/types/caseFile.ts
@@ -4,14 +4,10 @@ export interface RemoteCaseFile {
   name: string;
   original_name?: string | null;
   path: string;
-  url: string;
-  type: string;
-  attachment_type_id: number | null;
-  attachment_type_name?: string;
+  mime_type: string;
 }
 
 /** Новый файл для вложения судебного дела */
 export interface NewCaseFile {
   file: File;
-  type_id: number | null;
 }

--- a/src/shared/types/claimFile.ts
+++ b/src/shared/types/claimFile.ts
@@ -4,14 +4,10 @@ export interface RemoteClaimFile {
   name: string;
   original_name?: string | null;
   path: string;
-  url: string;
-  type: string;
-  attachment_type_id: number | null;
-  attachment_type_name?: string;
+  mime_type: string;
 }
 
 /** Новый файл для вложения претензии */
 export interface NewClaimFile {
   file: File;
-  type_id: number | null;
 }

--- a/src/shared/types/correspondence.ts
+++ b/src/shared/types/correspondence.ts
@@ -55,10 +55,8 @@ export interface CorrespondenceAttachment {
   file_type: string;
   /** Путь к файлу в хранилище */
   storage_path: string;
-  /** Публичная ссылка на файл */
-  file_url: string;
-  /** Тип вложения */
-  attachment_type_id: number | null;
+  /** MIME‑тип файла */
+  mime_type: string;
 }
 
 /** Связь писем: parent_id - родительское письмо, child_id - дочернее */

--- a/src/shared/types/defectFile.ts
+++ b/src/shared/types/defectFile.ts
@@ -4,14 +4,10 @@ export interface RemoteDefectFile {
   name: string;
   original_name?: string | null;
   path: string;
-  url: string;
-  type: string;
-  attachment_type_id: number | null;
-  attachment_type_name?: string;
+  mime_type: string;
 }
 
 /** Новый файл для вложения дефекта */
 export interface NewDefectFile {
   file: File;
-  type_id: number | null;
 }

--- a/src/shared/types/letterFile.ts
+++ b/src/shared/types/letterFile.ts
@@ -4,14 +4,10 @@ export interface RemoteLetterFile {
   name: string;
   original_name?: string | null;
   path: string;
-  url: string;
-  type: string;
-  attachment_type_id: number | null;
-  attachment_type_name?: string;
+  mime_type: string;
 }
 
 /** Новый файл для вложения письма */
 export interface NewLetterFile {
   file: File;
-  type_id: number | null;
 }

--- a/src/shared/types/ticketFile.ts
+++ b/src/shared/types/ticketFile.ts
@@ -4,14 +4,10 @@ export interface RemoteTicketFile {
   name: string;
   original_name?: string | null;
   path: string;
-  url: string;
-  type: string;
-  attachment_type_id: number | null;
-  attachment_type_name?: string;
+  mime_type: string;
 }
 
 /** Новый файл для вложения замечания */
 export interface NewTicketFile {
   file: File;
-  type_id: number | null;
 }


### PR DESCRIPTION
## Summary
- refactor attachments API to drop `attachment_types`
- update entities and features to use new attachment schema
- adjust file type models

## Testing
- `npm run lint` *(fails: Parsing error: Unexpected token, missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685667647cac832eab4939544bf56db1