### PR TITLE
Fix missing attachment type entity

### DIFF
--- a/src/entities/attachmentType.ts
+++ b/src/entities/attachmentType.ts
@@ -1,0 +1,22 @@
+import { supabase } from '@/shared/api/supabaseClient';
+import { useQuery } from '@tanstack/react-query';
+import type { AttachmentType } from '@/shared/types/attachmentType';
+
+const TABLE = 'attachment_types';
+
+/**
+ * Загружает список типов вложений из таблицы `attachment_types`.
+ */
+export const useAttachmentTypes = () =>
+  useQuery<AttachmentType[]>({
+    queryKey: [TABLE],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select('id, name')
+        .order('id');
+      if (error) throw error;
+      return (data ?? []) as AttachmentType[];
+    },
+    staleTime: 5 * 60_000,
+  });

--- a/src/shared/types/attachmentType.ts
+++ b/src/shared/types/attachmentType.ts
@@ -1,4 +1,7 @@
+/** Тип вложения (категория файла). */
 export interface AttachmentType {
+  /** Уникальный идентификатор типа */
   id: number;
+  /** Название типа */
   name: string;
 }


### PR DESCRIPTION
## Summary
- add hook `useAttachmentTypes` for attachment type reference data
- document `AttachmentType` interface

## Testing
- `npm run lint` *(fails: Parsing error in existing project files)*

------
https://chatgpt.com/codex/tasks/task_e_68567111fb68832e9a427a595d34edd0