### PR TITLE
Fix claims view and statuses

### DIFF
--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -26,6 +26,8 @@ export interface ClaimFormAntdProps {
   initialValues?: Partial<{ project_id: number; unit_ids: number[]; engineer_id: string }>;
   /** Показывать форму добавления дефектов */
   showDefectsForm?: boolean;
+  /** Показывать блок загрузки файлов */
+  showAttachments?: boolean;
 }
 
 export interface ClaimFormValues {
@@ -49,7 +51,7 @@ export interface ClaimFormValues {
   }>;
 }
 
-export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefectsForm = true }: ClaimFormAntdProps) {
+export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefectsForm = true, showAttachments = true }: ClaimFormAntdProps) {
   const [form] = Form.useForm<ClaimFormValues>();
   const [files, setFiles] = useState<File[]>([]);
   const globalProjectId = useProjectId();
@@ -207,13 +209,15 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
           )}
         </Form.List>
       )}
-      <Form.Item label="Файлы">
-        <FileDropZone onFiles={handleDropFiles} />
-        <AttachmentEditorTable
-          newFiles={files.map((f) => ({ file: f, mime: f.type }))}
-          onRemoveNew={removeFile}
-        />
-      </Form.Item>
+      {showAttachments && (
+        <Form.Item label="Файлы">
+          <FileDropZone onFiles={handleDropFiles} />
+          <AttachmentEditorTable
+            newFiles={files.map((f) => ({ file: f, mime: f.type }))}
+            onRemoveNew={removeFile}
+          />
+        </Form.Item>
+      )}
       {showDefectsForm && (
         <Form.Item style={{ textAlign: 'right' }}>
           <Button type="primary" htmlType="submit" loading={create.isPending}>

--- a/src/features/claim/ClaimStatusSelect.tsx
+++ b/src/features/claim/ClaimStatusSelect.tsx
@@ -33,7 +33,7 @@ export default function ClaimStatusSelect({
   );
 
   const handleChange = (value: number) => {
-    update.mutate({ id: claimId, updates: { status_id: value } });
+    update.mutate({ id: claimId, updates: { claim_status_id: value } });
     setEditing(false);
   };
 

--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -7,6 +7,7 @@ import { useSnackbar } from 'notistack';
 import { useClaims, useDeleteClaim } from '@/entities/claim';
 import { useUsers } from '@/entities/user';
 import { useUnitsByIds } from '@/entities/unit';
+import formatUnitName from '@/shared/utils/formatUnitName';
 import ClaimsTable from '@/widgets/ClaimsTable';
 import ClaimsFilters from '@/widgets/ClaimsFilters';
 import ClaimFormAntd from '@/features/claim/ClaimFormAntd';
@@ -63,7 +64,7 @@ export default function ClaimsPage() {
   const unitMap = useMemo(() => {
     const map = {} as Record<number, string>;
     (units ?? []).forEach((u) => {
-      map[u.id] = u.name;
+      map[u.id] = formatUnitName(u);
     });
     return map;
   }, [units]);

--- a/src/shared/ui/AttachmentEditorTable.tsx
+++ b/src/shared/ui/AttachmentEditorTable.tsx
@@ -26,6 +26,8 @@ interface Props {
   onRemoveRemote?: (id: string) => void;
   onRemoveNew?: (idx: number) => void;
   getSignedUrl?: (path: string, name: string) => Promise<string>;
+  /** Показывать колонку MIME */
+  showMime?: boolean;
 }
 
 /**
@@ -39,6 +41,7 @@ export default function AttachmentEditorTable({
                                                 onRemoveRemote,
                                                 onRemoveNew,
                                                 getSignedUrl,
+                                                showMime = true,
                                               }: Props) {
   const [cache, setCache] = React.useState<Record<string, string>>({});
 
@@ -105,11 +108,9 @@ export default function AttachmentEditorTable({
       width: 200,
       ellipsis: true,
     },
-    {
-      title: 'MIME',
-      dataIndex: 'mime',
-      width: 200,
-    },
+    ...(showMime
+      ? [{ title: 'MIME', dataIndex: 'mime', width: 200 } as ColumnsType<Row>[number]]
+      : []),
     {
       title: 'Действия',
       dataIndex: 'actions',


### PR DESCRIPTION
## Summary
- format unit names in claims table
- hide file block in claim form when viewing
- fix claim status update column
- add attachment removal for claims
- hide MIME column in attachment table when needed

## Testing
- `npm run lint` *(fails: missing eslint plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68567ee9e5c8832e8b65711f9aa65370