### PR TITLE
Set admin tables default page size

### DIFF
--- a/src/pages/UnitsPage/AdminPage.tsx
+++ b/src/pages/UnitsPage/AdminPage.tsx
@@ -20,59 +20,59 @@ export default function AdminPage() {
   return (
     <Container maxWidth="md" sx={{ py: 4 }}>
       <Stack spacing={4}>
-        <ProjectsTable pageSize={25} rowsPerPageOptions={[10, 25, 50, 100]} />
+        <ProjectsTable pageSize={5} rowsPerPageOptions={[5, 10, 25, 50, 100]} />
 
-        <ContractorAdmin pageSize={25} rowsPerPageOptions={[10, 25, 50, 100]} />
-        <BrigadesAdmin pageSize={25} rowsPerPageOptions={[10, 25, 50, 100]} />
+        <ContractorAdmin pageSize={5} rowsPerPageOptions={[5, 10, 25, 50, 100]} />
+        <BrigadesAdmin pageSize={5} rowsPerPageOptions={[5, 10, 25, 50, 100]} />
 
         <TicketStatusesAdmin
-          pageSize={25}
-          rowsPerPageOptions={[10, 25, 50, 100]}
+          pageSize={5}
+          rowsPerPageOptions={[5, 10, 25, 50, 100]}
         />
 
         <ClaimStatusesAdmin
-          pageSize={25}
-          rowsPerPageOptions={[10, 25, 50, 100]}
+          pageSize={5}
+          rowsPerPageOptions={[5, 10, 25, 50, 100]}
         />
 
         <DefectTypesAdmin
-          pageSize={25}
-          rowsPerPageOptions={[10, 25, 50, 100]}
+          pageSize={5}
+          rowsPerPageOptions={[5, 10, 25, 50, 100]}
         />
 
         <DefectStatusesAdmin
-          pageSize={25}
-          rowsPerPageOptions={[10, 25, 50, 100]}
+          pageSize={5}
+          rowsPerPageOptions={[5, 10, 25, 50, 100]}
         />
 
         <DefectDeadlinesAdmin
-          pageSize={25}
-          rowsPerPageOptions={[10, 25, 50, 100]}
+          pageSize={5}
+          rowsPerPageOptions={[5, 10, 25, 50, 100]}
         />
 
         <CourtCaseStatusesAdmin
-          pageSize={25}
-          rowsPerPageOptions={[10, 25, 50, 100]}
+          pageSize={5}
+          rowsPerPageOptions={[5, 10, 25, 50, 100]}
         />
 
         <LawsuitClaimTypesAdmin
-          pageSize={25}
-          rowsPerPageOptions={[10, 25, 50, 100]}
+          pageSize={5}
+          rowsPerPageOptions={[5, 10, 25, 50, 100]}
         />
 
 
         <LetterTypesAdmin
-          pageSize={25}
-          rowsPerPageOptions={[10, 25, 50, 100]}
+          pageSize={5}
+          rowsPerPageOptions={[5, 10, 25, 50, 100]}
         />
 
         <LetterStatusesAdmin
-          pageSize={25}
-          rowsPerPageOptions={[10, 25, 50, 100]}
+          pageSize={5}
+          rowsPerPageOptions={[5, 10, 25, 50, 100]}
         />
 
 
-        <UsersTable pageSize={25} rowsPerPageOptions={[10, 25, 50, 100]} />
+        <UsersTable pageSize={5} rowsPerPageOptions={[5, 10, 25, 50, 100]} />
 
         <RolePermissionsAdmin />
       </Stack>


### PR DESCRIPTION
## Summary
- set default pageSize to 5 for all admin tables

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856c0d16004832eb5f4067542bfd7f0