### PR TITLE
Update correspondence form UI and mutation

### DIFF
--- a/src/entities/correspondence/index.ts
+++ b/src/entities/correspondence/index.ts
@@ -204,7 +204,7 @@ export function useAddLetter() {
         attachments?: { file: File; type_id: number | null }[];
       }
     ) => {
-      const { attachments = [], parent_id, ...data } = payload as any;
+      const { attachments = [], parent_id, unit_ids = [], ...data } = payload as any;
 
       const senderIds = await getContactIds(data.sender);
       const receiverIds = await getContactIds(data.receiver);
@@ -264,8 +264,8 @@ export function useAddLetter() {
           await supabase.from(LETTER_ATTACH_TABLE).insert(rows);
         }
       }
-      if (data.unit_ids?.length) {
-        const rows = data.unit_ids.map((uid: number) => ({
+      if (unit_ids?.length) {
+        const rows = unit_ids.map((uid: number) => ({
           letter_id: letterId,
           unit_id: uid,
         }));
@@ -287,7 +287,7 @@ export function useAddLetter() {
         status_id: data.status_id ?? null,
         letter_type_id: data.letter_type_id ?? null,
         project_id: data.project_id ?? null,
-        unit_ids: data.unit_ids ?? [],
+        unit_ids: unit_ids ?? [],
         attachment_ids: attachmentIds,
         number: data.number,
         date: data.date,

--- a/src/features/correspondence/AddLetterForm.tsx
+++ b/src/features/correspondence/AddLetterForm.tsx
@@ -291,23 +291,13 @@ export default function AddLetterForm({ onSubmit, parentId = null, initialValues
                     }}
                   >
                     <Button danger icon={<DeleteOutlined />} disabled={!receiverValue} />
-                  </Popconfirm>
+          </Popconfirm>
                 </Space.Compact>
               </Space>
             </Form.Item>
           </Col>
-          <Col span={8}>
-            <Form.Item name="responsible_user_id" label="Ответственный">
-              <Select
-                showSearch
-                loading={loadingUsers}
-                options={users.map((u) => ({ value: u.id, label: u.name }))}
-                allowClear
-                placeholder="Выберите ответственного"
-              />
-            </Form.Item>
-          </Col>
         </Row>
+        <div style={{ height: 16 }} />
         <Row gutter={16}>
           <Col span={8}>
             <Form.Item name="letter_type_id" label="Категория письма">
@@ -359,9 +349,7 @@ export default function AddLetterForm({ onSubmit, parentId = null, initialValues
           {files.map((f, i) => (
               <div key={i} style={{ display: 'flex', alignItems: 'center', marginTop: 4 }}>
                 <span style={{ marginRight: 8 }}>{f.file.name}</span>
-                <Button type="text" danger onClick={() => removeFile(i)}>
-                  Удалить
-                </Button>
+                <Button type="text" danger icon={<DeleteOutlined />} onClick={() => removeFile(i)} />
               </div>
           ))}
         </Form.Item>


### PR DESCRIPTION
## Summary
- tweak AddLetterForm: remove responsible field and use trash icon for files
- adjust useAddLetter mutation to handle unit ids separately

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails with type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856c5b7a194832e8a4492a33e24691f