### PR TITLE
Fix claim attachments query and UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "audit:fix": "npm audit fix && npm audit fix --force",
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node tests/claim.test.js"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/src/entities/claim.ts
+++ b/src/entities/claim.ts
@@ -124,7 +124,7 @@ export function useClaims() {
         ? await supabase
             .from('claim_attachments')
             .select(
-              'claim_id, attachments(id, storage_path, path:file_url, mime_type:file_type, original_name)',
+              'claim_id, attachments(id, storage_path, file_url:path, mime_type:file_type, original_name)',
             )
             .in('claim_id', ids)
         : { data: [], error: null };
@@ -190,7 +190,7 @@ export function useClaim(id?: number | string) {
       const { data: attachRows } = await supabase
         .from('claim_attachments')
         .select(
-          'attachments(id, storage_path, path:file_url, mime_type:file_type, original_name)'
+          'attachments(id, storage_path, file_url:path, mime_type:file_type, original_name)'
         )
         .eq('claim_id', claimId);
       const attachments = (attachRows ?? []).map((row: any) => row.attachments);
@@ -431,7 +431,7 @@ export function useClaimAttachments(id?: number) {
     queryFn: async () => {
       const { data } = await supabase
         .from('claim_attachments')
-        .select('attachments(id, storage_path, path:file_url, mime_type:file_type, original_name)')
+        .select('attachments(id, storage_path, file_url:path, mime_type:file_type, original_name)')
         .eq('claim_id', id as number);
       return (data ?? []).map((r: any) => r.attachments);
     },

--- a/src/features/claim/ClaimAttachmentsBlock.tsx
+++ b/src/features/claim/ClaimAttachmentsBlock.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Form } from 'antd';
+import FileDropZone from '@/shared/ui/FileDropZone';
+import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
+import type { RemoteClaimFile } from '@/shared/types/claimFile';
+import { signedUrl } from '@/entities/claim';
+
+/**
+ * Блок загрузки и отображения файлов претензии.
+ * Используется как в форме создания претензии, так и в просмотре.
+ */
+export interface ClaimAttachmentsBlockProps {
+  /** Файлы, уже загруженные на сервер */
+  remoteFiles?: RemoteClaimFile[];
+  /** Новые файлы, выбранные пользователем */
+  newFiles?: File[];
+  /** Обработчик добавления новых файлов */
+  onFiles?: (files: File[]) => void;
+  /** Удалить файл с сервера */
+  onRemoveRemote?: (id: string) => void;
+  /** Удалить локально выбранный файл */
+  onRemoveNew?: (index: number) => void;
+  /** Показывать ли область загрузки */
+  showUpload?: boolean;
+}
+
+export default function ClaimAttachmentsBlock({
+  remoteFiles = [],
+  newFiles = [],
+  onFiles,
+  onRemoveRemote,
+  onRemoveNew,
+  showUpload = true,
+}: ClaimAttachmentsBlockProps) {
+  return (
+    <Form.Item label="Файлы">
+      {showUpload && <FileDropZone onFiles={onFiles ?? (() => {})} />}
+      <AttachmentEditorTable
+        remoteFiles={remoteFiles.map((f) => ({
+          id: String(f.id),
+          name: f.original_name ?? f.name,
+          path: f.path,
+          mime: f.mime_type,
+        }))}
+        newFiles={newFiles.map((f) => ({ file: f, mime: f.type }))}
+        onRemoveRemote={onRemoveRemote}
+        onRemoveNew={onRemoveNew}
+        getSignedUrl={(path, name) => signedUrl(path, name)}
+        showMime={false}
+      />
+    </Form.Item>
+  );
+}

--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -8,8 +8,7 @@ import {
   Row,
   Col,
 } from 'antd';
-import FileDropZone from '@/shared/ui/FileDropZone';
-import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
+import ClaimAttachmentsBlock from './ClaimAttachmentsBlock';
 import dayjs from 'dayjs';
 import { useVisibleProjects } from '@/entities/project';
 import { useUnitsByProject } from '@/entities/unit';
@@ -210,13 +209,11 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
         </Form.List>
       )}
       {showAttachments && (
-        <Form.Item label="Файлы">
-          <FileDropZone onFiles={handleDropFiles} />
-          <AttachmentEditorTable
-            newFiles={files.map((f) => ({ file: f, mime: f.type }))}
-            onRemoveNew={removeFile}
-          />
-        </Form.Item>
+        <ClaimAttachmentsBlock
+          newFiles={files}
+          onFiles={handleDropFiles}
+          onRemoveNew={removeFile}
+        />
       )}
       {showDefectsForm && (
         <Form.Item style={{ textAlign: 'right' }}>

--- a/src/features/claim/ClaimViewModal.tsx
+++ b/src/features/claim/ClaimViewModal.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Modal, Skeleton, Typography } from 'antd';
-import { useClaim, signedUrl, useRemoveClaimAttachment } from '@/entities/claim';
+import { useClaim, useRemoveClaimAttachment } from '@/entities/claim';
 import type { RemoteClaimFile } from '@/shared/types/claimFile';
-import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
+import ClaimAttachmentsBlock from './ClaimAttachmentsBlock';
 import TicketDefectsTable from '@/widgets/TicketDefectsTable';
 import ClaimFormAntd from './ClaimFormAntd';
 
@@ -57,16 +57,10 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
           ) : null}
           {files.length ? (
             <div style={{ marginTop: 16 }}>
-              <AttachmentEditorTable
-                remoteFiles={files.map((f) => ({
-                  id: String(f.id),
-                  name: f.name,
-                  path: f.path,
-                  mime: (f as any).mime_type,
-                }))}
+              <ClaimAttachmentsBlock
+                remoteFiles={files}
                 onRemoveRemote={handleRemove}
-                getSignedUrl={(path, name) => signedUrl(path, name)}
-                showMime={false}
+                showUpload={false}
               />
             </div>
           ) : null}

--- a/tests/claim.test.js
+++ b/tests/claim.test.js
@@ -1,0 +1,6 @@
+const fs = require('fs');
+const content = fs.readFileSync('src/entities/claim.ts', 'utf8');
+if (!content.includes('file_url:path')) {
+  throw new Error('Alias for file_url:path not found');
+}
+console.log('tests passed');


### PR DESCRIPTION
## Summary
- fix alias for claim attachments in Supabase queries
- extract attachments block for claim forms
- reuse attachments block in claim view
- hide file type column when uploading files
- add simple test to ensure alias is updated

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856c7226494832e928ca137d9be1b68