### PR TITLE
Improve claim view with defect list and attachment upload

### DIFF
--- a/src/features/claim/ClaimAttachmentsBlock.tsx
+++ b/src/features/claim/ClaimAttachmentsBlock.tsx
@@ -21,6 +21,8 @@ export interface ClaimAttachmentsBlockProps {
   onRemoveNew?: (index: number) => void;
   /** Показывать ли область загрузки */
   showUpload?: boolean;
+  /** Получить подписанную ссылку */
+  getSignedUrl?: (path: string, name: string) => Promise<string>;
 }
 
 export default function ClaimAttachmentsBlock({
@@ -30,6 +32,7 @@ export default function ClaimAttachmentsBlock({
   onRemoveRemote,
   onRemoveNew,
   showUpload = true,
+  getSignedUrl,
 }: ClaimAttachmentsBlockProps) {
   return (
     <Form.Item label="Файлы">
@@ -45,6 +48,7 @@ export default function ClaimAttachmentsBlock({
             newFiles={newFiles}
             onRemoveRemote={onRemoveRemote}
             onRemoveNew={onRemoveNew}
+            getSignedUrl={getSignedUrl}
           />
         </Col>
       </Row>

--- a/src/features/claim/ClaimAttachmentsTable.tsx
+++ b/src/features/claim/ClaimAttachmentsTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Table, Button, Tooltip } from 'antd';
-import { DeleteOutlined } from '@ant-design/icons';
+import { DeleteOutlined, DownloadOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import type { RemoteClaimFile } from '@/shared/types/claimFile';
 
@@ -16,6 +16,8 @@ export interface ClaimAttachmentsTableProps {
   onRemoveRemote?: (id: string) => void;
   /** Remove a local file */
   onRemoveNew?: (idx: number) => void;
+  /** Получить подписанную ссылку для скачивания */
+  getSignedUrl?: (path: string, name: string) => Promise<string>;
 }
 
 interface RowData {
@@ -25,6 +27,8 @@ interface RowData {
   size: number | null;
   remote: boolean;
   id?: string;
+  path?: string;
+  file?: File;
 }
 
 /**
@@ -36,15 +40,31 @@ export default function ClaimAttachmentsTable({
   newFiles = [],
   onRemoveRemote,
   onRemoveNew,
+  getSignedUrl,
 }: ClaimAttachmentsTableProps) {
+  const [sizes, setSizes] = React.useState<Record<string, number>>({});
+
+  React.useEffect(() => {
+    remoteFiles.forEach((f) => {
+      const id = String(f.id);
+      if (sizes[id] == null && f.size == null) {
+        fetch(f.url, { method: 'HEAD' })
+          .then((r) => Number(r.headers.get('content-length') || 0))
+          .then((s) => setSizes((p) => ({ ...p, [id]: s })))
+          .catch(() => {});
+      }
+    });
+  }, [remoteFiles, sizes]);
+
   const rows: RowData[] = [
     ...remoteFiles.map((f, idx) => ({
       key: `r-${idx}`,
       index: idx + 1,
       name: f.original_name ?? f.name,
-      size: null,
+      size: f.size ?? sizes[String(f.id)] ?? null,
       remote: true,
       id: String(f.id),
+      path: f.path,
     })),
     ...newFiles.map((f, idx) => ({
       key: `n-${idx}`,
@@ -52,6 +72,7 @@ export default function ClaimAttachmentsTable({
       name: f.name,
       size: f.size,
       remote: false,
+      file: f,
     })),
   ];
 
@@ -70,18 +91,50 @@ export default function ClaimAttachmentsTable({
       dataIndex: 'actions',
       width: 40,
       render: (_: unknown, row) => (
-        <Tooltip title="Удалить">
-          <Button
-            type="text"
-            size="small"
-            danger
-            icon={<DeleteOutlined />}
-            onClick={() => {
-              if (row.remote) row.id && onRemoveRemote?.(row.id);
-              else onRemoveNew?.(Number(row.key.split('-')[1]));
-            }}
-          />
-        </Tooltip>
+        <div style={{ display: 'flex', gap: 4 }}>
+          {row.remote ? (
+            <Tooltip title="Скачать">
+              <Button
+                type="text"
+                size="small"
+                icon={<DownloadOutlined />}
+                onClick={async () => {
+                  if (!row.path) return;
+                  const url = await getSignedUrl?.(row.path, row.name);
+                  if (!url) return;
+                  const a = document.createElement('a');
+                  a.href = url;
+                  a.download = row.name;
+                  document.body.appendChild(a);
+                  a.click();
+                  a.remove();
+                }}
+              />
+            </Tooltip>
+          ) : (
+            <Tooltip title="Скачать">
+              <Button
+                type="text"
+                size="small"
+                icon={<DownloadOutlined />}
+                href={URL.createObjectURL(row.file!)}
+                download={row.name}
+              />
+            </Tooltip>
+          )}
+          <Tooltip title="Удалить">
+            <Button
+              type="text"
+              size="small"
+              danger
+              icon={<DeleteOutlined />}
+              onClick={() => {
+                if (row.remote) row.id && onRemoveRemote?.(row.id);
+                else onRemoveNew?.(Number(row.key.split('-')[1]));
+              }}
+            />
+          </Tooltip>
+        </div>
       ),
     },
   ];

--- a/src/features/claim/ClaimViewModal.tsx
+++ b/src/features/claim/ClaimViewModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Modal, Skeleton, Typography } from 'antd';
-import { useClaim, useRemoveClaimAttachment } from '@/entities/claim';
+import { useClaim, useRemoveClaimAttachment, useAddClaimAttachments, signedUrl } from '@/entities/claim';
 import type { RemoteClaimFile } from '@/shared/types/claimFile';
 import ClaimAttachmentsBlock from './ClaimAttachmentsBlock';
 import TicketDefectsTable from '@/widgets/TicketDefectsTable';
@@ -15,6 +15,7 @@ interface Props {
 export default function ClaimViewModal({ open, claimId, onClose }: Props) {
   const { data: claim } = useClaim(claimId ?? undefined);
   const removeAtt = useRemoveClaimAttachment();
+  const addAtt = useAddClaimAttachments();
   const [files, setFiles] = React.useState<RemoteClaimFile[]>([]);
 
   React.useEffect(() => {
@@ -27,6 +28,19 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
       })) || [],
     );
   }, [claim]);
+
+  const handleAddFiles = async (fls: File[]) => {
+    if (!claim) return;
+    const uploaded = await addAtt.mutateAsync({ claimId: claim.id, files: fls });
+    const newFiles = uploaded.map((u) => ({
+      id: u.id,
+      name: u.original_name ?? u.storage_path.split('/').pop() ?? 'file',
+      path: u.storage_path,
+      mime_type: u.file_type,
+      url: u.file_url,
+    })) as RemoteClaimFile[];
+    setFiles((p) => [...p, ...newFiles]);
+  };
 
   const handleRemove = async (id: string) => {
     await removeAtt.mutateAsync({
@@ -50,20 +64,21 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
             showDefectsForm={false}
             showAttachments={false}
           />
-          {claim.ticket_ids?.length ? (
-            <div style={{ marginTop: 16 }}>
+          <div style={{ marginTop: 16 }}>
+            {claim.ticket_ids?.length ? (
               <TicketDefectsTable defectIds={claim.ticket_ids} />
-            </div>
-          ) : null}
-          {files.length ? (
-            <div style={{ marginTop: 16 }}>
-              <ClaimAttachmentsBlock
-                remoteFiles={files}
-                onRemoveRemote={handleRemove}
-                showUpload={false}
-              />
-            </div>
-          ) : null}
+            ) : (
+              <Typography.Text>Дефекты не указаны</Typography.Text>
+            )}
+          </div>
+          <div style={{ marginTop: 16 }}>
+            <ClaimAttachmentsBlock
+              remoteFiles={files}
+              onRemoveRemote={handleRemove}
+              onFiles={handleAddFiles}
+              getSignedUrl={signedUrl}
+            />
+          </div>
         </>
       ) : (
         <Skeleton active />

--- a/src/shared/types/claimFile.ts
+++ b/src/shared/types/claimFile.ts
@@ -6,6 +6,8 @@ export interface RemoteClaimFile {
   path: string;
   url: string;
   mime_type: string;
+  /** Размер файла в байтах */
+  size?: number;
 }
 
 /** Новый файл для вложения претензии */

--- a/src/widgets/DefectEditableTable.tsx
+++ b/src/widgets/DefectEditableTable.tsx
@@ -186,7 +186,7 @@ export default function DefectEditableTable({ fields, add, remove, projectId, fi
               size="small"
               placeholder="Статус"
               style={{ minWidth: 160 }}
-              dropdownMatchSelectWidth={false}
+              popupMatchSelectWidth={false}
               options={defectStatuses.map((s) => ({ value: s.id, label: s.name }))}
             />
           </Form.Item>
@@ -215,7 +215,7 @@ export default function DefectEditableTable({ fields, add, remove, projectId, fi
                 (o?.label ?? '').toLowerCase().includes(i.toLowerCase())
               }
               style={{ minWidth: 160, width: '100%' }}
-              dropdownMatchSelectWidth={false}
+              popupMatchSelectWidth={false}
               options={defectTypes.map((d) => ({ value: d.id, label: d.name }))}
             />
           </Form.Item>


### PR DESCRIPTION
## Summary
- show defect table and attachments on claim view modal
- allow uploading additional claim files with download links
- display file sizes in attachments table
- fix deprecated antd prop usage

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856dddb75d4832e9c6e053c76e23960