### PR TITLE
Improve attachments UI and defects form

### DIFF
--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState } from "react";
 import {
   Form,
   Input,
@@ -7,22 +7,31 @@ import {
   Button,
   Row,
   Col,
-} from 'antd';
-import ClaimAttachmentsBlock from './ClaimAttachmentsBlock';
-import dayjs from 'dayjs';
-import { useVisibleProjects } from '@/entities/project';
-import { useUnitsByProject } from '@/entities/unit';
-import { useUsers } from '@/entities/user';
-import { useClaimStatuses } from '@/entities/claimStatus';
-import { useCreateClaim } from '@/entities/claim';
-import { useProjectId } from '@/shared/hooks/useProjectId';
-import { useNotify } from '@/shared/hooks/useNotify';
-import DefectEditableTable from '@/widgets/DefectEditableTable';
-import { useCreateDefects, type NewDefect } from '@/entities/defect';
+  Affix,
+  Space,
+} from "antd";
+import { CheckOutlined } from "@ant-design/icons";
+import ClaimAttachmentsBlock from "./ClaimAttachmentsBlock";
+import dayjs from "dayjs";
+import { useVisibleProjects } from "@/entities/project";
+import { useUnitsByProject } from "@/entities/unit";
+import { useUsers } from "@/entities/user";
+import { useClaimStatuses } from "@/entities/claimStatus";
+import { useCreateClaim } from "@/entities/claim";
+import { useProjectId } from "@/shared/hooks/useProjectId";
+import { useNotify } from "@/shared/hooks/useNotify";
+import DefectEditableTable from "@/widgets/DefectEditableTable";
+import { useCreateDefects, type NewDefect } from "@/entities/defect";
 
 export interface ClaimFormAntdProps {
   onCreated?: () => void;
-  initialValues?: Partial<{ project_id: number; unit_ids: number[]; engineer_id: string }>;
+  /** Нажатие на кнопку отмены */
+  onCancel?: () => void;
+  initialValues?: Partial<{
+    project_id: number;
+    unit_ids: number[];
+    engineer_id: string;
+  }>;
   /** Показывать форму добавления дефектов */
   showDefectsForm?: boolean;
   /** Показывать блок загрузки файлов */
@@ -50,11 +59,17 @@ export interface ClaimFormValues {
   }>;
 }
 
-export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefectsForm = true, showAttachments = true }: ClaimFormAntdProps) {
+export default function ClaimFormAntd({
+  onCreated,
+  onCancel,
+  initialValues = {},
+  showDefectsForm = true,
+  showAttachments = true,
+}: ClaimFormAntdProps) {
   const [form] = Form.useForm<ClaimFormValues>();
   const [files, setFiles] = useState<File[]>([]);
   const globalProjectId = useProjectId();
-  const projectIdWatch = Form.useWatch('project_id', form) ?? globalProjectId;
+  const projectIdWatch = Form.useWatch("project_id", form) ?? globalProjectId;
   const projectId = projectIdWatch != null ? Number(projectIdWatch) : null;
 
   const { data: projects = [] } = useVisibleProjects();
@@ -68,23 +83,29 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
   const handleDropFiles = (dropped: File[]) => {
     setFiles((p) => [...p, ...dropped]);
   };
-  const removeFile = (idx: number) => setFiles((p) => p.filter((_, i) => i !== idx));
+  const removeFile = (idx: number) =>
+    setFiles((p) => p.filter((_, i) => i !== idx));
 
   useEffect(() => {
     if (initialValues.project_id != null) {
-      form.setFieldValue('project_id', initialValues.project_id);
+      form.setFieldValue("project_id", initialValues.project_id);
     } else if (globalProjectId) {
-      form.setFieldValue('project_id', Number(globalProjectId));
+      form.setFieldValue("project_id", Number(globalProjectId));
     }
-    if (initialValues.unit_ids) form.setFieldValue('unit_ids', initialValues.unit_ids);
+    if (initialValues.unit_ids)
+      form.setFieldValue("unit_ids", initialValues.unit_ids);
     if (initialValues.engineer_id)
-      form.setFieldValue('engineer_id', initialValues.engineer_id);
-    if (initialValues.claim_status_id != null) form.setFieldValue('claim_status_id', initialValues.claim_status_id);
-    if (initialValues.claim_no) form.setFieldValue('claim_no', initialValues.claim_no);
-    if (initialValues.claimed_on) form.setFieldValue('claimed_on', dayjs(initialValues.claimed_on));
+      form.setFieldValue("engineer_id", initialValues.engineer_id);
+    if (initialValues.claim_status_id != null)
+      form.setFieldValue("claim_status_id", initialValues.claim_status_id);
+    if (initialValues.claim_no)
+      form.setFieldValue("claim_no", initialValues.claim_no);
+    if (initialValues.claimed_on)
+      form.setFieldValue("claimed_on", dayjs(initialValues.claimed_on));
     if (initialValues.accepted_on)
-      form.setFieldValue('accepted_on', dayjs(initialValues.accepted_on));
-    if (initialValues.registered_on) form.setFieldValue('registered_on', dayjs(initialValues.registered_on));
+      form.setFieldValue("accepted_on", dayjs(initialValues.accepted_on));
+    if (initialValues.registered_on)
+      form.setFieldValue("registered_on", dayjs(initialValues.registered_on));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [globalProjectId, form]);
 
@@ -95,16 +116,16 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
     if (
       statuses.length &&
       !initialValues.claim_status_id &&
-      !form.getFieldValue('claim_status_id')
+      !form.getFieldValue("claim_status_id")
     ) {
-      form.setFieldValue('claim_status_id', statuses[0].id);
+      form.setFieldValue("claim_status_id", statuses[0].id);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [statuses, form]);
 
   useEffect(() => {
     if (!initialValues.unit_ids) {
-      form.setFieldValue('unit_ids', []);
+      form.setFieldValue("unit_ids", []);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectId, form]);
@@ -113,27 +134,33 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
     if (!showDefectsForm) return;
     const { defects: defs, ...rest } = values;
     if (!defs || defs.length === 0) {
-      notify.error('Добавьте хотя бы один дефект');
+      notify.error("Добавьте хотя бы один дефект");
       return;
     }
     const newDefs: NewDefect[] = defs.map((d) => ({
-      description: d.description || '',
+      description: d.description || "",
       defect_type_id: d.type_id ?? null,
       defect_status_id: d.status_id ?? null,
       brigade_id: d.brigade_id ?? null,
       contractor_id: d.contractor_id ?? null,
       is_warranty: d.is_warranty ?? false,
-      received_at: d.received_at ? d.received_at.format('YYYY-MM-DD') : null,
-      fixed_at: d.fixed_at ? d.fixed_at.format('YYYY-MM-DD') : null,
+      received_at: d.received_at ? d.received_at.format("YYYY-MM-DD") : null,
+      fixed_at: d.fixed_at ? d.fixed_at.format("YYYY-MM-DD") : null,
     }));
     await createDefects.mutateAsync(newDefs);
     await create.mutateAsync({
       ...rest,
       attachments: files,
       project_id: values.project_id ?? globalProjectId,
-      claimed_on: values.claimed_on ? values.claimed_on.format('YYYY-MM-DD') : null,
-      accepted_on: values.accepted_on ? values.accepted_on.format('YYYY-MM-DD') : null,
-      registered_on: values.registered_on ? values.registered_on.format('YYYY-MM-DD') : null,
+      claimed_on: values.claimed_on
+        ? values.claimed_on.format("YYYY-MM-DD")
+        : null,
+      accepted_on: values.accepted_on
+        ? values.accepted_on.format("YYYY-MM-DD")
+        : null,
+      registered_on: values.registered_on
+        ? values.registered_on.format("YYYY-MM-DD")
+        : null,
     } as any);
     form.resetFields();
     setFiles([]);
@@ -144,53 +171,92 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
     <Form form={form} layout="vertical" onFinish={onFinish} autoComplete="off">
       <Row gutter={16}>
         <Col span={8}>
-          <Form.Item name="project_id" label="Проект" rules={[{ required: true }]}> 
-            <Select allowClear showSearch options={projects.map((p) => ({ value: p.id, label: p.name }))} />
+          <Form.Item
+            name="project_id"
+            label="Проект"
+            rules={[{ required: true }]}
+          >
+            <Select
+              allowClear
+              showSearch
+              options={projects.map((p) => ({ value: p.id, label: p.name }))}
+            />
           </Form.Item>
         </Col>
         <Col span={8}>
-          <Form.Item name="unit_ids" label="Объекты" rules={[{ required: true }]}> 
+          <Form.Item
+            name="unit_ids"
+            label="Объекты"
+            rules={[{ required: true }]}
+          >
             <Select
               mode="multiple"
               showSearch
-              filterOption={(i, o) => (o?.label ?? '').toLowerCase().includes(i.toLowerCase())}
+              filterOption={(i, o) =>
+                (o?.label ?? "").toLowerCase().includes(i.toLowerCase())
+              }
               options={units.map((u) => ({ value: u.id, label: u.name }))}
               disabled={!projectId}
             />
           </Form.Item>
         </Col>
         <Col span={8}>
-          <Form.Item name="engineer_id" label="Закрепленный инженер" rules={[{ required: true }]}> 
-            <Select allowClear showSearch options={users.map((u) => ({ value: u.id, label: u.name }))} />
+          <Form.Item
+            name="engineer_id"
+            label="Закрепленный инженер"
+            rules={[{ required: true }]}
+          >
+            <Select
+              allowClear
+              showSearch
+              options={users.map((u) => ({ value: u.id, label: u.name }))}
+            />
           </Form.Item>
         </Col>
       </Row>
       <Row gutter={16}>
         <Col span={8}>
-          <Form.Item name="claim_no" label="№ претензии" rules={[{ required: true }]}> 
+          <Form.Item
+            name="claim_no"
+            label="№ претензии"
+            rules={[{ required: true }]}
+          >
             <Input />
           </Form.Item>
         </Col>
         <Col span={8}>
           <Form.Item name="claimed_on" label="Дата претензии">
-            <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+            <DatePicker format="DD.MM.YYYY" style={{ width: "100%" }} />
           </Form.Item>
         </Col>
         <Col span={8}>
-          <Form.Item name="accepted_on" label="Дата получения претензии Застройщиком">
-            <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+          <Form.Item
+            name="accepted_on"
+            label="Дата получения претензии Застройщиком"
+          >
+            <DatePicker format="DD.MM.YYYY" style={{ width: "100%" }} />
           </Form.Item>
         </Col>
       </Row>
       <Row gutter={16}>
         <Col span={8}>
-          <Form.Item name="registered_on" label="Дата регистрации претензии GARANTHUB">
-            <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+          <Form.Item
+            name="registered_on"
+            label="Дата регистрации претензии GARANTHUB"
+          >
+            <DatePicker format="DD.MM.YYYY" style={{ width: "100%" }} />
           </Form.Item>
         </Col>
         <Col span={8}>
-          <Form.Item name="claim_status_id" label="Статус" rules={[{ required: true }]}> 
-            <Select showSearch options={statuses.map((s) => ({ value: s.id, label: s.name }))} />
+          <Form.Item
+            name="claim_status_id"
+            label="Статус"
+            rules={[{ required: true }]}
+          >
+            <Select
+              showSearch
+              options={statuses.map((s) => ({ value: s.id, label: s.name }))}
+            />
           </Form.Item>
         </Col>
       </Row>
@@ -215,11 +281,24 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
         />
       )}
       {showDefectsForm && (
-        <Form.Item style={{ textAlign: 'right' }}>
-          <Button type="primary" htmlType="submit" loading={create.isPending}>
-            Создать
-          </Button>
-        </Form.Item>
+        <Affix offsetBottom={16}>
+          <Space>
+            {onCancel && (
+              <Button aria-label="Отмена" onClick={onCancel}>
+                Отмена
+              </Button>
+            )}
+            <Button
+              type="primary"
+              htmlType="submit"
+              icon={<CheckOutlined />}
+              loading={create.isPending}
+              aria-label="Создать"
+            >
+              Создать
+            </Button>
+          </Space>
+        </Affix>
       )}
     </Form>
   );

--- a/src/widgets/DefectEditableTable.tsx
+++ b/src/widgets/DefectEditableTable.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo } from 'react';
-import dayjs from 'dayjs';
+import React, { useMemo, useRef, useEffect } from "react";
+import dayjs from "dayjs";
 import {
   Table,
   Button,
@@ -14,16 +14,20 @@ import {
   Radio,
   Upload,
   Switch,
-} from 'antd';
-import { PlusOutlined, DeleteOutlined, UploadOutlined } from '@ant-design/icons';
-import { useDefectTypes } from '@/entities/defectType';
-import { useDefectStatuses } from '@/entities/defectStatus';
-import { useDefectDeadlines } from '@/entities/defectDeadline';
-import { useBrigades } from '@/entities/brigade';
-import { useContractors } from '@/entities/contractor';
-import type { ColumnsType } from 'antd/es/table';
-import type { FormInstance } from 'antd/es/form';
-import type { NewDefectFile } from '@/shared/types/defectFile';
+} from "antd";
+import {
+  PlusOutlined,
+  DeleteOutlined,
+  UploadOutlined,
+} from "@ant-design/icons";
+import { useDefectTypes } from "@/entities/defectType";
+import { useDefectStatuses } from "@/entities/defectStatus";
+import { useDefectDeadlines } from "@/entities/defectDeadline";
+import { useBrigades } from "@/entities/brigade";
+import { useContractors } from "@/entities/contractor";
+import type { ColumnsType } from "antd/es/table";
+import type { FormInstance } from "antd/es/form";
+import type { NewDefectFile } from "@/shared/types/defectFile";
 
 /**
  * Props for {@link DefectEditableTable}
@@ -58,17 +62,20 @@ interface FixByFieldProps {
 
 const FixByField: React.FC<FixByFieldProps> = React.memo(
   ({ field, form, brigades, contractors }) => {
-    const brigadePath = [field.name, 'brigade_id'];
-    const contractorPath = [field.name, 'contractor_id'];
+    const brigadePath = [field.name, "brigade_id"];
+    const contractorPath = [field.name, "contractor_id"];
     const brigadeVal: number | undefined = Form.useWatch(brigadePath, form);
-    const contractorVal: number | undefined = Form.useWatch(contractorPath, form);
-    const [mode, setMode] = React.useState<'brigade' | 'contractor'>(
-      contractorVal ? 'contractor' : 'brigade',
+    const contractorVal: number | undefined = Form.useWatch(
+      contractorPath,
+      form,
+    );
+    const [mode, setMode] = React.useState<"brigade" | "contractor">(
+      contractorVal ? "contractor" : "brigade",
     );
 
-    const handleModeChange = (value: 'brigade' | 'contractor') => {
+    const handleModeChange = (value: "brigade" | "contractor") => {
       setMode(value);
-      if (value === 'brigade') {
+      if (value === "brigade") {
         form.setFieldValue(contractorPath, null);
       } else {
         form.setFieldValue(brigadePath, null);
@@ -76,21 +83,21 @@ const FixByField: React.FC<FixByFieldProps> = React.memo(
     };
 
     React.useEffect(() => {
-      if (contractorVal && mode !== 'contractor') {
-        setMode('contractor');
-      } else if (brigadeVal && mode !== 'brigade') {
-        setMode('brigade');
+      if (contractorVal && mode !== "contractor") {
+        setMode("contractor");
+      } else if (brigadeVal && mode !== "brigade") {
+        setMode("brigade");
       }
     }, [brigadeVal, contractorVal]);
 
-    const namePath = mode === 'brigade' ? brigadePath : contractorPath;
-    const options = (mode === 'brigade' ? brigades : contractors).map((b) => ({
+    const namePath = mode === "brigade" ? brigadePath : contractorPath;
+    const options = (mode === "brigade" ? brigades : contractors).map((b) => ({
       value: b.id,
       label: b.name,
     }));
 
     return (
-      <Space direction="vertical" style={{ width: '100%' }}>
+      <Space direction="vertical" style={{ width: "100%" }}>
         <Radio.Group
           size="small"
           value={mode}
@@ -105,10 +112,10 @@ const FixByField: React.FC<FixByFieldProps> = React.memo(
             size="small"
             placeholder="Исполнитель"
             showSearch
-            style={{ width: '100%' }}
+            style={{ width: "100%" }}
             options={options}
             filterOption={(i, o) =>
-              (o?.label ?? '').toLowerCase().includes(i.toLowerCase())
+              (o?.label ?? "").toLowerCase().includes(i.toLowerCase())
             }
           />
         </Form.Item>
@@ -121,13 +128,30 @@ const FixByField: React.FC<FixByFieldProps> = React.memo(
  * Editable table for adding defects inside ticket form.
  * Shows skeleton until defect types and statuses are loaded.
  */
-export default function DefectEditableTable({ fields, add, remove, projectId, fileMap = {}, onFilesChange, showFiles = true }: Props) {
+export default function DefectEditableTable({
+  fields,
+  add,
+  remove,
+  projectId,
+  fileMap = {},
+  onFilesChange,
+  showFiles = true,
+}: Props) {
   const { data: defectTypes = [], isPending: loadingTypes } = useDefectTypes();
-  const { data: defectStatuses = [], isPending: loadingStatuses } = useDefectStatuses();
+  const { data: defectStatuses = [], isPending: loadingStatuses } =
+    useDefectStatuses();
   const { data: deadlines = [] } = useDefectDeadlines();
   const { data: brigades = [] } = useBrigades();
   const { data: contractors = [] } = useContractors();
   const form = Form.useFormInstance();
+  const descRefs = useRef<Record<number, HTMLTextAreaElement | null>>({});
+
+  useEffect(() => {
+    const ref = descRefs.current[fields.length - 1];
+    if (ref) {
+      ref.focus();
+    }
+  }, [fields.length]);
 
   const getFixDays = (typeId: number | null | undefined) => {
     if (!projectId || !typeId) return null;
@@ -137,245 +161,284 @@ export default function DefectEditableTable({ fields, add, remove, projectId, fi
     return rec?.fix_days ?? null;
   };
 
-
   const columns: ColumnsType<any> = useMemo(
     () =>
       [
-      {
-        title: '#',
-        dataIndex: 'index',
-        width: 40,
-        render: (_: any, __: any, i: number) => i + 1,
-      },
-      {
-        title: (
-          <span>
-            Описание дефекта<span style={{ color: 'red' }}>*</span>
-          </span>
-        ),
-        dataIndex: 'description',
-        width: 240,
-        ellipsis: true,
-        render: (_: any, field: any) => (
-          <Form.Item
-            name={[field.name, 'description']}
-            noStyle
-            rules={[{ required: true, message: 'Введите описание' }]}
-          >
-            <Input.TextArea size="small" autoSize placeholder="Описание" />
-          </Form.Item>
-        ),
-      },
-      {
-        title: (
-          <span>
-            Статус<span style={{ color: 'red' }}>*</span>
-          </span>
-        ),
-        dataIndex: 'status_id',
-        width: 180,
-        ellipsis: true,
-        render: (_: any, field: any) => (
-          <Form.Item
-            name={[field.name, 'status_id']}
-            noStyle
-            rules={[{ required: true, message: 'Выберите статус' }]}
-            initialValue={defectStatuses[0]?.id}
-          >
-            <Select
-              size="small"
-              placeholder="Статус"
-              style={{ minWidth: 160 }}
-              popupMatchSelectWidth={false}
-              options={defectStatuses.map((s) => ({ value: s.id, label: s.name }))}
-            />
-          </Form.Item>
-        ),
-      },
-      {
-        title: (
-          <span>
-            Тип<span style={{ color: 'red' }}>*</span>
-          </span>
-        ),
-        dataIndex: 'type_id',
-        width: 200,
-        ellipsis: true,
-        render: (_: any, field: any) => (
-          <Form.Item
-            name={[field.name, 'type_id']}
-            noStyle
-            rules={[{ required: true, message: 'Выберите тип' }]}
-          >
-            <Select
-              size="small"
-              placeholder="Тип"
-              showSearch
-              filterOption={(i, o) =>
-                (o?.label ?? '').toLowerCase().includes(i.toLowerCase())
-              }
-              style={{ minWidth: 160, width: '100%' }}
-              popupMatchSelectWidth={false}
-              options={defectTypes.map((d) => ({ value: d.id, label: d.name }))}
-            />
-          </Form.Item>
-        ),
-      },
-      {
-        title: 'Гарантия',
-        dataIndex: 'is_warranty',
-        width: 100,
-        render: (_: any, field: any) => (
-          <Form.Item name={[field.name, 'is_warranty']} valuePropName="checked" noStyle initialValue={false}>
-            <Switch size="small" />
-          </Form.Item>
-        ),
-      },
-      {
-        title: (
-          <span>
-            Дата получения<span style={{ color: 'red' }}>*</span>
-          </span>
-        ),
-        dataIndex: 'received_at',
-        width: 200,
-        ellipsis: true,
-        render: (_: any, field: any) => (
-          <Space direction="vertical" size={2}>
+        {
+          title: "#",
+          dataIndex: "index",
+          width: 40,
+          render: (_: any, __: any, i: number) => i + 1,
+        },
+        {
+          title: (
+            <span>
+              Описание дефекта<span style={{ color: "red" }}>*</span>
+            </span>
+          ),
+          dataIndex: "description",
+          width: 240,
+          ellipsis: true,
+          render: (_: any, field: any) => (
             <Form.Item
-              name={[field.name, 'received_at']}
+              name={[field.name, "description"]}
               noStyle
-              rules={[{ required: true, message: 'Укажите дату' }]}
-              initialValue={dayjs()}
+              rules={[{ required: true, message: "Введите описание" }]}
             >
-              <DatePicker size="small" format="DD.MM.YYYY" style={{ width: '100%' }} />
+              <Input.TextArea
+                size="small"
+                autoSize
+                placeholder="Описание"
+                ref={(el) => {
+                  descRefs.current[field.name] = el;
+                }}
+              />
             </Form.Item>
-            <Space size={4}>
-              {[10, 45, 60].map((d) => (
-                <Tag
-                  key={d}
-                  color="blue"
-                  onClick={() => {
-                    const rec = form.getFieldValue(['defects', field.name, 'received_at']);
-                    if (rec) {
-                      form.setFieldValue(
-                        ['defects', field.name, 'fixed_at'],
-                        dayjs(rec).add(d, 'day'),
-                      );
-                    }
-                  }}
-                  style={{ cursor: 'pointer' }}
-                >
-                  +{d}
-                </Tag>
-              ))}
-              {(() => {
-                const t = form.getFieldValue(['defects', field.name, 'type_id']);
-                const fd = getFixDays(t);
-                return fd ? (
+          ),
+        },
+        {
+          title: (
+            <span>
+              Статус<span style={{ color: "red" }}>*</span>
+            </span>
+          ),
+          dataIndex: "status_id",
+          width: 180,
+          ellipsis: true,
+          render: (_: any, field: any) => (
+            <Form.Item
+              name={[field.name, "status_id"]}
+              noStyle
+              rules={[{ required: true, message: "Выберите статус" }]}
+              initialValue={defectStatuses[0]?.id}
+            >
+              <Select
+                size="small"
+                placeholder="Статус"
+                style={{ minWidth: 160 }}
+                popupMatchSelectWidth={false}
+                options={defectStatuses.map((s) => ({
+                  value: s.id,
+                  label: s.name,
+                }))}
+              />
+            </Form.Item>
+          ),
+        },
+        {
+          title: (
+            <span>
+              Тип<span style={{ color: "red" }}>*</span>
+            </span>
+          ),
+          dataIndex: "type_id",
+          width: 200,
+          ellipsis: true,
+          render: (_: any, field: any) => (
+            <Form.Item
+              name={[field.name, "type_id"]}
+              noStyle
+              rules={[{ required: true, message: "Выберите тип" }]}
+            >
+              <Select
+                size="small"
+                placeholder="Тип"
+                showSearch
+                filterOption={(i, o) =>
+                  (o?.label ?? "").toLowerCase().includes(i.toLowerCase())
+                }
+                style={{ minWidth: 160, width: "100%" }}
+                popupMatchSelectWidth={false}
+                options={defectTypes.map((d) => ({
+                  value: d.id,
+                  label: d.name,
+                }))}
+              />
+            </Form.Item>
+          ),
+        },
+        {
+          title: "Гарантия",
+          dataIndex: "is_warranty",
+          width: 100,
+          render: (_: any, field: any) => (
+            <Form.Item
+              name={[field.name, "is_warranty"]}
+              valuePropName="checked"
+              noStyle
+              initialValue={false}
+            >
+              <Switch size="small" />
+            </Form.Item>
+          ),
+        },
+        {
+          title: (
+            <span>
+              Дата получения<span style={{ color: "red" }}>*</span>
+            </span>
+          ),
+          dataIndex: "received_at",
+          width: 200,
+          ellipsis: true,
+          render: (_: any, field: any) => (
+            <Space direction="vertical" size={2}>
+              <Form.Item
+                name={[field.name, "received_at"]}
+                noStyle
+                rules={[{ required: true, message: "Укажите дату" }]}
+                initialValue={dayjs()}
+              >
+                <DatePicker
+                  size="small"
+                  format="DD.MM.YYYY"
+                  style={{ width: "100%" }}
+                />
+              </Form.Item>
+              <Space size={4}>
+                {[10, 45, 60].map((d) => (
                   <Tag
-                    color="green"
+                    key={d}
+                    color="blue"
                     onClick={() => {
-                      const rec = form.getFieldValue(['defects', field.name, 'received_at']);
+                      const rec = form.getFieldValue([
+                        "defects",
+                        field.name,
+                        "received_at",
+                      ]);
                       if (rec) {
                         form.setFieldValue(
-                          ['defects', field.name, 'fixed_at'],
-                          dayjs(rec).add(fd, 'day'),
+                          ["defects", field.name, "fixed_at"],
+                          dayjs(rec).add(d, "day"),
                         );
                       }
                     }}
-                    style={{ cursor: 'pointer' }}
+                    style={{ cursor: "pointer" }}
                   >
-                    +{fd}
+                    +{d}
                   </Tag>
-                ) : null;
-              })()}
+                ))}
+                {(() => {
+                  const t = form.getFieldValue([
+                    "defects",
+                    field.name,
+                    "type_id",
+                  ]);
+                  const fd = getFixDays(t);
+                  return fd ? (
+                    <Tag
+                      color="green"
+                      onClick={() => {
+                        const rec = form.getFieldValue([
+                          "defects",
+                          field.name,
+                          "received_at",
+                        ]);
+                        if (rec) {
+                          form.setFieldValue(
+                            ["defects", field.name, "fixed_at"],
+                            dayjs(rec).add(fd, "day"),
+                          );
+                        }
+                      }}
+                      style={{ cursor: "pointer" }}
+                    >
+                      +{fd}
+                    </Tag>
+                  ) : null;
+                })()}
+              </Space>
             </Space>
-          </Space>
-        ),
-      },
-      {
-        title: (
-          <span>
-            Дата устранения<span style={{ color: 'red' }}>*</span>
-          </span>
-        ),
-        dataIndex: 'fixed_at',
-        width: 180,
-        ellipsis: true,
-        render: (_: any, field: any) => (
-          <Form.Item
-            name={[field.name, 'fixed_at']}
-            noStyle
-            rules={[{ required: true, message: 'Укажите дату' }]}
-          >
-            <DatePicker size="small" format="DD.MM.YYYY" style={{ width: '100%' }} />
-          </Form.Item>
-        ),
-      },
-      {
-        title: 'Кем устраняется',
-        dataIndex: 'executor',
-        width: 180,
-        ellipsis: true,
-        render: (_: any, field: any) => (
-          <FixByField
-            field={field}
-            form={form}
-            brigades={brigades}
-            contractors={contractors}
-          />
-        ),
-      },
-      showFiles
-        ? {
-            title: 'Файлы',
-            dataIndex: 'files',
-            width: 200,
-            render: (_: any, field: any) => (
-              <Upload
-                multiple
-                beforeUpload={(file) => {
-                  const cur = fileMap[field.name] ?? [];
-                  const arr = [...cur, { file, type_id: null }];
-                  onFilesChange?.(field.name, arr);
-                  return false;
-                }}
-                onRemove={(info) => {
-                  const cur = fileMap[field.name] ?? [];
-                  const idx = Number(info.uid);
-                  const arr = cur.filter((_, i) => i !== idx);
-                  onFilesChange?.(field.name, arr);
-                  return false;
-                }}
-                fileList={(fileMap[field.name] ?? []).map((f, i) => ({
-                  uid: String(i),
-                  name: f.file.name,
-                  status: 'done',
-                }))}
-              >
-                <Button size="small" icon={<UploadOutlined />}>Загрузить</Button>
-              </Upload>
-            ),
-          }
-        : null,
-      {
-        title: '',
-        dataIndex: 'actions',
-        width: 60,
-        render: (_: any, field: any) => (
-          <Tooltip title="Удалить">
-            <Button
-              size="small"
-              type="text"
-              danger
-              icon={<DeleteOutlined />}
-              onClick={() => remove(field.name)}
+          ),
+        },
+        {
+          title: (
+            <span>
+              Дата устранения<span style={{ color: "red" }}>*</span>
+            </span>
+          ),
+          dataIndex: "fixed_at",
+          width: 180,
+          ellipsis: true,
+          render: (_: any, field: any) => (
+            <Form.Item
+              name={[field.name, "fixed_at"]}
+              noStyle
+              rules={[{ required: true, message: "Укажите дату" }]}
+            >
+              <DatePicker
+                size="small"
+                format="DD.MM.YYYY"
+                style={{ width: "100%" }}
+              />
+            </Form.Item>
+          ),
+        },
+        {
+          title: "Кем устраняется",
+          dataIndex: "executor",
+          width: 180,
+          ellipsis: true,
+          render: (_: any, field: any) => (
+            <FixByField
+              field={field}
+              form={form}
+              brigades={brigades}
+              contractors={contractors}
             />
-          </Tooltip>
-        ),
-      },
-    ].filter(Boolean),
+          ),
+        },
+        showFiles
+          ? {
+              title: "Файлы",
+              dataIndex: "files",
+              width: 200,
+              render: (_: any, field: any) => (
+                <Upload
+                  multiple
+                  beforeUpload={(file) => {
+                    const cur = fileMap[field.name] ?? [];
+                    const arr = [...cur, { file, type_id: null }];
+                    onFilesChange?.(field.name, arr);
+                    return false;
+                  }}
+                  onRemove={(info) => {
+                    const cur = fileMap[field.name] ?? [];
+                    const idx = Number(info.uid);
+                    const arr = cur.filter((_, i) => i !== idx);
+                    onFilesChange?.(field.name, arr);
+                    return false;
+                  }}
+                  fileList={(fileMap[field.name] ?? []).map((f, i) => ({
+                    uid: String(i),
+                    name: f.file.name,
+                    status: "done",
+                  }))}
+                >
+                  <Button size="small" icon={<UploadOutlined />}>
+                    Загрузить
+                  </Button>
+                </Upload>
+              ),
+            }
+          : null,
+        {
+          title: "",
+          dataIndex: "actions",
+          width: 60,
+          render: (_: any, field: any) => (
+            <Tooltip title="Удалить">
+              <Button
+                size="small"
+                type="text"
+                danger
+                icon={<DeleteOutlined />}
+                onClick={() => remove(field.name)}
+              />
+            </Tooltip>
+          ),
+        },
+      ].filter(Boolean),
     [defectTypes, defectStatuses, remove, showFiles, fileMap],
   );
 
@@ -385,14 +448,20 @@ export default function DefectEditableTable({ fields, add, remove, projectId, fi
 
   return (
     <div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          marginBottom: 8,
+        }}
+      >
         <span style={{ fontWeight: 500 }}>Дефекты</span>
         <Button
           type="primary"
           icon={<PlusOutlined />}
           onClick={() =>
             add({
-              description: '',
+              description: "",
               status_id: defectStatuses[0]?.id ?? null,
               type_id: null,
               is_warranty: false,


### PR DESCRIPTION
## Summary
- update claim attachments block with Ant Design `Upload.Dragger`
- autofocus new defect row description
- affix create/cancel buttons in claim form
- allow canceling claim creation from claims page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6856e2a68a38832e8f52468a58e3cc51