### PR TITLE
Add claim description field and edit form

### DIFF
--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -22,7 +22,7 @@ import { useCreateDefects, type NewDefect } from '@/entities/defect';
 
 export interface ClaimFormAntdProps {
   onCreated?: () => void;
-  initialValues?: Partial<{ project_id: number; unit_ids: number[]; engineer_id: string }>;
+  initialValues?: Partial<{ project_id: number; unit_ids: number[]; engineer_id: string; description: string }>;
   /** Показывать форму добавления дефектов */
   showDefectsForm?: boolean;
   /** Показывать блок загрузки файлов */
@@ -38,6 +38,7 @@ export interface ClaimFormValues {
   accepted_on: dayjs.Dayjs | null;
   registered_on: dayjs.Dayjs | null;
   engineer_id: string | null;
+  description: string | null;
   defects?: Array<{
     type_id: number | null;
     fixed_at: dayjs.Dayjs | null;
@@ -85,6 +86,7 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
     if (initialValues.accepted_on)
       form.setFieldValue('accepted_on', dayjs(initialValues.accepted_on));
     if (initialValues.registered_on) form.setFieldValue('registered_on', dayjs(initialValues.registered_on));
+    if (initialValues.description) form.setFieldValue('description', initialValues.description);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [globalProjectId, form]);
 
@@ -191,6 +193,13 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
         <Col span={8}>
           <Form.Item name="claim_status_id" label="Статус" rules={[{ required: true }]}> 
             <Select showSearch options={statuses.map((s) => ({ value: s.id, label: s.name }))} />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={24}>
+          <Form.Item name="description" label="Дополнительная информация">
+            <Input.TextArea rows={2} />
           </Form.Item>
         </Col>
       </Row>

--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -1,0 +1,278 @@
+import React, { useEffect } from 'react';
+import type { Dayjs } from 'dayjs';
+import {
+  Form,
+  Input,
+  Select,
+  DatePicker,
+  Row,
+  Col,
+  Button,
+  Skeleton,
+} from 'antd';
+import {
+  useClaim,
+  useUpdateClaim,
+  useAddClaimAttachments,
+  useRemoveClaimAttachment,
+  signedUrl,
+} from '@/entities/claim';
+import { useVisibleProjects } from '@/entities/project';
+import { useUnitsByProject } from '@/entities/unit';
+import { useUsers } from '@/entities/user';
+import { useClaimStatuses } from '@/entities/claimStatus';
+import { useNotify } from '@/shared/hooks/useNotify';
+import { useProjectId } from '@/shared/hooks/useProjectId';
+import { useAuthStore } from '@/shared/store/authStore';
+import { useChangedFields } from '@/shared/hooks/useChangedFields';
+import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
+import FileDropZone from '@/shared/ui/FileDropZone';
+import { useClaimAttachments } from './model/useClaimAttachments';
+import type { RemoteClaimFile } from '@/shared/types/claimFile';
+
+export interface ClaimFormAntdEditProps {
+  claimId: string | number;
+  onCancel?: () => void;
+  onSaved?: () => void;
+  embedded?: boolean;
+}
+
+export interface ClaimFormAntdEditValues {
+  project_id: number | null;
+  unit_ids: number[];
+  claim_status_id: number | null;
+  claim_no: string;
+  claimed_on: Dayjs | null;
+  accepted_on: Dayjs | null;
+  registered_on: Dayjs | null;
+  engineer_id: string | null;
+  description: string | null;
+}
+
+export default function ClaimFormAntdEdit({
+  claimId,
+  onCancel,
+  onSaved,
+  embedded = false,
+}: ClaimFormAntdEditProps) {
+  const [form] = Form.useForm<ClaimFormAntdEditValues>();
+  const { data: claim } = useClaim(claimId);
+  const { data: projects = [] } = useVisibleProjects();
+  const projectIdWatch = Form.useWatch('project_id', form) ?? useProjectId();
+  const projectId = projectIdWatch != null ? Number(projectIdWatch) : null;
+  const { data: units = [] } = useUnitsByProject(projectId);
+  const { data: users = [] } = useUsers();
+  const { data: statuses = [] } = useClaimStatuses();
+  const update = useUpdateClaim();
+  const addAtt = useAddClaimAttachments();
+  const removeAtt = useRemoveClaimAttachment();
+  const notify = useNotify();
+  const userId = useAuthStore((s) => s.profile?.id) ?? null;
+  const attachments = useClaimAttachments({ claim: claim as any });
+  const { changedFields, handleValuesChange } = useChangedFields(form, [claim]);
+
+  const highlight = (name: keyof ClaimFormAntdEditValues) =>
+    changedFields[name as string]
+      ? { background: '#fffbe6', padding: 4, borderRadius: 2 }
+      : {};
+
+  useEffect(() => {
+    if (!claim) return;
+    form.setFieldsValue({
+      project_id: claim.project_id,
+      unit_ids: claim.unit_ids,
+      claim_status_id: claim.claim_status_id,
+      claim_no: claim.claim_no,
+      claimed_on: claim.claimedOn ?? null,
+      accepted_on: claim.acceptedOn ?? null,
+      registered_on: claim.registeredOn ?? null,
+      engineer_id: claim.engineer_id ?? null,
+      description: claim.description ?? '',
+    });
+    attachments.reset();
+  }, [claim, form]);
+
+  const onFinish = async (values: ClaimFormAntdEditValues) => {
+    if (!claim) return;
+    try {
+      await update.mutateAsync({
+        id: claim.id,
+        updates: {
+          project_id: values.project_id ?? claim.project_id,
+          unit_ids: values.unit_ids,
+          claim_status_id: values.claim_status_id,
+          claim_no: values.claim_no,
+          claimed_on: values.claimed_on
+            ? values.claimed_on.format('YYYY-MM-DD')
+            : null,
+          accepted_on: values.accepted_on
+            ? values.accepted_on.format('YYYY-MM-DD')
+            : null,
+          registered_on: values.registered_on
+            ? values.registered_on.format('YYYY-MM-DD')
+            : null,
+          engineer_id: values.engineer_id ?? null,
+          description: values.description ?? '',
+          updated_by: userId ?? undefined,
+        } as any,
+      });
+
+      for (const id of attachments.removedIds) {
+        await removeAtt.mutateAsync({
+          claimId: claim.id,
+          attachmentId: Number(id),
+        });
+      }
+      let uploaded: RemoteClaimFile[] = [];
+      if (attachments.newFiles.length) {
+        const res = await addAtt.mutateAsync({
+          claimId: claim.id,
+          files: attachments.newFiles.map((f) => f.file),
+        });
+        uploaded = res.map((u) => ({
+          id: u.id,
+          name: u.original_name ?? u.storage_path.split('/').pop() ?? 'file',
+          original_name: u.original_name ?? null,
+          path: u.storage_path,
+          url: u.file_url,
+          mime_type: u.file_type,
+        }));
+        attachments.appendRemote(uploaded);
+      }
+      attachments.markPersisted();
+      notify.success('Претензия обновлена');
+      onSaved?.();
+    } catch (e: any) {
+      notify.error(e.message);
+    }
+  };
+
+  if (!claim) return <Skeleton active />;
+
+  return (
+    <Form
+      form={form}
+      layout="vertical"
+      onFinish={onFinish}
+      onValuesChange={handleValuesChange}
+      style={{ maxWidth: embedded ? 'none' : 640 }}
+      autoComplete="off"
+    >
+      <Row gutter={16}>
+        <Col span={8}>
+          <Form.Item
+            name="project_id"
+            label="Проект"
+            rules={[{ required: true }]}
+            style={highlight('project_id')}
+          >
+            <Select allowClear options={projects.map((p) => ({ value: p.id, label: p.name }))} />
+          </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item
+            name="unit_ids"
+            label="Объекты"
+            rules={[{ required: true }]}
+            style={highlight('unit_ids')}
+          >
+            <Select
+              mode="multiple"
+              options={units.map((u) => ({ value: u.id, label: u.name }))}
+              disabled={!projectId}
+            />
+          </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item
+            name="engineer_id"
+            label="Закрепленный инженер"
+            rules={[{ required: true }]}
+            style={highlight('engineer_id')}
+          >
+            <Select allowClear showSearch options={users.map((u) => ({ value: u.id, label: u.name }))} />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={8}>
+          <Form.Item
+            name="claim_no"
+            label="№ претензии"
+            rules={[{ required: true }]}
+            style={highlight('claim_no')}
+          >
+            <Input />
+          </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item name="claimed_on" label="Дата претензии" style={highlight('claimed_on')}>
+            <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+          </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item
+            name="accepted_on"
+            label="Дата получения претензии Застройщиком"
+            style={highlight('accepted_on')}
+          >
+            <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={8}>
+          <Form.Item
+            name="registered_on"
+            label="Дата регистрации претензии GARANTHUB"
+            style={highlight('registered_on')}
+          >
+            <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+          </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item
+            name="claim_status_id"
+            label="Статус"
+            rules={[{ required: true }]}
+            style={highlight('claim_status_id')}
+          >
+            <Select showSearch options={statuses.map((s) => ({ value: s.id, label: s.name }))} />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={24}>
+          <Form.Item name="description" label="Дополнительная информация" style={highlight('description')}>
+            <Input.TextArea rows={2} />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Form.Item label="Файлы" style={attachments.attachmentsChanged ? { background: '#fffbe6', padding: 4, borderRadius: 2 } : {}}>
+        <FileDropZone onFiles={attachments.addFiles} />
+        <AttachmentEditorTable
+          remoteFiles={attachments.remoteFiles.map((f) => ({
+            id: String(f.id),
+            name: f.name,
+            path: f.path,
+            mime: f.mime_type,
+          }))}
+          newFiles={attachments.newFiles.map((f) => ({ file: f.file, mime: f.file.type }))}
+          onRemoveRemote={(id) => attachments.removeRemote(id)}
+          onRemoveNew={(idx) => attachments.removeNew(idx)}
+          getSignedUrl={(path, name) => signedUrl(path, name)}
+        />
+      </Form.Item>
+      <Form.Item style={{ textAlign: 'right' }}>
+        {onCancel && (
+          <Button style={{ marginRight: 8 }} onClick={onCancel} disabled={update.isPending}>
+            Отмена
+          </Button>
+        )}
+        <Button type="primary" htmlType="submit" loading={update.isPending}>
+          Сохранить
+        </Button>
+      </Form.Item>
+    </Form>
+  );
+}

--- a/src/features/claim/ClaimViewModal.tsx
+++ b/src/features/claim/ClaimViewModal.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { Modal, Skeleton, Typography } from 'antd';
-import { useClaim, useRemoveClaimAttachment, useAddClaimAttachments, signedUrl } from '@/entities/claim';
-import type { RemoteClaimFile } from '@/shared/types/claimFile';
-import ClaimAttachmentsBlock from './ClaimAttachmentsBlock';
+import { useClaim } from '@/entities/claim';
+import ClaimFormAntdEdit from './ClaimFormAntdEdit';
 import TicketDefectsTable from '@/widgets/TicketDefectsTable';
-import ClaimFormAntd from './ClaimFormAntd';
 
 interface Props {
   open: boolean;
@@ -14,41 +12,6 @@ interface Props {
 
 export default function ClaimViewModal({ open, claimId, onClose }: Props) {
   const { data: claim } = useClaim(claimId ?? undefined);
-  const removeAtt = useRemoveClaimAttachment();
-  const addAtt = useAddClaimAttachments();
-  const [files, setFiles] = React.useState<RemoteClaimFile[]>([]);
-
-  React.useEffect(() => {
-    setFiles(
-      claim?.attachments?.map((f) => ({
-        id: f.id,
-        name: f.original_name ?? f.name,
-        path: f.path ?? f.storage_path,
-        mime_type: f.type as any,
-      })) || [],
-    );
-  }, [claim]);
-
-  const handleAddFiles = async (fls: File[]) => {
-    if (!claim) return;
-    const uploaded = await addAtt.mutateAsync({ claimId: claim.id, files: fls });
-    const newFiles = uploaded.map((u) => ({
-      id: u.id,
-      name: u.original_name ?? u.storage_path.split('/').pop() ?? 'file',
-      path: u.storage_path,
-      mime_type: u.file_type,
-      url: u.file_url,
-    })) as RemoteClaimFile[];
-    setFiles((p) => [...p, ...newFiles]);
-  };
-
-  const handleRemove = async (id: string) => {
-    await removeAtt.mutateAsync({
-      claimId: claim!.id,
-      attachmentId: Number(id),
-    });
-    setFiles((p) => p.filter((f) => String(f.id) !== id));
-  };
   if (!open || !claimId) return null;
   const titleText = claim
     ? `Претензия №${claim.claim_no}`
@@ -58,26 +21,13 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
     <Modal open={open} onCancel={onClose} footer={null} width="80%" title={<Typography.Title level={4} style={{ margin: 0 }}>{titleText}</Typography.Title>}>
       {claim ? (
         <>
-          <ClaimFormAntd
-            initialValues={claim as any}
-            onCreated={onClose}
-            showDefectsForm={false}
-            showAttachments={false}
-          />
+          <ClaimFormAntdEdit embedded claimId={String(claimId)} onCancel={onClose} onSaved={onClose} />
           <div style={{ marginTop: 16 }}>
             {claim.ticket_ids?.length ? (
               <TicketDefectsTable defectIds={claim.ticket_ids} />
             ) : (
               <Typography.Text>Дефекты не указаны</Typography.Text>
             )}
-          </div>
-          <div style={{ marginTop: 16 }}>
-            <ClaimAttachmentsBlock
-              remoteFiles={files}
-              onRemoveRemote={handleRemove}
-              onFiles={handleAddFiles}
-              getSignedUrl={signedUrl}
-            />
           </div>
         </>
       ) : (

--- a/src/features/claim/model/useClaimAttachments.ts
+++ b/src/features/claim/model/useClaimAttachments.ts
@@ -1,0 +1,80 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { Claim } from '@/shared/types/claim';
+import type { RemoteClaimFile, NewClaimFile } from '@/shared/types/claimFile';
+
+/**
+ * Хук управления вложениями претензии.
+ */
+export function useClaimAttachments(options: { claim?: Claim | null }) {
+  const { claim } = options;
+
+  const [remoteFiles, setRemoteFiles] = useState<RemoteClaimFile[]>([]);
+  const [newFiles, setNewFiles] = useState<NewClaimFile[]>([]);
+  const [removedIds, setRemovedIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!claim) return;
+    const attachments = (claim.attachments || []).map((file: any) => {
+      const storagePath = file.storage_path ?? file.path;
+      const fileUrl = file.file_url ?? file.url ?? '';
+      const fileType = file.file_type ?? file.mime_type ?? file.type ?? '';
+      const originalName = file.original_name ?? null;
+      const name =
+        originalName ||
+        (storagePath ? storagePath.split('/').pop() : file.name) ||
+        'file';
+      return {
+        id: file.id,
+        name,
+        original_name: originalName,
+        path: storagePath ?? '',
+        url: fileUrl,
+        mime_type: fileType,
+      } as RemoteClaimFile;
+    });
+    setRemoteFiles(attachments);
+  }, [claim]);
+
+  const addFiles = useCallback((files: File[]) => {
+    setNewFiles((p) => [...p, ...files.map((f) => ({ file: f }))]);
+  }, []);
+
+  const removeNew = useCallback((idx: number) => {
+    setNewFiles((p) => p.filter((_, i) => i !== idx));
+  }, []);
+
+  const removeRemote = useCallback((id: string) => {
+    setRemoteFiles((p) => p.filter((f) => String(f.id) !== String(id)));
+    setRemovedIds((p) => [...p, id]);
+  }, []);
+
+  const appendRemote = useCallback((files: RemoteClaimFile[]) => {
+    setRemoteFiles((p) => [...p, ...files]);
+  }, []);
+
+  const markPersisted = useCallback(() => {
+    setNewFiles([]);
+    setRemovedIds([]);
+  }, []);
+
+  const attachmentsChanged = newFiles.length > 0 || removedIds.length > 0;
+
+  const resetAll = useCallback(() => {
+    setNewFiles([]);
+    setRemoteFiles([]);
+    setRemovedIds([]);
+  }, []);
+
+  return {
+    remoteFiles,
+    newFiles,
+    removedIds,
+    addFiles,
+    removeNew,
+    removeRemote,
+    appendRemote,
+    markPersisted,
+    attachmentsChanged,
+    reset: resetAll,
+  };
+}


### PR DESCRIPTION
## Summary
- add description field to `ClaimFormAntd`
- implement claim attachments hook
- add editable claim form with changed highlighting and attachments
- use edit form in `ClaimViewModal`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856e2669a9c832e944984f5f6b99dee