### PR TITLE
Add claim linking support

### DIFF
--- a/sql/claim_links.sql
+++ b/sql/claim_links.sql
@@ -1,0 +1,10 @@
+-- Таблица связей претензий
+CREATE TABLE IF NOT EXISTS claim_links (
+    id BIGSERIAL PRIMARY KEY,
+    parent_id BIGINT NOT NULL REFERENCES claims(id) ON DELETE CASCADE,
+    child_id BIGINT NOT NULL REFERENCES claims(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Одно дочернее может иметь только одну связь
+CREATE UNIQUE INDEX IF NOT EXISTS claim_links_child_idx ON claim_links(child_id);

--- a/src/entities/claim.ts
+++ b/src/entities/claim.ts
@@ -16,6 +16,7 @@ import {
 import dayjs from 'dayjs';
 
 const TABLE = 'claims';
+const LINKS_TABLE = 'claim_links';
 
 /**
  * Преобразует запись Supabase в объект претензии с удобными полями.
@@ -139,9 +140,17 @@ export function useClaims() {
         attachMap[row.claim_id] = arr;
       });
 
+      const { data: linkRows, error: linkErr } = await supabase
+        .from(LINKS_TABLE)
+        .select('parent_id, child_id');
+      if (linkErr) throw linkErr;
+      const linkMap = new Map<number, number>();
+      (linkRows ?? []).forEach((lnk: any) => linkMap.set(lnk.child_id, lnk.parent_id));
+
       return (data ?? []).map((r: any) =>
         mapClaim({
           ...r,
+          parent_id: linkMap.get(r.id) ?? null,
           unit_ids: unitMap[r.id] ?? [],
           ticket_ids: ticketMap[r.id] ?? [],
           attachments: attachMap[r.id] ?? [],
@@ -196,8 +205,16 @@ export function useClaim(id?: number | string) {
         .eq('claim_id', claimId);
       const attachments = (attachRows ?? []).map((row: any) => row.attachments);
 
+      const { data: linkRow } = await supabase
+        .from(LINKS_TABLE)
+        .select('parent_id')
+        .eq('child_id', claimId)
+        .maybeSingle();
+      const parentId = linkRow?.parent_id ?? null;
+
       return mapClaim({
         ...data,
+        parent_id: parentId,
         unit_ids: unitIds,
         ticket_ids: ticketIds,
         attachments,
@@ -496,4 +513,49 @@ export async function signedUrl(path: string, filename = ''): Promise<string> {
     .createSignedUrl(path, 60, { download: filename || undefined });
   if (error) throw error;
   return data.signedUrl;
+}
+
+export function useClaimLinks() {
+  return useQuery({
+    queryKey: [LINKS_TABLE],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from(LINKS_TABLE)
+        .select('id, parent_id, child_id');
+      if (error) throw error;
+      return (data ?? []) as import('@/shared/types/claim').ClaimLink[];
+    },
+    staleTime: 5 * 60_000,
+  });
+}
+
+export function useLinkClaims() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ parentId, childIds }: { parentId: string; childIds: string[] }) => {
+      const ids = childIds.map((c) => Number(c));
+      if (ids.length === 0) return;
+      await supabase.from(LINKS_TABLE).delete().in('child_id', ids);
+      const rows = ids.map((child_id) => ({ parent_id: Number(parentId), child_id }));
+      await supabase.from(LINKS_TABLE).insert(rows);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: [LINKS_TABLE] });
+      qc.invalidateQueries({ queryKey: [TABLE] });
+    },
+  });
+}
+
+export function useUnlinkClaim() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: number) => {
+      const childId = Number(id);
+      await supabase.from(LINKS_TABLE).delete().eq('child_id', childId);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: [LINKS_TABLE] });
+      qc.invalidateQueries({ queryKey: [TABLE] });
+    },
+  });
 }

--- a/src/features/claim/LinkClaimsDialog.tsx
+++ b/src/features/claim/LinkClaimsDialog.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Modal, Input, Table, Button } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import type { ClaimWithNames } from '@/shared/types/claimWithNames';
+
+interface Props {
+  open: boolean;
+  parent: ClaimWithNames | null;
+  claims: ClaimWithNames[];
+  onClose: () => void;
+  onSubmit: (ids: string[]) => void;
+}
+
+/** Диалог выбора претензий для связывания */
+export default function LinkClaimsDialog({ open, parent, claims, onClose, onSubmit }: Props) {
+  const [selected, setSelected] = useState<string[]>([]);
+  const [search, setSearch] = useState('');
+
+  useEffect(() => {
+    setSelected([]);
+    setSearch('');
+  }, [parent, open]);
+
+  const parents = useMemo(() => {
+    const ids = new Set<string>();
+    claims.forEach((c) => {
+      if (c.parent_id) ids.add(String(c.parent_id));
+    });
+    return ids;
+  }, [claims]);
+
+  const filtered = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    return claims
+      .filter((c) => String(c.id) !== String(parent?.id))
+      .filter((c) => c.parent_id == null)
+      .filter((c) => !parents.has(String(c.id)))
+      .filter((c) => !term || String(c.id).includes(term) || c.claim_no.toLowerCase().includes(term));
+  }, [claims, parent, search, parents]);
+
+  const columns: ColumnsType<ClaimWithNames> = [
+    { title: 'ID', dataIndex: 'id', width: 80 },
+    { title: '№ претензии', dataIndex: 'claim_no', ellipsis: true },
+    { title: 'Статус', dataIndex: 'statusName', width: 160 },
+  ];
+
+  return (
+    <Modal
+      title="Связать существующие претензии"
+      open={open}
+      onCancel={onClose}
+      footer={[
+        <Button key="cancel" onClick={onClose}>
+          Отмена
+        </Button>,
+        <Button key="link" type="primary" disabled={selected.length === 0} onClick={() => onSubmit(selected)}>
+          Связать
+        </Button>,
+      ]}
+      width={700}
+      destroyOnHidden
+    >
+      <Input
+        placeholder="Поиск по ID или номеру"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        allowClear
+        style={{ marginBottom: 16 }}
+      />
+      <Table<ClaimWithNames>
+        rowKey="id"
+        columns={columns}
+        dataSource={filtered}
+        size="small"
+        pagination={{ pageSize: 8, showSizeChanger: false }}
+        scroll={{ y: 320 }}
+        rowSelection={{
+          selectedRowKeys: selected,
+          onChange: (keys) => setSelected(keys as string[]),
+        }}
+        locale={{ emptyText: 'Нет подходящих претензий' }}
+      />
+    </Modal>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -81,6 +81,17 @@ body {
   font-style: italic;
   border-left: 3px solid #1890ff;
 }
+.main-claim-row {
+  background: #eaf4ff !important;
+  font-weight: 600;
+  box-shadow: 0 1px 0 #b5d3f7;
+}
+.child-claim-row {
+  background: #f8fafb !important;
+  color: #888;
+  font-style: italic;
+  border-left: 3px solid #1890ff;
+}
 .ticket-fixed-row {
   background: #f6ffed !important;
 }

--- a/src/shared/types/claim.ts
+++ b/src/shared/types/claim.ts
@@ -1,6 +1,8 @@
 export interface Claim {
   /** Уникальный идентификатор претензии */
   id: number;
+  /** Идентификатор родительской претензии */
+  parent_id?: number | null;
   /** Проект, к которому относится претензия */
   project_id: number;
   /** Задействованные объекты */
@@ -33,4 +35,14 @@ export interface Claim {
   updated_by?: string;
   /** Дата обновления */
   updated_at?: string;
+}
+
+/** Связь претензий: parent_id - родительская, child_id - дочерняя */
+export interface ClaimLink {
+  /** Уникальный идентификатор связи */
+  id: string;
+  /** Идентификатор родительской претензии */
+  parent_id: string;
+  /** Идентификатор дочерней претензии */
+  child_id: string;
 }


### PR DESCRIPTION
## Summary
- add claim-links table SQL script
- support links in claims queries and add hooks to manage them
- introduce dialog for linking claims
- display parent/child hierarchy and actions in claims table
- enable linking of claims on the claims page
- add styles for claim hierarchy rows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856e3d23814832eb4f4a5cba305e6a3