### PR TITLE
Fix attachments display and icon import

### DIFF
--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -90,7 +90,6 @@ export default function ClaimFormAntdEdit({
       engineer_id: claim.engineer_id ?? null,
       description: claim.description ?? '',
     });
-    attachments.reset();
   }, [claim, form]);
 
   const onFinish = async (values: ClaimFormAntdEditValues) => {

--- a/src/features/claim/model/useClaimAttachments.ts
+++ b/src/features/claim/model/useClaimAttachments.ts
@@ -13,7 +13,12 @@ export function useClaimAttachments(options: { claim?: Claim | null }) {
   const [removedIds, setRemovedIds] = useState<string[]>([]);
 
   useEffect(() => {
-    if (!claim) return;
+    if (!claim) {
+      setRemoteFiles([]);
+      setNewFiles([]);
+      setRemovedIds([]);
+      return;
+    }
     const attachments = (claim.attachments || []).map((file: any) => {
       const storagePath = file.storage_path ?? file.path;
       const fileUrl = file.file_url ?? file.url ?? '';
@@ -33,6 +38,8 @@ export function useClaimAttachments(options: { claim?: Claim | null }) {
       } as RemoteClaimFile;
     });
     setRemoteFiles(attachments);
+    setNewFiles([]);
+    setRemovedIds([]);
   }, [claim]);
 
   const addFiles = useCallback((files: File[]) => {

--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -1,7 +1,13 @@
 import React, { useState, useMemo } from 'react';
 import { ConfigProvider, Alert, Card, Button, Tooltip, Popconfirm, message, Space } from 'antd';
 import ruRU from 'antd/locale/ru_RU';
-import { SettingOutlined, EyeOutlined, DeleteOutlined } from '@ant-design/icons';
+import {
+  SettingOutlined,
+  EyeOutlined,
+  DeleteOutlined,
+  PlusOutlined,
+  LinkOutlined,
+} from '@ant-design/icons';
 import ExportClaimsButton from '@/features/claim/ExportClaimsButton';
 import { useSnackbar } from 'notistack';
 import { useClaims, useDeleteClaim, useLinkClaims, useUnlinkClaim } from '@/entities/claim';


### PR DESCRIPTION
## Summary
- fix attachments state reset in `useClaimAttachments`
- remove outdated reset from claim edit form
- import missing icons in claims page

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_6856e8106708832ea0a845aeff57c3a4