### PR TITLE
Add claim-defects relation

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -154,6 +154,20 @@
     "column_default": null
   },
   {
+    "table_name": "claim_defects",
+    "column_name": "claim_id",
+    "data_type": "bigint",
+    "is_nullable": "NO",
+    "column_default": null
+  },
+  {
+    "table_name": "claim_defects",
+    "column_name": "defect_id",
+    "data_type": "bigint",
+    "is_nullable": "NO",
+    "column_default": null
+  },
+  {
     "table_name": "claims",
     "column_name": "id",
     "data_type": "bigint",

--- a/sql/claim_defects.sql
+++ b/sql/claim_defects.sql
@@ -1,0 +1,8 @@
+-- Таблица связей претензий и дефектов
+CREATE TABLE IF NOT EXISTS claim_defects (
+    claim_id BIGINT NOT NULL REFERENCES claims(id) ON DELETE CASCADE,
+    defect_id BIGINT NOT NULL REFERENCES defects(id) ON DELETE CASCADE,
+    PRIMARY KEY (claim_id, defect_id)
+);
+
+CREATE INDEX IF NOT EXISTS claim_defects_defect_idx ON claim_defects(defect_id);

--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -128,7 +128,7 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
       received_at: d.received_at ? d.received_at.format('YYYY-MM-DD') : null,
       fixed_at: d.fixed_at ? d.fixed_at.format('YYYY-MM-DD') : null,
     }));
-    await createDefects.mutateAsync(newDefs);
+    const defectIds = await createDefects.mutateAsync(newDefs);
     await create.mutateAsync({
       ...rest,
       attachments: files,
@@ -136,6 +136,7 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
       claimed_on: values.claimed_on ? values.claimed_on.format('YYYY-MM-DD') : null,
       accepted_on: values.accepted_on ? values.accepted_on.format('YYYY-MM-DD') : null,
       registered_on: values.registered_on ? values.registered_on.format('YYYY-MM-DD') : null,
+      defect_ids: defectIds,
     } as any);
     form.resetFields();
     setFiles([]);

--- a/src/shared/types/claim.ts
+++ b/src/shared/types/claim.ts
@@ -23,6 +23,8 @@ export interface Claim {
   engineer_id: string | null;
   /** Связанные тикеты-дефекты */
   ticket_ids?: number[];
+  /** Связанные дефекты */
+  defect_ids?: number[];
   /** Дополнительное описание */
   description?: string;
   /** Идентификаторы файлов */

--- a/src/shared/types/claimDefect.ts
+++ b/src/shared/types/claimDefect.ts
@@ -1,0 +1,6 @@
+export interface ClaimDefect {
+  /** Идентификатор претензии */
+  claim_id: number;
+  /** Идентификатор дефекта */
+  defect_id: number;
+}


### PR DESCRIPTION
## Summary
- add `claim_defects` table description
- add claim-defect SQL migration
- support defects relation in Claim entity and API
- record defects when creating a claim
- type definitions for claim defects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856e8bfa5a8832e99786ee8782e0cdd