### PR TITLE
Reorder claim view and update attachments UI

### DIFF
--- a/src/features/claim/ClaimAttachmentsBlock.tsx
+++ b/src/features/claim/ClaimAttachmentsBlock.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Form, Row, Col } from 'antd';
+import { Form } from 'antd';
 import FileDropZone from '@/shared/ui/FileDropZone';
 import ClaimAttachmentsTable from './ClaimAttachmentsTable';
 import type { RemoteClaimFile } from '@/shared/types/claimFile';
@@ -36,22 +36,14 @@ export default function ClaimAttachmentsBlock({
 }: ClaimAttachmentsBlockProps) {
   return (
     <Form.Item label="Файлы">
-      <Row gutter={16} align="top">
-        {showUpload && (
-          <Col flex="auto">
-            <FileDropZone onFiles={onFiles ?? (() => {})} />
-          </Col>
-        )}
-        <Col>
-          <ClaimAttachmentsTable
-            remoteFiles={remoteFiles}
-            newFiles={newFiles}
-            onRemoveRemote={onRemoveRemote}
-            onRemoveNew={onRemoveNew}
-            getSignedUrl={getSignedUrl}
-          />
-        </Col>
-      </Row>
+      {showUpload && <FileDropZone onFiles={onFiles ?? (() => {})} />}
+      <ClaimAttachmentsTable
+        remoteFiles={remoteFiles}
+        newFiles={newFiles}
+        onRemoveRemote={onRemoveRemote}
+        onRemoveNew={onRemoveNew}
+        getSignedUrl={getSignedUrl}
+      />
     </Form.Item>
   );
 }

--- a/src/features/claim/ClaimAttachmentsTable.tsx
+++ b/src/features/claim/ClaimAttachmentsTable.tsx
@@ -24,7 +24,6 @@ interface RowData {
   key: string;
   index: number;
   name: string;
-  size: number | null;
   remote: boolean;
   id?: string;
   path?: string;
@@ -32,8 +31,8 @@ interface RowData {
 }
 
 /**
- * Compact table displaying attachments of a claim.
- * Numbers files and shows size in MB.
+ * Компактная таблица вложений претензии.
+ * Показывает порядковый номер и название файла.
  */
 export default function ClaimAttachmentsTable({
   remoteFiles = [],
@@ -42,26 +41,13 @@ export default function ClaimAttachmentsTable({
   onRemoveNew,
   getSignedUrl,
 }: ClaimAttachmentsTableProps) {
-  const [sizes, setSizes] = React.useState<Record<string, number>>({});
-
-  React.useEffect(() => {
-    remoteFiles.forEach((f) => {
-      const id = String(f.id);
-      if (sizes[id] == null && f.size == null) {
-        fetch(f.url, { method: 'HEAD' })
-          .then((r) => Number(r.headers.get('content-length') || 0))
-          .then((s) => setSizes((p) => ({ ...p, [id]: s })))
-          .catch(() => {});
-      }
-    });
-  }, [remoteFiles, sizes]);
+  // размеры файлов для отображения не используются
 
   const rows: RowData[] = [
     ...remoteFiles.map((f, idx) => ({
       key: `r-${idx}`,
       index: idx + 1,
       name: f.original_name ?? f.name,
-      size: f.size ?? sizes[String(f.id)] ?? null,
       remote: true,
       id: String(f.id),
       path: f.path,
@@ -70,7 +56,6 @@ export default function ClaimAttachmentsTable({
       key: `n-${idx}`,
       index: remoteFiles.length + idx + 1,
       name: f.name,
-      size: f.size,
       remote: false,
       file: f,
     })),
@@ -81,12 +66,6 @@ export default function ClaimAttachmentsTable({
   const columns: ColumnsType<RowData> = [
     { dataIndex: 'index', width: 40 },
     { dataIndex: 'name', width: 200, ellipsis: true },
-    {
-      dataIndex: 'size',
-      width: 80,
-      render: (s: number | null) =>
-        s != null ? (s / 1024 / 1024).toFixed(2) : '—',
-    },
     {
       dataIndex: 'actions',
       width: 40,

--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -35,6 +35,10 @@ export interface ClaimFormAntdEditProps {
   onCancel?: () => void;
   onSaved?: () => void;
   embedded?: boolean;
+  /** Показывать блок работы с файлами */
+  showAttachments?: boolean;
+  /** Внешнее состояние вложений */
+  attachmentsState?: ReturnType<typeof useClaimAttachments>;
 }
 
 export interface ClaimFormAntdEditValues {
@@ -54,6 +58,8 @@ export default function ClaimFormAntdEdit({
   onCancel,
   onSaved,
   embedded = false,
+  showAttachments = true,
+  attachmentsState,
 }: ClaimFormAntdEditProps) {
   const [form] = Form.useForm<ClaimFormAntdEditValues>();
   const { data: claim } = useClaim(claimId);
@@ -69,7 +75,8 @@ export default function ClaimFormAntdEdit({
   const removeAtt = useRemoveClaimAttachment();
   const notify = useNotify();
   const userId = useAuthStore((s) => s.profile?.id) ?? null;
-  const attachments = useClaimAttachments({ claim: claim as any });
+  const attachments =
+    attachmentsState ?? useClaimAttachments({ claim: claim as any });
   const { changedFields, handleValuesChange } = useChangedFields(form, [claim]);
 
   const highlight = (name: keyof ClaimFormAntdEditValues) =>
@@ -248,21 +255,33 @@ export default function ClaimFormAntdEdit({
           </Form.Item>
         </Col>
       </Row>
-      <Form.Item label="Файлы" style={attachments.attachmentsChanged ? { background: '#fffbe6', padding: 4, borderRadius: 2 } : {}}>
-        <FileDropZone onFiles={attachments.addFiles} />
-        <AttachmentEditorTable
-          remoteFiles={attachments.remoteFiles.map((f) => ({
-            id: String(f.id),
-            name: f.name,
-            path: f.path,
-            mime: f.mime_type,
-          }))}
-          newFiles={attachments.newFiles.map((f) => ({ file: f.file, mime: f.file.type }))}
-          onRemoveRemote={(id) => attachments.removeRemote(id)}
-          onRemoveNew={(idx) => attachments.removeNew(idx)}
-          getSignedUrl={(path, name) => signedUrl(path, name)}
-        />
-      </Form.Item>
+      {showAttachments && (
+        <Form.Item
+          label="Файлы"
+          style={
+            attachments.attachmentsChanged
+              ? { background: '#fffbe6', padding: 4, borderRadius: 2 }
+              : {}
+          }
+        >
+          <FileDropZone onFiles={attachments.addFiles} />
+          <AttachmentEditorTable
+            remoteFiles={attachments.remoteFiles.map((f) => ({
+              id: String(f.id),
+              name: f.name,
+              path: f.path,
+              mime: f.mime_type,
+            }))}
+            newFiles={attachments.newFiles.map((f) => ({
+              file: f.file,
+              mime: f.file.type,
+            }))}
+            onRemoveRemote={(id) => attachments.removeRemote(id)}
+            onRemoveNew={(idx) => attachments.removeNew(idx)}
+            getSignedUrl={(path, name) => signedUrl(path, name)}
+          />
+        </Form.Item>
+      )}
       <Form.Item style={{ textAlign: 'right' }}>
         {onCancel && (
           <Button style={{ marginRight: 8 }} onClick={onCancel} disabled={update.isPending}>

--- a/src/features/claim/ClaimViewModal.tsx
+++ b/src/features/claim/ClaimViewModal.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { Modal, Skeleton, Typography } from 'antd';
-import { useClaim } from '@/entities/claim';
+import { useClaim, signedUrl } from '@/entities/claim';
 import ClaimFormAntdEdit from './ClaimFormAntdEdit';
+import ClaimAttachmentsBlock from './ClaimAttachmentsBlock';
 import TicketDefectsTable from '@/widgets/TicketDefectsTable';
+import { useClaimAttachments } from './model/useClaimAttachments';
 
 interface Props {
   open: boolean;
@@ -12,6 +14,7 @@ interface Props {
 
 export default function ClaimViewModal({ open, claimId, onClose }: Props) {
   const { data: claim } = useClaim(claimId ?? undefined);
+  const attachments = useClaimAttachments({ claim: claim as any });
   if (!open || !claimId) return null;
   const titleText = claim
     ? `Претензия №${claim.claim_no}`
@@ -21,7 +24,14 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
     <Modal open={open} onCancel={onClose} footer={null} width="80%" title={<Typography.Title level={4} style={{ margin: 0 }}>{titleText}</Typography.Title>}>
       {claim ? (
         <>
-          <ClaimFormAntdEdit embedded claimId={String(claimId)} onCancel={onClose} onSaved={onClose} />
+          <ClaimFormAntdEdit
+            embedded
+            claimId={String(claimId)}
+            onCancel={onClose}
+            onSaved={onClose}
+            showAttachments={false}
+            attachmentsState={attachments}
+          />
           <div style={{ marginTop: 16 }}>
             {claim.defect_ids?.length ? (
               <TicketDefectsTable defectIds={claim.defect_ids} />
@@ -29,6 +39,14 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
               <Typography.Text>Дефекты не указаны</Typography.Text>
             )}
           </div>
+          <ClaimAttachmentsBlock
+            remoteFiles={attachments.remoteFiles}
+            newFiles={attachments.newFiles.map((f) => f.file)}
+            onFiles={attachments.addFiles}
+            onRemoveRemote={attachments.removeRemote}
+            onRemoveNew={attachments.removeNew}
+            getSignedUrl={(path, name) => signedUrl(path, name)}
+          />
         </>
       ) : (
         <Skeleton active />


### PR DESCRIPTION
## Summary
- simplify `ClaimAttachmentsTable` without size column
- arrange `ClaimAttachmentsBlock` vertically
- support external attachments in `ClaimFormAntdEdit`
- show defects before attachments in `ClaimViewModal`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856f96a02a8832eaed0e0a70f69e422