### PR TITLE
Show claim attachments in table

### DIFF
--- a/src/widgets/ClaimAttachmentsList.tsx
+++ b/src/widgets/ClaimAttachmentsList.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Table, Button, Tooltip } from 'antd';
+import { DownloadOutlined } from '@ant-design/icons';
+import type { RemoteClaimFile } from '@/shared/types/claimFile';
+import { signedUrl } from '@/entities/claim';
+
+interface Props {
+  files: RemoteClaimFile[];
+}
+
+export default function ClaimAttachmentsList({ files }: Props) {
+  if (!files.length) return null;
+
+  const columns = [
+    { dataIndex: 'index', width: 40 },
+    { dataIndex: 'name', ellipsis: true },
+    {
+      dataIndex: 'actions',
+      width: 40,
+      render: (_: unknown, row: any) => (
+        <Tooltip title="Скачать">
+          <Button
+            type="text"
+            size="small"
+            icon={<DownloadOutlined />}
+            onClick={async () => {
+              const url = await signedUrl(row.path, row.name);
+              const a = document.createElement('a');
+              a.href = url;
+              a.download = row.name;
+              document.body.appendChild(a);
+              a.click();
+              a.remove();
+            }}
+          />
+        </Tooltip>
+      ),
+    },
+  ];
+
+  const data = files.map((f, i) => ({
+    key: String(f.id),
+    index: i + 1,
+    name: f.original_name ?? f.name,
+    path: f.path,
+  }));
+
+  return (
+    <Table
+      rowKey="key"
+      size="small"
+      pagination={false}
+      columns={columns as any}
+      dataSource={data}
+      showHeader={false}
+    />
+  );
+}

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -14,6 +14,7 @@ import { useDeleteClaim } from '@/entities/claim';
 import type { ClaimFilters } from '@/shared/types/claimFilters';
 import type { ClaimWithNames } from '@/shared/types/claimWithNames';
 import ClaimStatusSelect from '@/features/claim/ClaimStatusSelect';
+import ClaimAttachmentsList from './ClaimAttachmentsList';
 
 const fmt = (d: any) => (d && dayjs.isDayjs(d) && d.isValid() ? d.format('DD.MM.YYYY') : '—');
 
@@ -149,7 +150,14 @@ export default function ClaimsTable({ claims, filters, loading, columns: columns
       loading={loading}
       pagination={{ pageSize: 25, showSizeChanger: true }}
       size="middle"
-      expandable={{ expandRowByClick: true, indentSize: 24 }}
+      expandable={{
+        expandRowByClick: true,
+        indentSize: 24,
+        rowExpandable: (record) => (record.attachments?.length ?? 0) > 0,
+        expandedRowRender: (record) => (
+          <ClaimAttachmentsList files={record.attachments || []} />
+        ),
+      }}
       rowClassName={rowClassName}
     />
   );


### PR DESCRIPTION
## Summary
- add ClaimAttachmentsList widget to render attached files
- display attachments under expandable rows in claims table

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_6856fa21d270832e85fa229d62b030b8