### PR TITLE
Implement claims filter improvements

### DIFF
--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -90,6 +90,13 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [globalProjectId, form]);
 
+  // По умолчанию ставим текущую дату регистрации
+  useEffect(() => {
+    if (!form.getFieldValue('registered_on')) {
+      form.setFieldValue('registered_on', dayjs());
+    }
+  }, [form]);
+
   /**
    * Если статус не указан, подставляем первым из списка.
    */

--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -92,27 +92,36 @@ export default function ClaimsPage() {
     return map;
   }, [units]);
 
+  const unitNumberMap = useMemo(() => {
+    const map = {} as Record<number, string>;
+    (units ?? []).forEach((u) => {
+      map[u.id] = u.name;
+    });
+    return map;
+  }, [units]);
+
   const claimsWithNames: ClaimWithNames[] = useMemo(
     () =>
       claims.map((c) => ({
         ...c,
         unitNames: c.unit_ids.map((id) => unitMap[id]).filter(Boolean).join(', '),
+        unitNumbers: c.unit_ids.map((id) => unitNumberMap[id]).filter(Boolean).join(', '),
         responsibleEngineerName: userMap[c.engineer_id] ?? null,
         hasCheckingDefect: false,
       })),
-    [claims, unitMap, userMap, checkingDefectMap],
+    [claims, unitMap, unitNumberMap, userMap, checkingDefectMap],
   );
 
   const options = useMemo(() => {
     const uniq = (arr: any[], key: string) => Array.from(new Set(arr.map((i) => i[key]).filter(Boolean))).map((v) => ({ label: v, value: v }));
     return {
       projects: uniq(claimsWithNames, 'projectName'),
-      units: uniq(claimsWithNames, 'unitNames'),
+      units: Array.from(new Set((units ?? []).map((u) => u.name))).map((v) => ({ label: v, value: v })),
       statuses: uniq(claimsWithNames, 'statusName'),
       responsibleEngineers: uniq(claimsWithNames, 'responsibleEngineerName'),
       ids: uniq(claimsWithNames, 'id'),
     };
-  }, [claimsWithNames]);
+  }, [claimsWithNames, units]);
 
   function getBaseColumns() {
     return {
@@ -125,7 +134,7 @@ export default function ClaimsPage() {
       acceptedOn: { title: 'Дата получения Застройщиком', dataIndex: 'acceptedOn', width: 120, sorter: (a: any, b: any) => (a.acceptedOn ? a.acceptedOn.valueOf() : 0) - (b.acceptedOn ? b.acceptedOn.valueOf() : 0), render: (v: any) => fmt(v) },
       registeredOn: { title: 'Дата регистрации претензии', dataIndex: 'registeredOn', width: 120, sorter: (a: any, b: any) => (a.registeredOn ? a.registeredOn.valueOf() : 0) - (b.registeredOn ? b.registeredOn.valueOf() : 0), render: (v: any) => fmt(v) },
       resolvedOn: { title: 'Дата устранения', dataIndex: 'resolvedOn', width: 120, sorter: (a: any, b: any) => (a.resolvedOn ? a.resolvedOn.valueOf() : 0) - (b.resolvedOn ? b.resolvedOn.valueOf() : 0), render: (v: any) => fmt(v) },
-      responsibleEngineerName: { title: 'Ответственный инженер', dataIndex: 'responsibleEngineerName', width: 180, sorter: (a: any, b: any) => (a.responsibleEngineerName || '').localeCompare(b.responsibleEngineerName || '') },
+      responsibleEngineerName: { title: 'Закрепленный инженер', dataIndex: 'responsibleEngineerName', width: 180, sorter: (a: any, b: any) => (a.responsibleEngineerName || '').localeCompare(b.responsibleEngineerName || '') },
       actions: {
         title: 'Действия',
         key: 'actions',

--- a/src/shared/types/claimFilters.ts
+++ b/src/shared/types/claimFilters.ts
@@ -7,5 +7,9 @@ export interface ClaimFilters {
   status?: string;
   responsible?: string;
   claim_no?: string;
+  /** Поиск в поле дополнительной информации */
+  description?: string;
+  /** Скрывать записи со статусом "Закрыто" */
+  hideClosed?: boolean;
   period?: [Dayjs, Dayjs];
 }

--- a/src/shared/types/claimWithNames.ts
+++ b/src/shared/types/claimWithNames.ts
@@ -12,6 +12,8 @@ export interface ClaimWithNames extends Claim {
   responsibleEngineerName: string | null;
   /** Список объектов одной строкой */
   unitNames?: string;
+  /** Список номеров объектов одной строкой */
+  unitNumbers?: string;
   /** Дата обнаружения дефекта */
   claimedOn: Dayjs | null;
   /** Дата принятия претензии застройщиком */

--- a/src/shared/utils/claimFilter.ts
+++ b/src/shared/utils/claimFilter.ts
@@ -5,6 +5,7 @@ export function filterClaims<T extends {
   id: number;
   projectName?: string;
   unitNames?: string;
+  unitNumbers?: string;
   statusName?: string;
   responsibleEngineerName?: string | null;
   claim_no?: string;
@@ -13,14 +14,16 @@ export function filterClaims<T extends {
   return rows.filter((r) => {
     if (f.id && f.id.length > 0 && !f.id.includes(r.id)) return false;
     if (f.project && r.projectName !== f.project) return false;
-    if (f.units && f.units.length > 0 && r.unitNames) {
-      const units = r.unitNames.split(',').map((u) => u.trim());
+    if (f.units && f.units.length > 0 && r.unitNumbers) {
+      const units = r.unitNumbers.split(',').map((u) => u.trim());
       const ok = f.units.every((u) => units.includes(u));
       if (!ok) return false;
     }
     if (f.status && r.statusName !== f.status) return false;
     if (f.responsible && r.responsibleEngineerName !== f.responsible) return false;
     if (f.claim_no && (!r.claim_no || !r.claim_no.includes(f.claim_no))) return false;
+    if (f.description && (!r.description || !r.description.includes(f.description))) return false;
+    if (f.hideClosed && /закры/i.test(r.statusName || '')) return false;
     if (f.period && f.period.length === 2) {
       const [from, to] = f.period;
       if (!r.registeredOn) return false;

--- a/src/widgets/ClaimsFilters.tsx
+++ b/src/widgets/ClaimsFilters.tsx
@@ -1,21 +1,31 @@
 import React, { useEffect } from 'react';
-import { Form, DatePicker, Select, Input, Button } from 'antd';
+import { Form, DatePicker, Select, Input, Button, Switch } from 'antd';
 import type { ClaimFilters } from '@/shared/types/claimFilters';
 
 const { RangePicker } = DatePicker;
 
 export default function ClaimsFilters({ options, onChange, initialValues = {} }: { options: any; onChange: (v: ClaimFilters) => void; initialValues?: Partial<ClaimFilters>; }) {
+  const LS_HIDE_CLOSED = 'claimsHideClosed';
   const [form] = Form.useForm();
   useEffect(() => {
     form.setFieldsValue(initialValues);
   }, [initialValues, form]);
 
   useEffect(() => {
+    try {
+      const hideClosed = JSON.parse(localStorage.getItem(LS_HIDE_CLOSED) || 'false');
+      form.setFieldValue('hideClosed', hideClosed);
+    } catch {}
     onChange(form.getFieldsValue());
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handleValuesChange = (_, values: any) => {
+  const handleValuesChange = (_: any, values: any) => {
     onChange(values);
+    if (Object.prototype.hasOwnProperty.call(values, 'hideClosed')) {
+      try {
+        localStorage.setItem(LS_HIDE_CLOSED, JSON.stringify(values.hideClosed));
+      } catch {}
+    }
   };
 
   const reset = () => {
@@ -43,8 +53,14 @@ export default function ClaimsFilters({ options, onChange, initialValues = {} }:
       <Form.Item name="claim_no" label="№ претензии">
         <Input />
       </Form.Item>
-      <Form.Item name="responsible" label="Ответственный инженер">
+      <Form.Item name="responsible" label="Закрепленный инженер">
         <Select allowClear options={options.responsibleEngineers} />
+      </Form.Item>
+      <Form.Item name="description" label="Дополнительная информация">
+        <Input />
+      </Form.Item>
+      <Form.Item name="hideClosed" label="Скрыть закрытые" valuePropName="checked">
+        <Switch />
       </Form.Item>
       <Form.Item>
         <Button onClick={reset} block>

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -59,7 +59,7 @@ export default function ClaimsTable({ claims, filters, loading, columns: columns
       { title: 'Дата получения Застройщиком', dataIndex: 'acceptedOn', width: 120, sorter: (a, b) => (a.acceptedOn ? a.acceptedOn.valueOf() : 0) - (b.acceptedOn ? b.acceptedOn.valueOf() : 0), render: (v) => fmt(v) },
       { title: 'Дата регистрации претензии', dataIndex: 'registeredOn', width: 120, sorter: (a, b) => (a.registeredOn ? a.registeredOn.valueOf() : 0) - (b.registeredOn ? b.registeredOn.valueOf() : 0), render: (v) => fmt(v) },
       { title: 'Дата устранения', dataIndex: 'resolvedOn', width: 120, sorter: (a, b) => (a.resolvedOn ? a.resolvedOn.valueOf() : 0) - (b.resolvedOn ? b.resolvedOn.valueOf() : 0), render: (v) => fmt(v) },
-      { title: 'Ответственный инженер', dataIndex: 'responsibleEngineerName', width: 180, sorter: (a, b) => (a.responsibleEngineerName || '').localeCompare(b.responsibleEngineerName || '') },
+      { title: 'Закрепленный инженер', dataIndex: 'responsibleEngineerName', width: 180, sorter: (a, b) => (a.responsibleEngineerName || '').localeCompare(b.responsibleEngineerName || '') },
       {
         title: 'Действия',
         key: 'actions',
@@ -104,13 +104,18 @@ export default function ClaimsTable({ claims, filters, loading, columns: columns
   const filtered = useMemo(() => {
     return claims.filter((c) => {
       const matchesProject = !filters.project || c.projectName === filters.project;
-      const matchesUnits = !filters.units || filters.units.every((u) => c.unitNames.includes(u));
+      const matchesUnits = !filters.units || (() => {
+        const units = c.unitNumbers ? c.unitNumbers.split(',').map((n) => n.trim()) : [];
+        return filters.units.every((u) => units.includes(u));
+      })();
       const matchesStatus = !filters.status || c.statusName === filters.status;
       const matchesResponsible = !filters.responsible || c.responsibleEngineerName === filters.responsible;
       const matchesNumber = !filters.claim_no || c.claim_no.includes(filters.claim_no);
       const matchesIds = !filters.id || filters.id.includes(c.id);
+      const matchesDescription = !filters.description || (c.description ?? '').includes(filters.description);
+      const matchesHideClosed = !(filters.hideClosed && /закры/i.test(c.statusName));
       const matchesPeriod = !filters.period || (c.registeredOn && c.registeredOn.isSameOrAfter(filters.period[0], 'day') && c.registeredOn.isSameOrBefore(filters.period[1], 'day'));
-      return matchesProject && matchesUnits && matchesStatus && matchesResponsible && matchesNumber && matchesIds && matchesPeriod;
+      return matchesProject && matchesUnits && matchesStatus && matchesResponsible && matchesNumber && matchesIds && matchesDescription && matchesHideClosed && matchesPeriod;
     });
   }, [claims, filters]);
 


### PR DESCRIPTION
## Summary
- extend ClaimFilters and ClaimWithNames types
- support filtering by description and hiding closed claims
- show units by numbers in filters
- rename engineer column and filter to "Закрепленный инженер"
- set current date on new claim creation

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing errors and warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6856fbd18e34832eafb333895e7c956b