### PR TITLE
Fix claims table updates

### DIFF
--- a/src/shared/hooks/useRealtimeUpdates.ts
+++ b/src/shared/hooks/useRealtimeUpdates.ts
@@ -88,6 +88,31 @@ export function useRealtimeUpdates() {
         )
         .on(
           'postgres_changes',
+          { event: 'INSERT', schema: 'public', table: 'claims', filter: `project_id=eq.${pid}` },
+          () => qc.invalidateQueries({ queryKey: ['claims'] }),
+        )
+        .on(
+          'postgres_changes',
+          { event: 'UPDATE', schema: 'public', table: 'claims', filter: `project_id=eq.${pid}` },
+          () => qc.invalidateQueries({ queryKey: ['claims'] }),
+        )
+        .on(
+          'postgres_changes',
+          { event: 'DELETE', schema: 'public', table: 'claims', filter: `project_id=eq.${pid}` },
+          () => qc.invalidateQueries({ queryKey: ['claims'] }),
+        )
+        .on(
+          'postgres_changes',
+          { event: 'INSERT', schema: 'public', table: 'claim_links' },
+          () => qc.invalidateQueries({ queryKey: ['claims'] }),
+        )
+        .on(
+          'postgres_changes',
+          { event: 'DELETE', schema: 'public', table: 'claim_links' },
+          () => qc.invalidateQueries({ queryKey: ['claims'] }),
+        )
+        .on(
+          'postgres_changes',
           { event: 'INSERT', schema: 'public', table: 'unit_history', filter: `project_id=eq.${pid}` },
           () => qc.invalidateQueries({ queryKey: ['unit_history'] }),
         );
@@ -108,6 +133,32 @@ export function useRealtimeUpdates() {
           'postgres_changes',
           { event: 'DELETE', schema: 'public', table: 'letters' },
           () => qc.invalidateQueries({ queryKey: ['letters'] }),
+        );
+      channel
+        .on(
+          'postgres_changes',
+          { event: 'INSERT', schema: 'public', table: 'claims' },
+          () => qc.invalidateQueries({ queryKey: ['claims'] }),
+        )
+        .on(
+          'postgres_changes',
+          { event: 'UPDATE', schema: 'public', table: 'claims' },
+          () => qc.invalidateQueries({ queryKey: ['claims'] }),
+        )
+        .on(
+          'postgres_changes',
+          { event: 'DELETE', schema: 'public', table: 'claims' },
+          () => qc.invalidateQueries({ queryKey: ['claims'] }),
+        )
+        .on(
+          'postgres_changes',
+          { event: 'INSERT', schema: 'public', table: 'claim_links' },
+          () => qc.invalidateQueries({ queryKey: ['claims'] }),
+        )
+        .on(
+          'postgres_changes',
+          { event: 'DELETE', schema: 'public', table: 'claim_links' },
+          () => qc.invalidateQueries({ queryKey: ['claims'] }),
         );
     }
     channel.subscribe();


### PR DESCRIPTION
## Summary
- subscribe to `claims` and `claim_links` in realtime updates

## Testing
- `npm run lint`
- `npm test`
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6856fcf1c0fc832eaa6e8c2635d28381