### PR TITLE
Move claim edit actions

### DIFF
--- a/src/features/claim/ClaimViewModal.tsx
+++ b/src/features/claim/ClaimViewModal.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { Modal, Skeleton, Typography } from 'antd';
+import { Modal, Skeleton, Typography, Button } from 'antd';
 import { useClaim, signedUrl } from '@/entities/claim';
 import ClaimFormAntdEdit from './ClaimFormAntdEdit';
 import ClaimAttachmentsBlock from './ClaimAttachmentsBlock';
 import TicketDefectsTable from '@/widgets/TicketDefectsTable';
 import { useClaimAttachments } from './model/useClaimAttachments';
+import type { ClaimFormAntdEditRef } from '@/shared/types/claimFormAntdEditRef';
 
 interface Props {
   open: boolean;
@@ -15,6 +16,7 @@ interface Props {
 export default function ClaimViewModal({ open, claimId, onClose }: Props) {
   const { data: claim } = useClaim(claimId ?? undefined);
   const attachments = useClaimAttachments({ claim: claim as any });
+  const formRef = React.useRef<ClaimFormAntdEditRef>(null);
   if (!open || !claimId) return null;
   const titleText = claim
     ? `Претензия №${claim.claim_no}`
@@ -25,11 +27,13 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
       {claim ? (
         <>
           <ClaimFormAntdEdit
+            ref={formRef}
             embedded
             claimId={String(claimId)}
             onCancel={onClose}
             onSaved={onClose}
             showAttachments={false}
+            hideActions
             attachmentsState={attachments}
           />
           <div style={{ marginTop: 16 }}>
@@ -47,6 +51,14 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
             onRemoveNew={attachments.removeNew}
             getSignedUrl={(path, name) => signedUrl(path, name)}
           />
+          <div style={{ textAlign: 'right', marginTop: 16 }}>
+            <Button style={{ marginRight: 8 }} onClick={onClose} disabled={formRef.current?.isSubmitting}>
+              Отмена
+            </Button>
+            <Button type="primary" onClick={() => formRef.current?.submit()} loading={formRef.current?.isSubmitting}>
+              Сохранить
+            </Button>
+          </div>
         </>
       ) : (
         <Skeleton active />

--- a/src/shared/types/claimFormAntdEditRef.ts
+++ b/src/shared/types/claimFormAntdEditRef.ts
@@ -1,0 +1,9 @@
+/**
+ * Интерфейс управления формой редактирования претензии.
+ */
+export interface ClaimFormAntdEditRef {
+  /** Отправить форму */
+  submit: () => void;
+  /** Идет ли отправка формы */
+  isSubmitting: boolean;
+}


### PR DESCRIPTION
## Summary
- add ref type for claim edit form
- expose submit and loading state via `ClaimFormAntdEditRef`
- hide actions in form when used in view modal
- render Cancel/Save below attachments in `ClaimViewModal`
- fix repeated arguments in `ClaimFormAntdEdit`

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_6856fd6bbdc0832ebc292ba9589df9f2