### PR TITLE
Fix claims table expansion

### DIFF
--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -7,6 +7,8 @@ import {
   DeleteOutlined,
   PlusOutlined,
   LinkOutlined,
+  PlusSquareOutlined,
+  MinusSquareOutlined,
   FileTextOutlined,
   BranchesOutlined,
 } from '@ant-design/icons';
@@ -179,9 +181,21 @@ export default function ClaimsTable({ claims, filters, loading, columns: columns
       pagination={{ pageSize: 25, showSizeChanger: true }}
       size="middle"
       expandable={{
-        expandRowByClick: true,
+        expandRowByClick: false,
         indentSize: 24,
         expandedRowKeys,
+        expandIcon: ({ expanded, onExpand, record }) => {
+          if (!record.children) return null;
+          const Icon = expanded ? MinusSquareOutlined : PlusSquareOutlined;
+          return (
+            <Button
+              type="text"
+              size="small"
+              icon={<Icon />}
+              onClick={(e) => onExpand(record, e)}
+            />
+          );
+        },
         onExpand: (expanded, record) => {
           setExpandedRowKeys((prev) => {
             const set = new Set(prev);


### PR DESCRIPTION
## Summary
- add Ant Design plus/minus icons for expanding claim rows
- show custom expand button to view related claims

## Testing
- `npm run lint` *(fails: Parsing errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685704dd9f34832eb1c1f9c7378912ea