### PR TITLE
Fix admin role permissions constant

### DIFF
--- a/src/widgets/RolePermissionsAdmin.tsx
+++ b/src/widgets/RolePermissionsAdmin.tsx
@@ -18,8 +18,9 @@ const PAGES = [
   'admin',
 ];
 
-// Список таблиц, для которых можно настроить права на редактирование и удаление
+// Таблицы, для которых можно назначать права на редактирование и удаление
 // Дополнен таблицей "claims" для управления претензиями
+const TABLES = ['defects', 'court_cases', 'letters', 'claims'];
 
 export default function RolePermissionsAdmin() {
   const { data = [], isLoading } = useRolePermissions();


### PR DESCRIPTION
## Summary
- define `TABLES` constant used in RolePermissionsAdmin

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6857faa48eb4832eac06af92f6d9bd08