### PR TITLE
Fix defects queries for updated schema

### DIFF
--- a/src/shared/types/defect.ts
+++ b/src/shared/types/defect.ts
@@ -20,8 +20,6 @@ export interface DefectRecord {
   fixed_at: string | null;
   /** Пользователь, подтвердивший устранение */
   fixed_by: string | null;
-  /** Массив идентификаторов вложений */
-  attachment_ids?: number[];
   /** Дата создания */
   created_at: string | null;
 }


### PR DESCRIPTION
## Summary
- adjust defect queries to match new `defect_attachments` table
- clean up attachment id handling
- update defect type definitions

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857fcf98e88832ea7c5229d96e02cb1