### PR TITLE
Replace MUI dialog with AntD modal

### DIFF
--- a/src/features/courtCaseStatus/CourtCaseStatusForm.tsx
+++ b/src/features/courtCaseStatus/CourtCaseStatusForm.tsx
@@ -4,14 +4,23 @@
 // -----------------------------------------------------------------------------
 
 import React, { useState } from 'react';
-import { Stack, TextField, Button, DialogActions } from '@mui/material';
+import { Form, Input, Button, Space } from 'antd';
 
+/**
+ * Свойства формы стадии судебного дела.
+ */
 interface CourtCaseStatusFormProps {
+    /** Начальные данные для редактирования */
     initialData?: { id?: number; name?: string; color?: string | null };
+    /** Обработчик отправки формы */
     onSubmit: (values: { name: string; color: string }) => void;
+    /** Закрытие формы без сохранения */
     onCancel: () => void;
 }
 
+/**
+ * Форма создания или редактирования стадии судебного дела.
+ */
 export default function CourtCaseStatusForm({ initialData, onSubmit, onCancel }: CourtCaseStatusFormProps) {
     const [name, setName] = useState(initialData?.name ?? '');
     const [color, setColor] = useState(initialData?.color ?? '#1976d2');
@@ -23,33 +32,30 @@ export default function CourtCaseStatusForm({ initialData, onSubmit, onCancel }:
     };
 
     return (
-        <form onSubmit={handleSave} noValidate>
-            <Stack spacing={2} sx={{ minWidth: 320 }}>
-                <TextField
-                    label="Название"
+        <Form onSubmitCapture={handleSave} layout="vertical" style={{ minWidth: 320 }}>
+            <Form.Item label="Название" required>
+                <Input
                     value={name}
                     onChange={(e) => setName(e.target.value)}
                     autoFocus
-                    required
-                    size="small"
-                    fullWidth
                 />
-                <TextField
-                    label="Цвет"
+            </Form.Item>
+            <Form.Item label="Цвет" required>
+                <Input
                     type="color"
                     value={color}
                     onChange={(e) => setColor(e.target.value)}
-                    required
-                    fullWidth
-                    inputProps={{ style: { height: 48, padding: 0 } }}
+                    style={{ height: 48 }}
                 />
-                <DialogActions sx={{ px: 0 }}>
+            </Form.Item>
+            <Form.Item>
+                <Space>
                     <Button onClick={onCancel}>Отмена</Button>
-                    <Button type="submit" variant="contained">
+                    <Button type="primary" htmlType="submit">
                         Сохранить
                     </Button>
-                </DialogActions>
-            </Stack>
-        </form>
+                </Space>
+            </Form.Item>
+        </Form>
     );
 }

--- a/src/widgets/CourtCaseStatusesAdmin.tsx
+++ b/src/widgets/CourtCaseStatusesAdmin.tsx
@@ -2,8 +2,7 @@
 
 import React, { useState } from 'react';
 import { GridActionsCellItem } from '@mui/x-data-grid';
-import EditIcon from '@mui/icons-material/Edit';
-import DeleteIcon from '@mui/icons-material/Delete';
+import { Edit2, Trash2 } from 'lucide-react';
 
 import {
     useCourtCaseStatuses,
@@ -14,7 +13,7 @@ import {
 
 import CourtCaseStatusForm from '@/features/courtCaseStatus/CourtCaseStatusForm';
 import AdminDataGrid from '@/shared/ui/AdminDataGrid';
-import { Dialog, DialogTitle, DialogContent, Box } from '@mui/material';
+import { Modal } from 'antd';
 import { useNotify } from '@/shared/hooks/useNotify';
 
 // Интерфейс пропсов для поддержки пагинации
@@ -46,13 +45,13 @@ export default function CourtCaseStatusesAdmin({
             headerName: 'Цвет',
             width: 90,
             renderCell: (params: any) => (
-                <Box
-                    sx={{
+                <div
+                    style={{
                         width: 32,
                         height: 24,
-                        bgcolor: params.value,
+                        background: params.value,
                         border: '1px solid #bbb',
-                        borderRadius: 0.5,
+                        borderRadius: 4,
                     }}
                 />
             ),
@@ -64,13 +63,13 @@ export default function CourtCaseStatusesAdmin({
             getActions: ({ row }) => [
                 <GridActionsCellItem
                     key="edit"
-                    icon={<EditIcon />}
+                    icon={<Edit2 size={16} />}
                     label="Редактировать"
                     onClick={() => setModal({ mode: 'edit', data: row })}
                 />,
                 <GridActionsCellItem
                     key="del"
-                    icon={<DeleteIcon color="error" />}
+                    icon={<Trash2 color="red" size={16} />}
                     label="Удалить"
                     onClick={() => {
                         if (!window.confirm('Удалить стадию?')) return;
@@ -92,31 +91,32 @@ export default function CourtCaseStatusesAdmin({
     return (
         <>
             {modal && (
-                <Dialog open onClose={close} maxWidth="xs" fullWidth>
-                    <DialogTitle>
-                        {modal.mode === 'add' ? 'Новая стадия' : 'Редактировать стадию'}
-                    </DialogTitle>
-                    <DialogContent dividers>
-                        <CourtCaseStatusForm
-                            initialData={modal.mode === 'edit' ? modal.data : undefined}
-                            onSubmit={(d) =>
-                                (modal.mode === 'add'
-                                    ? add.mutate(d, {
-                                          onSuccess: () => ok('Стадия создана'),
+                <Modal
+                    open
+                    onCancel={close}
+                    title={modal.mode === 'add' ? 'Новая стадия' : 'Редактировать стадию'}
+                    footer={null}
+                    destroyOnClose
+                >
+                    <CourtCaseStatusForm
+                        initialData={modal.mode === 'edit' ? modal.data : undefined}
+                        onSubmit={(d) =>
+                            (modal.mode === 'add'
+                                ? add.mutate(d, {
+                                      onSuccess: () => ok('Стадия создана'),
+                                      onError: (e) => notify.error(e.message),
+                                  })
+                                : update.mutate(
+                                      { id: modal.data.id, updates: d },
+                                      {
+                                          onSuccess: () => ok('Стадия обновлена'),
                                           onError: (e) => notify.error(e.message),
-                                      })
-                                    : update.mutate(
-                                          { id: modal.data.id, updates: d },
-                                          {
-                                              onSuccess: () => ok('Стадия обновлена'),
-                                              onError: (e) => notify.error(e.message),
-                                          },
-                                      ))
-                            }
-                            onCancel={close}
-                        />
-                    </DialogContent>
-                </Dialog>
+                                      },
+                                  ))
+                        }
+                        onCancel={close}
+                    />
+                </Modal>
             )}
 
             <AdminDataGrid


### PR DESCRIPTION
## Summary
- migrate CourtCaseStatusForm to Ant Design
- replace MUI Dialog in CourtCaseStatusesAdmin with Ant Design Modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858038acd08832e8a9fb500761d12c6