### PR TITLE
Reorder navbar links

### DIFF
--- a/src/widgets/NavBar.tsx
+++ b/src/widgets/NavBar.tsx
@@ -32,13 +32,13 @@ const NavBar: React.FC = () => {
       key: 'structure',
       label: <RouterLink to="/structure">Структура проекта</RouterLink>,
     },
-    perm?.pages.includes('defects') && {
-      key: 'defects',
-      label: <RouterLink to="/defects">Дефекты</RouterLink>,
-    },
     perm?.pages.includes('claims') && {
       key: 'claims',
       label: <RouterLink to="/claims">Претензии</RouterLink>,
+    },
+    perm?.pages.includes('defects') && {
+      key: 'defects',
+      label: <RouterLink to="/defects">Дефекты</RouterLink>,
     },
     perm?.pages.includes('court-cases') && {
       key: 'court-cases',


### PR DESCRIPTION
## Summary
- reorder links in `NavBar` widget according to the required sequence

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68580bdffcb0832eba91c771237daf44