### PR TITLE
Add official claim flag

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -109,7 +109,14 @@
     "column_name": "defect_id",
     "data_type": "bigint",
     "is_nullable": "NO",
-    "column_default": null
+  "column_default": null
+  },
+  {
+    "table_name": "claim_defects",
+    "column_name": "is_official",
+    "data_type": "boolean",
+    "is_nullable": "YES",
+    "column_default": "false"
   },
   {
     "table_name": "claim_units",
@@ -221,7 +228,14 @@
     "column_name": "updated_at",
     "data_type": "timestamp with time zone",
     "is_nullable": "YES",
-    "column_default": "now()"
+  "column_default": "now()"
+  },
+  {
+    "table_name": "claims",
+    "column_name": "is_official",
+    "data_type": "boolean",
+    "is_nullable": "YES",
+    "column_default": "false"
   },
   {
     "table_name": "contractors",

--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   Row,
   Col,
+  Switch,
 } from 'antd';
 import ClaimAttachmentsBlock from './ClaimAttachmentsBlock';
 import dayjs from 'dayjs';
@@ -46,6 +47,7 @@ export interface ClaimFormValues {
   /** Срок устранения всех дефектов */
   resolved_on: dayjs.Dayjs | null;
   engineer_id: string | null;
+  is_official: boolean;
   description: string | null;
   defects?: Array<{
     type_id: number | null;
@@ -97,6 +99,11 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
     if (initialValues.registered_on) form.setFieldValue('registered_on', dayjs(initialValues.registered_on));
     if (initialValues.resolved_on) form.setFieldValue('resolved_on', dayjs(initialValues.resolved_on));
     if (initialValues.description) form.setFieldValue('description', initialValues.description);
+    if (initialValues.is_official != null) {
+      form.setFieldValue('is_official', initialValues.is_official);
+    } else {
+      form.setFieldValue('is_official', false);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [globalProjectId, form]);
 
@@ -238,6 +245,17 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
         <Col span={24}>
           <Form.Item name="description" label="Дополнительная информация">
             <Input.TextArea rows={2} />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={8}>
+          <Form.Item
+            name="is_official"
+            label="Официальная претензия"
+            valuePropName="checked"
+          >
+            <Switch />
           </Form.Item>
         </Col>
       </Row>

--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -9,6 +9,7 @@ import {
   Col,
   Button,
   Skeleton,
+  Switch,
 } from 'antd';
 import {
   useClaim,
@@ -53,6 +54,7 @@ export interface ClaimFormAntdEditValues {
   accepted_on: Dayjs | null;
   registered_on: Dayjs | null;
   engineer_id: string | null;
+  is_official: boolean;
   description: string | null;
 }
 
@@ -111,6 +113,7 @@ const ClaimFormAntdEdit = React.forwardRef<
       registered_on: claim.registeredOn ?? null,
       engineer_id: claim.engineer_id ?? null,
       description: claim.description ?? '',
+      is_official: claim.is_official ?? false,
     });
   }, [claim, form]);
 
@@ -134,6 +137,7 @@ const ClaimFormAntdEdit = React.forwardRef<
             ? values.registered_on.format('YYYY-MM-DD')
             : null,
           engineer_id: values.engineer_id ?? null,
+          is_official: values.is_official,
           description: values.description ?? '',
           updated_by: userId ?? undefined,
         } as any,
@@ -267,6 +271,18 @@ const ClaimFormAntdEdit = React.forwardRef<
         <Col span={24}>
           <Form.Item name="description" label="Дополнительная информация" style={highlight('description')}>
             <Input.TextArea rows={2} />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row gutter={16}>
+        <Col span={8}>
+          <Form.Item
+            name="is_official"
+            label="Официальная претензия"
+            valuePropName="checked"
+            style={highlight('is_official')}
+          >
+            <Switch />
           </Form.Item>
         </Col>
       </Row>

--- a/src/features/claim/ClaimViewModal.tsx
+++ b/src/features/claim/ClaimViewModal.tsx
@@ -86,7 +86,11 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
         : [];
       if (createdIds.length) {
         await supabase.from('claim_defects').insert(
-          createdIds.map((id) => ({ claim_id: claim.id, defect_id: id })),
+          createdIds.map((id) => ({
+            claim_id: claim.id,
+            defect_id: id,
+            is_official: claim.is_official,
+          })),
         );
       }
       if (removedIds.length) {

--- a/src/index.css
+++ b/src/index.css
@@ -92,8 +92,14 @@ body {
 .defect-confirmed-row {
   background: #f6ffed !important;
 }
+.defect-official-row {
+  background: #fff1f0 !important;
+}
 .claim-checking-row {
   background: #f6ffed !important;
+}
+.claim-official-row {
+  background: #fff1f0 !important;
 }
 .defect-closed-row {
   color: #aaa;

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -68,7 +68,7 @@ export default function DefectsPage() {
     // замена: no tickets
     const claimsMap = new Map<
       number,
-      { id: number; unit_ids: number[]; project_id: number }[]
+      { id: number; unit_ids: number[]; project_id: number; is_official: boolean }[]
     >();
     claims.forEach((c: any) => {
       (c.defect_ids || []).forEach((id: number) => {
@@ -77,6 +77,7 @@ export default function DefectsPage() {
           id: c.id,
           unit_ids: c.unit_ids || [],
           project_id: c.project_id,
+          is_official: c.is_official ?? false,
         });
         claimsMap.set(id, arr);
       });
@@ -103,6 +104,7 @@ export default function DefectsPage() {
           contractors.find((c) => c.id === d.contractor_id)?.name ||
           "Подрядчик";
       }
+      const isOfficial = linked.some((l) => l.is_official);
       return {
         ...d,
         claimIds: claimLinked.map((l) => l.id),
@@ -118,6 +120,7 @@ export default function DefectsPage() {
         defectTypeName: d.defect_type?.name ?? "",
         defectStatusName: d.defect_status?.name ?? "",
         defectStatusColor: d.defect_status?.color ?? null,
+        isOfficial,
       } as DefectWithInfo;
     });
   }, [defects, claims, units, projects]);

--- a/src/shared/types/claim.ts
+++ b/src/shared/types/claim.ts
@@ -21,6 +21,8 @@ export interface Claim {
   resolved_on: string | null;
   /** Ответственный инженер */
   engineer_id: string | null;
+  /** Официальная претензия */
+  is_official?: boolean;
   /** Связанные дефекты */
   defect_ids?: number[];
   /** Дополнительное описание */

--- a/src/shared/types/claimDefect.ts
+++ b/src/shared/types/claimDefect.ts
@@ -3,4 +3,6 @@ export interface ClaimDefect {
   claim_id: number;
   /** Идентификатор дефекта */
   defect_id: number;
+  /** Дефект по официальной претензии */
+  is_official?: boolean;
 }

--- a/src/shared/types/claimWithNames.ts
+++ b/src/shared/types/claimWithNames.ts
@@ -26,4 +26,6 @@ export interface ClaimWithNames extends Claim {
   attachments?: import('./claimFile').RemoteClaimFile[];
   /** Есть связанные дефекты со статусом "На проверке" */
   hasCheckingDefect?: boolean;
+  /** Признак официальной претензии */
+  is_official?: boolean;
 }

--- a/src/shared/types/defect.ts
+++ b/src/shared/types/defect.ts
@@ -50,4 +50,6 @@ export interface DefectWithInfo extends DefectRecord {
   projectNames?: string;
   /** Прошло дней с даты получения */
   days?: number | null;
+  /** Дефект из официальной претензии */
+  isOfficial?: boolean;
 }

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -85,6 +85,7 @@ export default function ClaimsTable({ claims, filters, loading, columns: columns
   }, [claims, filters]);
 
   const rowClassName = (row: ClaimWithNames) => {
+    if (row.is_official) return 'claim-official-row';
     return row.hasCheckingDefect ? 'claim-checking-row' : '';
   };
 

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -174,6 +174,7 @@ export default function DefectsTable({
   const rowClassName = (row: DefectWithInfo) => {
     const classes = ["main-defect-row"];
     if (row.claimIds?.length) classes.push("defect-claim-row");
+    if (row.isOfficial) classes.push("defect-official-row");
     const checking = row.defectStatusName?.toLowerCase().includes("провер");
     const closed = row.defectStatusName?.toLowerCase().includes("закры");
     if (checking) classes.push("defect-confirmed-row");


### PR DESCRIPTION
## Summary
- support `is_official` field for claims and claim defects
- expose official flag in types and API hooks
- add switch to claim forms
- highlight official claims and defects in tables
- keep schema description updated

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858118e4760832ea466de205e4a5df1