### PR TITLE
Remove extra top space across pages

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -73,11 +73,9 @@ export default function App() {
       data-oid=":l5ev61"
     >
       {!hideNavBar && <NavBar data-oid="fyv_m5h" />}
-      {!hideNavBar && <Toolbar data-oid="xulvruw" />}{" "}
-      {/* Компенсация высоты фиксированной шапки */}
       <Container
         maxWidth={false}
-        sx={{ flexGrow: 1, py: 3 }}
+        sx={{ flexGrow: 1, py: 2 }}
         data-oid=".x4sl-p"
       >
         <AppRouter data-oid="ozp552w" />

--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -162,14 +162,14 @@ export default function ClaimsPage() {
   return (
     <ConfigProvider locale={ruRU}>
       <>
-        <Button type="primary" onClick={() => setShowAddForm((p) => !p)} style={{ marginTop: 16, marginRight: 8 }}>
+        <Button type="primary" onClick={() => setShowAddForm((p) => !p)} style={{ marginRight: 8 }}>
           {showAddForm ? 'Скрыть форму' : 'Добавить претензию'}
         </Button>
-        <Button onClick={() => setShowFilters((p) => !p)} style={{ marginTop: 16 }}>
+        <Button onClick={() => setShowFilters((p) => !p)}>
           {showFilters ? 'Скрыть фильтры' : 'Показать фильтры'}
         </Button>
-        <Button icon={<SettingOutlined />} style={{ marginTop: 16, marginLeft: 8 }} onClick={() => setShowColumnsDrawer(true)} />
-        <span style={{ marginTop: 16, marginLeft: 8, display: 'inline-block' }}>
+        <Button icon={<SettingOutlined />} style={{ marginLeft: 8 }} onClick={() => setShowColumnsDrawer(true)} />
+        <span style={{ marginLeft: 8, display: 'inline-block' }}>
           <ExportClaimsButton claims={claimsWithNames} filters={filters} />
         </span>
         {showAddForm && (

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -524,22 +524,18 @@ export default function CorrespondencePage() {
   return (
     <ConfigProvider locale={ruRU}>
       <>
-        <Button
-          type="primary"
-          onClick={() => setShowAddForm((p) => !p)}
-          style={{ marginTop: 16, marginRight: 8 }}
-        >
+        <Button type="primary" onClick={() => setShowAddForm((p) => !p)} style={{ marginRight: 8 }}>
           {showAddForm ? 'Скрыть форму' : 'Добавить письмо'}
         </Button>
-        <Button onClick={() => setShowFilters((p) => !p)} style={{ marginTop: 16 }}>
+        <Button onClick={() => setShowFilters((p) => !p)}>
           {showFilters ? 'Скрыть фильтры' : 'Показать фильтры'}
         </Button>
         <Button
           icon={<SettingOutlined />}
-          style={{ marginTop: 16, marginLeft: 8 }}
+          style={{ marginLeft: 8 }}
           onClick={() => setShowColumnsDrawer(true)}
         />
-        <span style={{ marginTop: 16, marginLeft: 8, display: 'inline-block' }}>
+        <span style={{ marginLeft: 8, display: 'inline-block' }}>
           <ExportLettersButton
             letters={filtered}
             users={users}

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -444,20 +444,20 @@ export default function CourtCasesPage() {
           <Button
             type="primary"
             onClick={() => setShowAddForm((p) => !p)}
-            style={{ marginTop: 16, marginRight: 8 }}
+            style={{ marginRight: 8 }}
           >
             {showAddForm ? 'Скрыть форму' : 'Добавить дело'}
           </Button>
         )}
-        <Button onClick={() => setShowFilters((p) => !p)} style={{ marginTop: 16 }}>
+        <Button onClick={() => setShowFilters((p) => !p)}>
           {showFilters ? 'Скрыть фильтры' : 'Показать фильтры'}
         </Button>
         <Button
           icon={<SettingOutlined />}
-          style={{ marginTop: 16, marginLeft: 8 }}
+          style={{ marginLeft: 8 }}
           onClick={() => setShowColumnsDrawer(true)}
         />
-        <span style={{ marginTop: 16, marginLeft: 8, display: 'inline-block' }}>
+        <span style={{ marginLeft: 8, display: 'inline-block' }}>
           <ExportCourtCasesButton
             cases={filteredCases}
             stages={Object.fromEntries(stages.map((s) => [s.id, s.name]))}

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -404,18 +404,11 @@ export default function DefectsPage() {
   return (
     <ConfigProvider locale={ruRU}>
       <>
-        <Button
-          onClick={() => setShowFilters((p) => !p)}
-          style={{ marginTop: 16 }}
-        >
+        <Button onClick={() => setShowFilters((p) => !p)}>
           {showFilters ? "Скрыть фильтры" : "Показать фильтры"}
         </Button>
-        <Button
-          icon={<SettingOutlined />}
-          style={{ marginTop: 16, marginLeft: 8 }}
-          onClick={() => setShowColumnsDrawer(true)}
-        />
-        <span style={{ marginTop: 16, marginLeft: 8, display: "inline-block" }}>
+        <Button icon={<SettingOutlined />} style={{ marginLeft: 8 }} onClick={() => setShowColumnsDrawer(true)} />
+        <span style={{ marginLeft: 8, display: "inline-block" }}>
           <ExportDefectsButton defects={filteredData} filters={filters} />
         </span>
         {showFilters && (

--- a/src/pages/UnitsPage/LoginPage.tsx
+++ b/src/pages/UnitsPage/LoginPage.tsx
@@ -54,7 +54,7 @@ export default function LoginPage() {
   };
 
   return (
-    <Paper sx={{ p: 4, maxWidth: 380, mx: "auto", mt: 6 }}>
+    <Paper sx={{ p: 4, maxWidth: 380, mx: "auto", mt: 4 }}>
       <form onSubmit={login}>
         <Stack spacing={2}>
           <Typography variant="h5" align="center">

--- a/src/pages/UnitsPage/RegisterPage.tsx
+++ b/src/pages/UnitsPage/RegisterPage.tsx
@@ -80,7 +80,7 @@ export default function RegisterPage() {
   };
 
   return (
-    <div style={{ maxWidth: 440, margin: '24px auto' }}>
+    <div style={{ maxWidth: 440, margin: '16px auto' }}>
       <Form form={form} layout="vertical" onFinish={signUp} autoComplete="off">
         <Form.Item>
           <Typography.Title level={3} style={{ textAlign: 'center' }}>


### PR DESCRIPTION
## Summary
- remove unused toolbar and shrink container padding
- tighten page button layout margins
- reduce login/register page top margin

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858137bffb4832eb7c30bf61cfaf027