### PR TITLE
Fix defects removal delay on claim delete

### DIFF
--- a/src/entities/claim.ts
+++ b/src/entities/claim.ts
@@ -309,7 +309,10 @@ export function useCreateClaim() {
         is_official: created.is_official,
       } as Claim;
     },
-    onSuccess: () => qc.invalidateQueries({ queryKey: [TABLE] }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: [TABLE] });
+      qc.invalidateQueries({ queryKey: ['defects'] });
+    },
   });
 }
 
@@ -412,7 +415,10 @@ export function useDeleteClaim() {
       if (error) throw error;
       return id;
     },
-    onSuccess: () => qc.invalidateQueries({ queryKey: [TABLE] }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: [TABLE] });
+      qc.invalidateQueries({ queryKey: ['defects'] });
+    },
   });
 }
 

--- a/src/shared/hooks/useRealtimeUpdates.ts
+++ b/src/shared/hooks/useRealtimeUpdates.ts
@@ -82,6 +82,23 @@ export function useRealtimeUpdates() {
           () => qc.invalidateQueries({ queryKey: ['unit_history'] }),
         );
     });
+
+    channel
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'defects' },
+        () => qc.invalidateQueries({ queryKey: ['defects'] }),
+      )
+      .on(
+        'postgres_changes',
+        { event: 'UPDATE', schema: 'public', table: 'defects' },
+        () => qc.invalidateQueries({ queryKey: ['defects'] }),
+      )
+      .on(
+        'postgres_changes',
+        { event: 'DELETE', schema: 'public', table: 'defects' },
+        () => qc.invalidateQueries({ queryKey: ['defects'] }),
+      );
     if (subscribeAllLetters) {
       channel
         .on(


### PR DESCRIPTION
## Summary
- invalidate cached defects when deleting claims
- refresh defect data via realtime updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858263bc104832e8b8802e2b775db07