### PR TITLE
Fix defect highlighting

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -86,9 +86,6 @@ body {
   font-weight: 600;
   box-shadow: 0 1px 0 #b5d3f7;
 }
-.defect-claim-row {
-  background: #fff1f0 !important;
-}
 .defect-confirmed-row {
   background: #f6ffed !important;
 }

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -71,15 +71,15 @@ export default function DefectsPage() {
       { id: number; unit_ids: number[]; project_id: number; is_official: boolean }[]
     >();
     claims.forEach((c: any) => {
-      (c.defect_ids || []).forEach((id: number) => {
-        const arr = claimsMap.get(id) || [];
+      (c.claim_defects || []).forEach((cd: any) => {
+        const arr = claimsMap.get(cd.defect_id) || [];
         arr.push({
           id: c.id,
           unit_ids: c.unit_ids || [],
           project_id: c.project_id,
-          is_official: c.is_official ?? false,
+          is_official: cd.is_official ?? false,
         });
-        claimsMap.set(id, arr);
+        claimsMap.set(cd.defect_id, arr);
       });
     });
     return defects.map((d: any) => {

--- a/src/shared/types/claimSimple.ts
+++ b/src/shared/types/claimSimple.ts
@@ -1,0 +1,14 @@
+export interface ClaimSimple {
+  /** Уникальный идентификатор претензии */
+  id: number;
+  /** Проект, к которому относится претензия */
+  project_id: number;
+  /** Претензия официальная */
+  is_official?: boolean;
+  /** Связанные объекты */
+  unit_ids: number[];
+  /** Идентификаторы связанных дефектов */
+  defect_ids: number[];
+  /** Связанные дефекты с признаком официальности */
+  claim_defects: import('./claimDefect').ClaimDefect[];
+}

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -173,7 +173,6 @@ export default function DefectsTable({
 
   const rowClassName = (row: DefectWithInfo) => {
     const classes = ["main-defect-row"];
-    if (row.claimIds?.length) classes.push("defect-claim-row");
     if (row.isOfficial) classes.push("defect-official-row");
     const checking = row.defectStatusName?.toLowerCase().includes("провер");
     const closed = row.defectStatusName?.toLowerCase().includes("закры");


### PR DESCRIPTION
## Summary
- track defect official flag per claim_defect
- expose `ClaimSimple` type for simplified claims
- highlight defects red only when official
- cleanup unused CSS class

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit` *(fails: modules not found)*

------
https://chatgpt.com/codex/tasks/task_e_68582a8e2118832e90415e9e537aefb7