### PR TITLE
Fix Claim View modal state reset on save

### DIFF
--- a/src/features/claim/ClaimViewModal.tsx
+++ b/src/features/claim/ClaimViewModal.tsx
@@ -32,8 +32,11 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
   const [showAdd, setShowAdd] = React.useState(false);
   const tmpIdRef = React.useRef(-1);
 
+  const lastClaimIdRef = React.useRef<number | null>(null);
+
   React.useEffect(() => {
-    if (claim && open) {
+    if (claim && open && lastClaimIdRef.current !== claim.id) {
+      lastClaimIdRef.current = claim.id;
       setDefectIds(claim.defect_ids || []);
       setNewDefs([]);
       setRemovedIds([]);

--- a/src/features/claim/model/useClaimAttachments.ts
+++ b/src/features/claim/model/useClaimAttachments.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import type { Claim } from '@/shared/types/claim';
 import type { RemoteClaimFile, NewClaimFile } from '@/shared/types/claimFile';
 
@@ -12,13 +12,19 @@ export function useClaimAttachments(options: { claim?: Claim | null }) {
   const [newFiles, setNewFiles] = useState<NewClaimFile[]>([]);
   const [removedIds, setRemovedIds] = useState<string[]>([]);
 
+  const lastIdRef = useRef<number | null>(null);
+
   useEffect(() => {
     if (!claim) {
       setRemoteFiles([]);
       setNewFiles([]);
       setRemovedIds([]);
+      lastIdRef.current = null;
       return;
     }
+    if (lastIdRef.current === claim.id) return;
+    lastIdRef.current = claim.id;
+
     const attachments = (claim.attachments || []).map((file: any) => {
       const storagePath = file.storage_path ?? file.path;
       const fileUrl = file.file_url ?? file.url ?? '';


### PR DESCRIPTION
## Summary
- prevent resetting attachments when claim refetches
- prevent resetting defects when claim refetches

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68582f74d884832e975c43008cd30347