### PR TITLE
Fix Claim view modal state reset on close

### DIFF
--- a/src/features/claim/ClaimViewModal.tsx
+++ b/src/features/claim/ClaimViewModal.tsx
@@ -43,6 +43,16 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
     }
   }, [claim, open]);
 
+  React.useEffect(() => {
+    if (!open) {
+      lastClaimIdRef.current = null;
+      setDefectIds([]);
+      setNewDefs([]);
+      setRemovedIds([]);
+      attachments.reset();
+    }
+  }, [open]);
+
   const { data: loadedDefs = [] } = useDefectsWithNames(defectIds);
 
   const defectTypeMap = React.useMemo(() => {


### PR DESCRIPTION
## Summary
- reset local state in `ClaimViewModal` when closing the modal
- clear attachments and defect lists to avoid showing temporary IDs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6858326ef8e8832e8d223a45d2073455