### PR TITLE
Sync claim defects official flag

### DIFF
--- a/src/features/claim/ClaimViewModal.tsx
+++ b/src/features/claim/ClaimViewModal.tsx
@@ -92,7 +92,7 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
     setShowAdd(false);
   };
 
-  const handleSaved = async () => {
+  const handleSaved = async (isOfficial: boolean) => {
     if (!claim) return;
     try {
       const createdIds = newDefs.length
@@ -105,7 +105,7 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
           createdIds.map((id) => ({
             claim_id: claim.id,
             defect_id: id,
-            is_official: claim.is_official,
+            is_official: isOfficial,
           })),
         );
       }


### PR DESCRIPTION
## Summary
- propagate official claim flag to linked defects when saving
- provide updated flag to ClaimViewModal for new defects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858339561d0832e86680824779f899c