### PR TITLE
fix: update claim defects is_official when claim toggled

### DIFF
--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -155,6 +155,14 @@ const ClaimFormAntdEdit = React.forwardRef<
           .eq('claim_id', claim.id);
       }
 
+      // если претензия перестала быть официальной, обновляем связанные дефекты
+      if (claim.is_official && !values.is_official) {
+        await supabase
+          .from('claim_defects')
+          .update({ is_official: false })
+          .eq('claim_id', claim.id);
+      }
+
       for (const id of attachments.removedIds) {
         await removeAtt.mutateAsync({
           claimId: claim.id,


### PR DESCRIPTION
## Summary
- update claim defects' `is_official` flag when claim loses official status

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858354a6518832eb1630e6fec37eca9