### PR TITLE
Add claim shortcut in structure

### DIFF
--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -21,6 +21,7 @@ import dayjs from "dayjs";
 import TableColumnsDrawer from '@/widgets/TableColumnsDrawer';
 import type { TableColumnSetting } from '@/shared/types/tableColumnSetting';
 import type { ColumnsType } from 'antd/es/table';
+import { useSearchParams } from 'react-router-dom';
 import type { ClaimWithNames } from '@/shared/types/claimWithNames';
 
 export default function ClaimsPage() {
@@ -34,8 +35,20 @@ export default function ClaimsPage() {
   );
   const { data: units = [] } = useUnitsByIds(unitIds);
   const checkingDefectMap = useMemo(() => new Map<number, boolean>(), []);
+  const [searchParams] = useSearchParams();
+  const initialValues = {
+    project_id: searchParams.get('project_id')
+      ? Number(searchParams.get('project_id')!)
+      : undefined,
+    unit_ids: searchParams.get('unit_id')
+      ? [Number(searchParams.get('unit_id')!)]
+      : [],
+    engineer_id: searchParams.get('engineer_id') || undefined,
+  };
   const [filters, setFilters] = useState({});
-  const [showAddForm, setShowAddForm] = useState(false);
+  const [showAddForm, setShowAddForm] = useState(
+    searchParams.get('open_form') === '1',
+  );
   const LS_SHOW_FILTERS = 'claims:showFilters';
   const [showFilters, setShowFilters] = useState<boolean>(() => {
     try {
@@ -44,6 +57,11 @@ export default function ClaimsPage() {
       return true;
     }
   });
+  React.useEffect(() => {
+    if (searchParams.get('open_form') === '1') {
+      setShowAddForm(true);
+    }
+  }, [searchParams]);
   React.useEffect(() => {
     try {
       localStorage.setItem(LS_SHOW_FILTERS, JSON.stringify(showFilters));
@@ -174,7 +192,10 @@ export default function ClaimsPage() {
         </span>
         {showAddForm && (
           <div style={{ marginTop: 16 }}>
-            <ClaimFormAntd onCreated={() => setShowAddForm(false)} />
+            <ClaimFormAntd
+              onCreated={() => setShowAddForm(false)}
+              initialValues={initialValues}
+            />
           </div>
         )}
         <TableColumnsDrawer

--- a/src/widgets/UnitsMatrix/UnitsMatrix.tsx
+++ b/src/widgets/UnitsMatrix/UnitsMatrix.tsx
@@ -6,11 +6,13 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
-  Button,
+  Button as MuiButton,
   TextField,
   Typography,
   Tooltip,
 } from "@mui/material";
+import { Modal, Button as AntButton, ConfigProvider } from 'antd';
+import ruRU from 'antd/locale/ru_RU';
 import AddIcon from "@mui/icons-material/Add";
 import FloorCell from "@/entities/floor/FloorCell";
 import useUnitsMatrix from "@/shared/hooks/useUnitsMatrix";
@@ -251,7 +253,7 @@ export default function UnitsMatrix({
             />
           </DialogContent>
           <DialogActions>
-            <Button
+            <MuiButton
               onClick={() =>
                 setEditDialog({
                   open: false,
@@ -262,10 +264,10 @@ export default function UnitsMatrix({
               }
             >
               Отмена
-            </Button>
-            <Button variant="contained" onClick={handleSaveEdit}>
+            </MuiButton>
+            <MuiButton variant="contained" onClick={handleSaveEdit}>
               Сохранить
-            </Button>
+            </MuiButton>
           </DialogActions>
         </Dialog>
         <Dialog
@@ -285,90 +287,94 @@ export default function UnitsMatrix({
               : "Квартира будет удалена безвозвратно."}
           </DialogContent>
           <DialogActions>
-            <Button
+            <MuiButton
               onClick={() =>
                 setConfirmDialog({ open: false, type: "", target: null })
               }
             >
               Отмена
-            </Button>
-            <Button
+            </MuiButton>
+            <MuiButton
               color="error"
               variant="contained"
               onClick={handleConfirmDelete}
             >
               Удалить
-            </Button>
+            </MuiButton>
           </DialogActions>
         </Dialog>
       </Box>
 
       {/* Модальное меню по ячейке квартиры */}
-      <Dialog
-        open={actionDialog.open}
-        onClose={() => setActionDialog({ open: false, unit: null, action: "" })}
-        maxWidth="md"
-        fullWidth
-        PaperProps={{
-          sx: { minWidth: 540, maxWidth: 900 },
-        }}
-      >
-        <DialogTitle sx={{ fontWeight: 600, textAlign: "center" }}>
-          Квартира {actionDialog.unit?.name}
-        </DialogTitle>
-        {!actionDialog.action && (
-          <DialogContent
-            sx={{ display: "flex", flexDirection: "column", gap: 2 }}
-          >
-            <Button
-              variant="contained"
-              color="secondary"
-              fullWidth
-              onClick={() => {
-                const id = actionDialog.unit?.id;
-                const search = createSearchParams({
-                  project_id: String(projectId),
-                  unit_id: String(id ?? ''),
-                  responsible_lawyer_id: String(profileId ?? ''),
-                  open_form: '1',
-                }).toString();
-                navigate(`/court-cases?${search}`);
-                setActionDialog({ open: false, unit: null, action: '' });
-              }}
-            >
-              Добавить судебное дело
-            </Button>
-            <Button
-              variant="contained"
-              color="info"
-              fullWidth
-              onClick={() => {
-                const id = actionDialog.unit?.id;
-                const search = createSearchParams({
-                  project_id: String(projectId),
-                  unit_id: String(id ?? ''),
-                  responsible_user_id: String(profileId ?? ''),
-                  open_form: '1',
-                }).toString();
-                navigate(`/correspondence?${search}`);
-                setActionDialog({ open: false, unit: null, action: '' });
-              }}
-            >
-              Добавить письмо
-            </Button>
-            <Button
-              variant="contained"
-              color="inherit"
-              fullWidth
-              onClick={() =>
-                setActionDialog((ad) => ({ ...ad, action: 'history' }))
-              }
-            >
-              Показать историю
-            </Button>
-          </DialogContent>
-        )}
-      </Dialog>
+      <ConfigProvider locale={ruRU}>
+        <Modal
+          open={actionDialog.open}
+          onCancel={() =>
+            setActionDialog({ open: false, unit: null, action: "" })
+          }
+          footer={null}
+          title={`Квартира ${actionDialog.unit?.name}`}
+          width={600}
+        >
+          {!actionDialog.action && (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+              <AntButton
+                type="primary"
+                onClick={() => {
+                  const id = actionDialog.unit?.id;
+                  const search = createSearchParams({
+                    project_id: String(projectId),
+                    unit_id: String(id ?? ''),
+                    engineer_id: String(profileId ?? ''),
+                    open_form: '1',
+                  }).toString();
+                  navigate(`/claims?${search}`);
+                  setActionDialog({ open: false, unit: null, action: '' });
+                }}
+              >
+                Добавить претензию
+              </AntButton>
+              <AntButton
+                onClick={() => {
+                  const id = actionDialog.unit?.id;
+                  const search = createSearchParams({
+                    project_id: String(projectId),
+                    unit_id: String(id ?? ''),
+                    responsible_lawyer_id: String(profileId ?? ''),
+                    open_form: '1',
+                  }).toString();
+                  navigate(`/court-cases?${search}`);
+                  setActionDialog({ open: false, unit: null, action: '' });
+                }}
+              >
+                Добавить судебное дело
+              </AntButton>
+              <AntButton
+                onClick={() => {
+                  const id = actionDialog.unit?.id;
+                  const search = createSearchParams({
+                    project_id: String(projectId),
+                    unit_id: String(id ?? ''),
+                    responsible_user_id: String(profileId ?? ''),
+                    open_form: '1',
+                  }).toString();
+                  navigate(`/correspondence?${search}`);
+                  setActionDialog({ open: false, unit: null, action: '' });
+                }}
+              >
+                Добавить письмо
+              </AntButton>
+              <AntButton
+                onClick={() =>
+                  setActionDialog((ad) => ({ ...ad, action: 'history' }))
+                }
+              >
+                Показать историю
+              </AntButton>
+            </div>
+          )}
+        </Modal>
+      </ConfigProvider>
       {/* Диалог со всеми замечаниями */}
       <HistoryDialog
         open={actionDialog.action === "history"}


### PR DESCRIPTION
## Summary
- add Ant Design modal with claim button for units
- prefill claim form via query params
- open claim form automatically by `open_form=1`

## Testing
- `npm test`
- `npm run lint` *(fails: parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_6858364d72e0832e95a224e674e37d51