### PR TITLE
Fix ambiguous profiles relation in defect queries

### DIFF
--- a/src/entities/defect.ts
+++ b/src/entities/defect.ts
@@ -33,7 +33,7 @@ export function useDefects() {
         .from(TABLE)
         .select(
           'id, description, type_id, status_id, project_id, unit_id, created_by, updated_by, updated_at, brigade_id, contractor_id, is_warranty, received_at, fixed_at, fixed_by, created_at,' +
-          ' defect_type:defect_types!fk_defects_type(id,name), defect_status:statuses!fk_defects_status(id,name,color), fixed_by_user:profiles(id,name)'
+          ' defect_type:defect_types!fk_defects_type(id,name), defect_status:statuses!fk_defects_status(id,name,color), fixed_by_user:profiles!fk_defects_fixed_by(id,name)'
         )
         .order('id');
       if (error) throw error;
@@ -63,7 +63,7 @@ export function useDefect(id?: number) {
         .from(TABLE)
         .select(
           'id, description, type_id, status_id, project_id, unit_id, created_by, updated_by, updated_at, brigade_id, contractor_id, is_warranty, received_at, fixed_at, fixed_by, created_at,' +
-          ' defect_type:defect_types!fk_defects_type(id,name), defect_status:statuses!fk_defects_status(id,name,color), fixed_by_user:profiles(id,name)'
+          ' defect_type:defect_types!fk_defects_type(id,name), defect_status:statuses!fk_defects_status(id,name,color), fixed_by_user:profiles!fk_defects_fixed_by(id,name)'
         )
         .eq('id', id as number)
         .single();
@@ -117,7 +117,7 @@ export function useDefectsWithNames(ids?: number[]) {
       const { data, error } = await supabase
         .from(TABLE)
         .select(
-          'id, description, type_id, status_id, project_id, unit_id, created_by, updated_by, updated_at, brigade_id, contractor_id, is_warranty, received_at, fixed_at, fixed_by, defect_type:defect_types!fk_defects_type(id,name), defect_status:statuses!fk_defects_status(id,name,color), fixed_by_user:profiles(id,name)'
+          'id, description, type_id, status_id, project_id, unit_id, created_by, updated_by, updated_at, brigade_id, contractor_id, is_warranty, received_at, fixed_at, fixed_by, defect_type:defect_types!fk_defects_type(id,name), defect_status:statuses!fk_defects_status(id,name,color), fixed_by_user:profiles!fk_defects_fixed_by(id,name)'
         )
         .in('id', ids as number[]);
       if (error) throw error;


### PR DESCRIPTION
## Summary
- fix Supabase relation alias for `fixed_by_user` when querying defects

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing errors in many files)*

------
https://chatgpt.com/codex/tasks/task_e_68583ecd476c832ebbc77a128f8d9c41