### PR TITLE
Добавление обязательности даты регистрации претензии

### DIFF
--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -232,7 +232,11 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
       </Row>
       <Row gutter={16}>
         <Col span={8}>
-          <Form.Item name="registered_on" label="Дата регистрации претензии GARANTHUB">
+          <Form.Item
+            name="registered_on"
+            label="Дата регистрации претензии GARANTHUB"
+            rules={[{ required: true }]}
+          >
             <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
           </Form.Item>
         </Col>

--- a/src/shared/types/claim.ts
+++ b/src/shared/types/claim.ts
@@ -15,7 +15,7 @@ export interface Claim {
   claimed_on: string | null;
   /** Дата принятия претензии застройщиком */
   accepted_on: string | null;
-  /** Дата регистрации претензии в системе */
+  /** Дата регистрации претензии GARANTHUB */
   registered_on: string | null;
   /** Дата фактического устранения */
   resolved_on: string | null;


### PR DESCRIPTION
## Summary
- добавили правило обязательного заполнения поля "Дата регистрации претензии GARANTHUB" в форме создания претензии
- обновили описание типа `Claim` для отражения нового названия поля

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685848490544832eab2c7f4d8d697235