### PR TITLE
Добавлены новые колонки дефектов в карточке претензии

### DIFF
--- a/src/widgets/TicketDefectsTable.tsx
+++ b/src/widgets/TicketDefectsTable.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
-import { Table, Button } from 'antd';
+import dayjs from 'dayjs';
+import { Table, Button, Tooltip, Space } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
+import { EyeOutlined } from '@ant-design/icons';
 
 interface Item {
   id: number;
   description: string;
   defectTypeName?: string | null;
+  defectStatusName?: string | null;
+  is_warranty?: boolean;
+  received_at?: string | null;
+  fixed_at?: string | null;
+  fixByName?: string | null;
 }
 
 interface Props {
@@ -13,13 +20,18 @@ interface Props {
   items: Item[];
   /** Callback удаления дефекта */
   onRemove?: (id: number) => void;
+  /** Открытие просмотра дефекта */
+  onView?: (id: number) => void;
 }
 
 /**
  * Таблица дефектов в карточке претензии.
  * Показывает минимальный набор полей и кнопку удаления.
  */
-export default function TicketDefectsTable({ items, onRemove }: Props) {
+export default function TicketDefectsTable({ items, onRemove, onView }: Props) {
+  const fmt = (d: string | null | undefined) =>
+    d ? dayjs(d).format('DD.MM.YYYY') : '—';
+
   const columns: ColumnsType<Item> = [
     { title: 'ID', dataIndex: 'id', width: 80 },
     { title: 'Описание', dataIndex: 'description' },
@@ -28,17 +40,59 @@ export default function TicketDefectsTable({ items, onRemove }: Props) {
       dataIndex: 'defectTypeName',
       render: (v: string | null) => v || '—',
     },
+    {
+      title: 'Статус',
+      dataIndex: 'defectStatusName',
+      render: (v: string | null) => v || '—',
+    },
+    {
+      title: 'Гарантия',
+      dataIndex: 'is_warranty',
+      width: 100,
+      render: (v: boolean | undefined) => (v ? 'Да' : 'Нет'),
+    },
+    {
+      title: 'Дата получения',
+      dataIndex: 'received_at',
+      width: 120,
+      render: fmt,
+    },
+    {
+      title: 'Дата устранения',
+      dataIndex: 'fixed_at',
+      width: 120,
+      render: fmt,
+    },
+    {
+      title: 'Кем устраняется',
+      dataIndex: 'fixByName',
+      render: (v: string | null) => v || '—',
+    },
   ];
 
-  if (onRemove) {
+  if (onRemove || onView) {
     columns.push({
       title: 'Действия',
       key: 'actions',
       width: 100,
       render: (_, row) => (
-        <Button size="small" danger onClick={() => onRemove(row.id)}>
-          Удалить
-        </Button>
+        <Space size="middle">
+          {onView && (
+            <Tooltip title="Просмотр">
+              <Button
+                size="small"
+                type="text"
+                icon={<EyeOutlined />}
+                onClick={() => onView(row.id)}
+              />
+            </Tooltip>
+          )}
+          {onRemove && (
+            <Button size="small" danger onClick={() => onRemove(row.id)}>
+              Удалить
+            </Button>
+          )}
+        </Space>
       ),
     });
   }


### PR DESCRIPTION
## Summary
- расширена таблица `TicketDefectsTable` колонками статуса, гарантии, датами и исполнителем
- добавлено открытие карточки дефекта из просмотра претензии
- в `ClaimViewModal` вычисляются названия статуса и исполнителя

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68584bc97328832e9c5cdcf763beca78