### PR TITLE
Handle closed claims styling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -98,6 +98,10 @@ body {
 .claim-official-row {
   background: #fff1f0 !important;
 }
+.claim-closed-row {
+  color: #aaa;
+  background: inherit !important;
+}
 .defect-closed-row {
   color: #aaa;
   background: inherit !important;

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -87,7 +87,9 @@ export default function ClaimsTable({ claims, filters, loading, columns: columns
   const rowClassName = (row: ClaimWithNames) => {
     if (row.is_official) return 'claim-official-row';
     const checking = row.statusName?.toLowerCase().includes('провер');
+    const closed = row.statusName?.toLowerCase().includes('закры');
     if (checking || row.hasCheckingDefect) return 'claim-checking-row';
+    if (closed) return 'claim-closed-row';
     return '';
   };
 


### PR DESCRIPTION
## Summary
- grey out claim rows when claim status is closed
- add `claim-closed-row` styles similar to defects

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68584c9507a0832e9d5ac21e8fb8d9dd