### PR TITLE
Implement defect view attachments and docx export

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-table": "^7.8.0",
     "react-window": "^1.8.11",
     "slugify": "^1.6.6",
+    "docx": "^8.3.1",
     "yup": "^1.6.1",
     "zod": "^3.24.3",
     "zustand": "^5.0.3"

--- a/src/features/defect/DefectAttachmentsBlock.tsx
+++ b/src/features/defect/DefectAttachmentsBlock.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Form } from 'antd';
+import FileDropZone from '@/shared/ui/FileDropZone';
+import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
+import type { RemoteDefectFile } from '@/shared/types/defectFile';
+
+export interface DefectAttachmentsBlockProps {
+  /** Загруженные файлы */
+  remoteFiles: RemoteDefectFile[];
+  /** Добавить файлы */
+  onFiles: (files: File[]) => void;
+  /** Удалить файл */
+  onRemove: (id: string) => void;
+  /** Получить подписанную ссылку */
+  getSignedUrl: (path: string, name: string) => Promise<string>;
+}
+
+/** Блок отображения и загрузки файлов дефекта */
+export default function DefectAttachmentsBlock({
+  remoteFiles,
+  onFiles,
+  onRemove,
+  getSignedUrl,
+}: DefectAttachmentsBlockProps) {
+  return (
+    <Form.Item label="Файлы">
+      <FileDropZone onFiles={onFiles} />
+      <AttachmentEditorTable
+        remoteFiles={remoteFiles.map((f) => ({
+          id: String(f.id),
+          name: f.original_name ?? f.name,
+          path: f.path,
+          mime: f.mime_type,
+        }))}
+        onRemoveRemote={onRemove}
+        getSignedUrl={getSignedUrl}
+      />
+    </Form.Item>
+  );
+}

--- a/src/features/defect/DefectViewModal.tsx
+++ b/src/features/defect/DefectViewModal.tsx
@@ -1,9 +1,18 @@
-import React from "react";
-import dayjs from "dayjs";
-import { Modal, Typography, Skeleton } from "antd";
-import { useDefect, signedUrl } from "@/entities/defect";
-import { useBrigades } from "@/entities/brigade";
-import { useContractors } from "@/entities/contractor";
+import React, { useEffect, useMemo, useState } from 'react';
+import dayjs from 'dayjs';
+import { Modal, Typography, Skeleton, Tooltip, Button } from 'antd';
+import { DownloadOutlined } from '@ant-design/icons';
+import {
+  useDefect,
+  signedUrl,
+  useAddDefectAttachments,
+  useRemoveDefectAttachment,
+} from '@/entities/defect';
+import { useBrigades } from '@/entities/brigade';
+import { useContractors } from '@/entities/contractor';
+import DefectAttachmentsBlock from './DefectAttachmentsBlock';
+import { createDefectDocx } from '@/shared/utils/createDefectDocx';
+import type { RemoteDefectFile } from '@/shared/types/defectFile';
 
 interface Props {
   open: boolean;
@@ -16,25 +25,69 @@ export default function DefectViewModal({ open, defectId, onClose }: Props) {
   const { data: defect, isLoading } = useDefect(defectId ?? undefined);
   const { data: brigades = [] } = useBrigades();
   const { data: contractors = [] } = useContractors();
-  const fixByName = React.useMemo(() => {
-    if (!defect) return "—";
-    if (defect.brigade_id)
-      return (
-        brigades.find((b) => b.id === defect.brigade_id)?.name ?? "Бригада"
+  const addAtt = useAddDefectAttachments();
+  const removeAtt = useRemoveDefectAttachment();
+
+  const [files, setFiles] = useState<RemoteDefectFile[]>([]);
+
+  useEffect(() => {
+    if (defect) {
+      setFiles(
+        (defect.attachments ?? []).map((f: any) => ({
+          id: String(f.id),
+          name: f.original_name ?? f.storage_path.split('/').pop(),
+          path: f.storage_path,
+          mime_type: f.file_type,
+          original_name: f.original_name,
+          url: f.file_url,
+        })) as RemoteDefectFile[],
       );
-    if (defect.contractor_id)
-      return (
-        contractors.find((c) => c.id === defect.contractor_id)?.name ||
-        "Подрядчик"
-      );
-    return "—";
+    }
+  }, [defect]);
+
+  const fixByName = useMemo(() => {
+    if (!defect) return '—';
+    if (defect.brigade_id) {
+      return brigades.find((b) => b.id === defect.brigade_id)?.name ?? 'Бригада';
+    }
+    if (defect.contractor_id) {
+      return contractors.find((c) => c.id === defect.contractor_id)?.name ?? 'Подрядчик';
+    }
+    return '—';
   }, [defect, brigades, contractors]);
+
   if (!defectId) return null;
+
   const title = defect
-    ? `Дефект с ID №${defect.id} от ${dayjs(
-        defect.received_at ?? defect.created_at,
-      ).format("DD.MM.YYYY")}`
-    : "Дефект";
+    ? `Дефект с ID №${defect.id} от ${dayjs(defect.received_at ?? defect.created_at).format('DD.MM.YYYY')}`
+    : 'Дефект';
+
+  const handleFiles = async (f: File[]) => {
+    if (!defectId) return;
+    const uploaded = await addAtt.mutateAsync({ defectId, files: f });
+    setFiles((p) => [
+      ...p,
+      ...uploaded.map((u: any) => ({
+        id: String(u.id),
+        name: u.original_name ?? u.storage_path.split('/').pop(),
+        path: u.storage_path,
+        mime_type: u.file_type,
+        original_name: u.original_name,
+        url: u.file_url,
+      })),
+    ]);
+  };
+
+  const handleRemove = async (id: string) => {
+    if (!defectId) return;
+    await removeAtt.mutateAsync({ defectId, attachmentId: Number(id) });
+    setFiles((p) => p.filter((f) => String(f.id) !== id));
+  };
+
+  const downloadDocx = () => {
+    if (defect) createDefectDocx(defect as any);
+  };
+
   return (
     <Modal
       open={open}
@@ -50,60 +103,38 @@ export default function DefectViewModal({ open, defectId, onClose }: Props) {
       {isLoading || !defect ? (
         <Skeleton active />
       ) : (
-        <div style={{ display: "grid", gap: 8 }}>
+        <div style={{ display: 'grid', gap: 8 }}>
           <Typography.Text>
             <b>Описание:</b> {defect.description}
           </Typography.Text>
           <Typography.Text>
-            <b>Тип дефекта:</b> {defect.defect_type?.name ?? "—"}
+            <b>Тип дефекта:</b> {defect.defect_type?.name ?? '—'}
           </Typography.Text>
           <Typography.Text>
-            <b>Статус:</b> {defect.defect_status?.name ?? "—"}
+            <b>Статус:</b> {defect.defect_status?.name ?? '—'}
           </Typography.Text>
           <Typography.Text>
             <b>Кем устраняется:</b> {fixByName}
           </Typography.Text>
           <Typography.Text>
-            <b>Дата получения:</b>{" "}
-            {defect.received_at
-              ? dayjs(defect.received_at).format("DD.MM.YYYY")
-              : "—"}
+            <b>Дата получения:</b>{' '}
+            {defect.received_at ? dayjs(defect.received_at).format('DD.MM.YYYY') : '—'}
           </Typography.Text>
           <Typography.Text>
-            <b>Дата создания:</b>{" "}
-            {defect.created_at
-              ? dayjs(defect.created_at).format("DD.MM.YYYY")
-              : "—"}
+            <b>Дата создания:</b>{' '}
+            {defect.created_at ? dayjs(defect.created_at).format('DD.MM.YYYY') : '—'}
           </Typography.Text>
-          {defect.attachments?.length ? (
-            <div>
-              <b>Файлы:</b>
-              <ul style={{ paddingLeft: 20 }}>
-                {defect.attachments.map((f: any) => (
-                  <li key={f.id}>
-                    <a
-                      onClick={async (e) => {
-                        e.preventDefault();
-                        const url = await signedUrl(
-                          f.storage_path,
-                          f.original_name ?? "file",
-                        );
-                        const a = document.createElement("a");
-                        a.href = url;
-                        a.download = f.original_name ?? "file";
-                        document.body.appendChild(a);
-                        a.click();
-                        a.remove();
-                      }}
-                      href="#"
-                    >
-                      {f.original_name ?? f.storage_path.split("/").pop()}
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ) : null}
+          <DefectAttachmentsBlock
+            remoteFiles={files}
+            onFiles={handleFiles}
+            onRemove={handleRemove}
+            getSignedUrl={(p, n) => signedUrl(p, n)}
+          />
+          <div style={{ textAlign: 'right' }}>
+            <Tooltip title="Скачать форму устранения">
+              <Button type="text" icon={<DownloadOutlined />} onClick={downloadDocx} />
+            </Tooltip>
+          </div>
         </div>
       )}
     </Modal>

--- a/src/shared/types/defectWithFiles.ts
+++ b/src/shared/types/defectWithFiles.ts
@@ -1,0 +1,11 @@
+import type { DefectRecord } from './defect';
+import type { Attachment } from './attachment';
+
+/** Дефект с вложениями и связными названиями типов и статусов */
+export interface DefectWithFiles extends DefectRecord {
+  attachments: Attachment[];
+  /** Тип дефекта */
+  defect_type?: { id: number; name: string } | null;
+  /** Статус дефекта */
+  defect_status?: { id: number; name: string; color: string | null } | null;
+}

--- a/src/shared/utils/createDefectDocx.ts
+++ b/src/shared/utils/createDefectDocx.ts
@@ -1,0 +1,41 @@
+import { Document, Packer, Paragraph, TextRun } from 'docx';
+import dayjs from 'dayjs';
+import { saveAs } from 'file-saver';
+import type { DefectWithFiles } from '@/shared/types/defectWithFiles';
+
+/**
+ * Сформировать DOCX-файл типовой формы устранения замечания
+ * и скачать его.
+ * @param defect данные дефекта
+ */
+export async function createDefectDocx(defect: DefectWithFiles) {
+  const doc = new Document({
+    sections: [
+      {
+        properties: {},
+        children: [
+          new Paragraph({
+            children: [
+              new TextRun({ text: 'Форма устранения замечания', bold: true }),
+            ],
+          }),
+          new Paragraph(`ID дефекта: ${defect.id}`),
+          new Paragraph(`Описание: ${defect.description}`),
+          new Paragraph(`Тип дефекта: ${defect.defect_type?.name ?? '-'}`),
+          new Paragraph(
+            `Дата получения: ${
+              defect.received_at ? dayjs(defect.received_at).format('DD.MM.YYYY') : '-' }
+            `,
+          ),
+          new Paragraph(
+            `Дата устранения: ${
+              defect.fixed_at ? dayjs(defect.fixed_at).format('DD.MM.YYYY') : '-' }
+            `,
+          ),
+        ],
+      },
+    ],
+  });
+  const blob = await Packer.toBlob(doc);
+  saveAs(blob, `defect_${defect.id}.docx`);
+}


### PR DESCRIPTION
## Summary
- add ability to upload/download/delete defect files
- generate DOCX report of defect info
- expose new hooks for defect attachments
- update defect view modal with new functionality
- declare shared types for defect with files
- add docx dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68584fb52138832eaa6463bbfb037ea3