### PR TITLE
feat: export claims with defects links

### DIFF
--- a/src/entities/defect.ts
+++ b/src/entities/defect.ts
@@ -462,7 +462,7 @@ export function useCancelDefectFix() {
         }
       }
 
-      return id;
+  return id;
     },
     onSuccess: (_id) => {
       qc.invalidateQueries({ queryKey: [TABLE] });
@@ -473,6 +473,25 @@ export function useCancelDefectFix() {
     },
     onError: (e: any) => notify.error(`Ошибка обновления: ${e.message}`),
   });
+}
+
+/**
+ * Получить краткую информацию о дефектах по их идентификаторам.
+ */
+export async function getDefectsInfo(ids: number[]) {
+  if (!ids.length) {
+    return [] as Array<{ id: number; description: string; statusName: string | null }>;
+  }
+  const { data, error } = await supabase
+    .from('defects')
+    .select('id, description, statuses!fk_defects_status(name)')
+    .in('id', ids);
+  if (error) throw error;
+  return (data ?? []).map((d: any) => ({
+    id: d.id as number,
+    description: d.description as string,
+    statusName: d.statuses?.name ?? null,
+  }));
 }
 
 export async function signedUrl(path: string, filename = ''): Promise<string> {


### PR DESCRIPTION
## Summary
- add `getDefectsInfo` helper to fetch defect descriptions
- extend claim export to include file links and defect rows

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_685851a0204c832eafead0af9993cd39