### PR TITLE
Allow viewing claims from any project

### DIFF
--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -13,6 +13,7 @@ import {
 } from 'antd';
 import {
   useClaim,
+  useClaimAll,
   useUpdateClaim,
   useAddClaimAttachments,
   useRemoveClaimAttachment,
@@ -26,6 +27,8 @@ import { useClaimStatuses } from '@/entities/claimStatus';
 import { useNotify } from '@/shared/hooks/useNotify';
 import { useProjectId } from '@/shared/hooks/useProjectId';
 import { useAuthStore } from '@/shared/store/authStore';
+import { useRolePermission } from '@/entities/rolePermission';
+import type { RoleName } from '@/shared/types/rolePermission';
 import { useChangedFields } from '@/shared/hooks/useChangedFields';
 import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
 import FileDropZone from '@/shared/ui/FileDropZone';
@@ -79,7 +82,11 @@ const ClaimFormAntdEdit = React.forwardRef<
   ref,
 ) {
   const [form] = Form.useForm<ClaimFormAntdEditValues>();
-  const { data: claim } = useClaim(claimId);
+  const role = useAuthStore((s) => s.profile?.role as RoleName | undefined);
+  const { data: perm } = useRolePermission(role);
+  const claimAssigned = useClaim(claimId);
+  const claimAll = useClaimAll(claimId);
+  const claim = perm?.only_assigned_project ? claimAssigned.data : claimAll.data;
   const { data: projects = [] } = useVisibleProjects();
   const globalProjectId = useProjectId();
   const projectIdWatch = Form.useWatch('project_id', form);

--- a/src/features/claim/ClaimViewModal.tsx
+++ b/src/features/claim/ClaimViewModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Modal, Skeleton, Typography, Button } from 'antd';
-import { useClaim, signedUrl, closeDefectsForClaim } from '@/entities/claim';
+import { useClaim, useClaimAll, signedUrl, closeDefectsForClaim } from '@/entities/claim';
 import ClaimFormAntdEdit from './ClaimFormAntdEdit';
 import ClaimAttachmentsBlock from './ClaimAttachmentsBlock';
 import TicketDefectsEditorTable from '@/widgets/TicketDefectsEditorTable';
@@ -22,6 +22,8 @@ import { supabase } from '@/shared/api/supabaseClient';
 import { useClaimAttachments } from './model/useClaimAttachments';
 import type { ClaimFormAntdEditRef } from '@/shared/types/claimFormAntdEditRef';
 import { useAuthStore } from '@/shared/store/authStore';
+import { useRolePermission } from '@/entities/rolePermission';
+import type { RoleName } from '@/shared/types/rolePermission';
 
 interface Props {
   open: boolean;
@@ -30,7 +32,11 @@ interface Props {
 }
 
 export default function ClaimViewModal({ open, claimId, onClose }: Props) {
-  const { data: claim } = useClaim(claimId ?? undefined);
+  const role = useAuthStore((s) => s.profile?.role as RoleName | undefined);
+  const { data: perm } = useRolePermission(role);
+  const claimAssigned = useClaim(claimId ?? undefined);
+  const claimAll = useClaimAll(claimId ?? undefined);
+  const claim = perm?.only_assigned_project ? claimAssigned.data : claimAll.data;
   const attachments = useClaimAttachments({ claim: claim as any });
   const formRef = React.useRef<ClaimFormAntdEditRef>(null);
   const createDefs = useCreateDefects();


### PR DESCRIPTION
## Summary
- add `useClaimAll` for fetching claims without project filter
- fetch claims based on role in ClaimViewModal and edit form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68585d8cb3ac832ea96952b2560112d3