### PR TITLE
Fix court case creation

### DIFF
--- a/src/features/courtCase/AddCourtCaseForm.tsx
+++ b/src/features/courtCase/AddCourtCaseForm.tsx
@@ -89,7 +89,6 @@ export default function AddCourtCaseForm({
         fix_start_date: null,
         fix_end_date: null,
         description: values.description || '',
-        attachment_ids: [],
       } as any);
       notify.success('Дело успешно добавлено!');
       onSuccess?.();


### PR DESCRIPTION
## Summary
- handle unit links and attachments via join tables when creating court cases
- update court case update/delete logic for new schema
- remove unused attachment ids in old form

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68585df90a04832eb3d5f94504ea72a9