### PR TITLE
Fix claim update failing with 406

### DIFF
--- a/src/entities/claim.ts
+++ b/src/entities/claim.ts
@@ -446,14 +446,16 @@ export function useCreateClaim() {
  */
 export function useUpdateClaim() {
   const qc = useQueryClient();
-  const { projectId, projectIds, onlyAssigned } = useProjectFilter();
   return useMutation({
     mutationFn: async ({ id, updates }: { id: number; updates: Partial<Claim>; }) => {
       const { unit_ids, ...rest } = updates as Partial<Claim> & { unit_ids?: number[] };
 
-      let q = supabase.from(TABLE).update(rest).eq('id', id);
-      q = filterByProjects(q, projectId, projectIds, onlyAssigned);
-      const { data, error } = await q.select('*').single();
+      const { data, error } = await supabase
+        .from(TABLE)
+        .update(rest)
+        .eq('id', id)
+        .select('*')
+        .maybeSingle();
       if (error) throw error;
 
       if (Array.isArray(unit_ids)) {


### PR DESCRIPTION
## Summary
- avoid project filter when updating claim
- use `maybeSingle` to prevent 406 error after update

## Testing
- `npm test`
- `npm run lint` *(fails: eslint plugins missing)*
- `npx tsc -p tsconfig.json` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685861f901cc832e8ed994deebc3ff70