### PR TITLE
Fix modal warnings

### DIFF
--- a/src/features/correspondence/LetterViewModal.tsx
+++ b/src/features/correspondence/LetterViewModal.tsx
@@ -26,7 +26,7 @@ export default function LetterViewModal({ open, letterId, onClose }: Props) {
       onCancel={onClose}
       footer={null}
       width="80%"
-      destroyOnClose
+      destroyOnHidden
       title={<Typography.Title level={4} style={{ margin: 0 }}>{titleText}</Typography.Title>}
     >
       {letter ? (

--- a/src/features/courtCase/AddCourtCaseFormAntd.tsx
+++ b/src/features/courtCase/AddCourtCaseFormAntd.tsx
@@ -85,13 +85,17 @@ export default function AddCourtCaseFormAntd({
     }
   }, [initialValues, globalProjectId, profileId, form]);
 
+  /**
+   * Reset selected units when project changes to avoid inconsistent data
+   * as units are linked to a specific project.
+   */
   useEffect(() => {
     const prev = prevProjectIdRef.current;
     if (prev != null && projectId != null && prev !== projectId) {
-      form.setFieldValue('unit_ids', []);
+      form.setFieldsValue({ unit_ids: [] });
     }
     prevProjectIdRef.current = projectId ?? null;
-  }, [projectId, form]);
+  }, [projectId]);
 
   const { data: projects = [] } = useVisibleProjects();
   const { data: units = [], isPending: unitsLoading } = useUnitsByProject(projectId);

--- a/src/features/courtCase/CourtCaseViewModal.tsx
+++ b/src/features/courtCase/CourtCaseViewModal.tsx
@@ -25,7 +25,7 @@ export default function CourtCaseViewModal({ open, caseId, onClose }: Props) {
       onCancel={onClose}
       footer={null}
       width="80%"
-      destroyOnClose
+      destroyOnHidden
       title={<Typography.Title level={4} style={{ margin: 0 }}>{titleText}</Typography.Title>}
     >
       {courtCase ? (

--- a/src/widgets/CourtCaseStatusesAdmin.tsx
+++ b/src/widgets/CourtCaseStatusesAdmin.tsx
@@ -96,7 +96,7 @@ export default function CourtCaseStatusesAdmin({
                     onCancel={close}
                     title={modal.mode === 'add' ? 'Новая стадия' : 'Редактировать стадию'}
                     footer={null}
-                    destroyOnClose
+                    destroyOnHidden
                 >
                     <CourtCaseStatusForm
                         initialData={modal.mode === 'edit' ? modal.data : undefined}


### PR DESCRIPTION
## Summary
- fix resetting units on project switch
- replace deprecated `destroyOnClose` with `destroyOnHidden`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685862b75460832ebccf41f7e287db49