### PR TITLE
Restrict claim object selection to single

### DIFF
--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -55,7 +55,8 @@ export interface ClaimFormAntdEditProps {
 
 export interface ClaimFormAntdEditValues {
   project_id: number | null;
-  unit_ids: number[];
+  /** Идентификатор выбранного объекта */
+  unit_id: number | null;
   claim_status_id: number | null;
   claim_no: string;
   claimed_on: Dayjs | null;
@@ -117,7 +118,7 @@ const ClaimFormAntdEdit = React.forwardRef<
     if (!claim) return;
     form.setFieldsValue({
       project_id: claim.project_id,
-      unit_ids: claim.unit_ids,
+      unit_id: claim.unit_ids?.[0] ?? null,
       claim_status_id: claim.claim_status_id,
       claim_no: claim.claim_no,
       claimed_on: claim.claimedOn ?? null,
@@ -136,7 +137,7 @@ const ClaimFormAntdEdit = React.forwardRef<
         id: claim.id,
         updates: {
           project_id: values.project_id ?? claim.project_id,
-          unit_ids: values.unit_ids,
+          unit_ids: values.unit_id != null ? [values.unit_id] : [],
           claim_status_id: values.claim_status_id,
           claim_no: values.claim_no,
           claimed_on: values.claimed_on
@@ -224,13 +225,14 @@ const ClaimFormAntdEdit = React.forwardRef<
         </Col>
         <Col span={8}>
           <Form.Item
-            name="unit_ids"
-            label="Объекты"
+            name="unit_id"
+            label="Объект"
             rules={[{ required: true }]}
-            style={highlight('unit_ids')}
+            style={highlight('unit_id')}
           >
             <Select
-              mode="multiple"
+              showSearch
+              allowClear
               options={units.map((u) => ({ value: u.id, label: u.name }))}
               disabled={!projectId}
             />

--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -57,9 +57,9 @@ export default function ClaimsPage() {
     project_id: searchParams.get('project_id')
       ? Number(searchParams.get('project_id')!)
       : undefined,
-    unit_ids: searchParams.get('unit_id')
-      ? [Number(searchParams.get('unit_id')!)]
-      : [],
+    unit_id: searchParams.get('unit_id')
+      ? Number(searchParams.get('unit_id')!)
+      : undefined,
     engineer_id: searchParams.get('engineer_id') || undefined,
   };
   const [filters, setFilters] = useState({});


### PR DESCRIPTION
## Summary
- limit claim forms to selecting one object
- adjust claim page initial values for single object

## Testing
- `npm run lint` *(fails: eslint modules missing)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685868a264f8832e9694b8c748e2abd5