### PR TITLE
Fix building select out-of-range value

### DIFF
--- a/src/pages/ProjectStructurePage/ProjectStructurePage.tsx
+++ b/src/pages/ProjectStructurePage/ProjectStructurePage.tsx
@@ -250,9 +250,9 @@ export default function ProjectStructurePage() {
                             }}
                         >
                             <Select
-                                value={building || ""}
+                                value={buildings.includes(building) ? building : ""}
                                 onChange={(e) => setBuilding(e.target.value)}
-                                displayEmpty={false}
+                                displayEmpty
                                 sx={{
                                     bgcolor: "rgba(255,255,255,0.11)",
                                     borderRadius: "10px",


### PR DESCRIPTION
## Summary
- prevent MUI warnings by ensuring selected building is valid

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685868f8b7fc832e830c3a42ccf90423