### PR TITLE
Add unit status indicators on structure page

### DIFF
--- a/src/entities/floor/FloorCell.tsx
+++ b/src/entities/floor/FloorCell.tsx
@@ -15,6 +15,8 @@ export default function FloorCell({
   floor,
   units,
   casesByUnit,
+  lettersByUnit,
+  claimsByUnit,
   onAddUnit,
   onEditFloor,
   onDeleteFloor,
@@ -105,6 +107,8 @@ export default function FloorCell({
           key={unit.id}
           unit={unit}
           cases={casesByUnit ? casesByUnit[unit.id] : []}
+          hasLetter={Boolean(lettersByUnit ? lettersByUnit[unit.id] : false)}
+          claimInfo={claimsByUnit ? claimsByUnit[unit.id] : null}
           onEditUnit={() => onEditUnit?.(unit)}
           onDeleteUnit={() => onDeleteUnit?.(unit)}
           onAction={() => onUnitClick?.(unit)}

--- a/src/entities/unit/UnitCell.tsx
+++ b/src/entities/unit/UnitCell.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { Paper, Box, Tooltip, IconButton, Typography } from "@mui/material";
+import MailIcon from "@mui/icons-material/Mail";
+import type { UnitClaimInfo } from "@/shared/types/unitClaimInfo";
 import EditOutlined from "@mui/icons-material/EditOutlined";
 import DeleteOutline from "@mui/icons-material/DeleteOutline";
 
@@ -19,17 +21,32 @@ function getSemiTransparent(color, alpha = 0.3) {
 
 /**
  * Ячейка объекта на шахматке.
- * Подсвечивает наличие тикетов и судебных дел.
+ * Подсвечивает наличие писем, претензий и судебных дел.
+ * Используется в шахматке на странице структуры проекта.
  */
+interface Props {
+  unit: any;
+  cases?: any[];
+  hasLetter?: boolean;
+  claimInfo?: UnitClaimInfo | null;
+  onEditUnit?: (unit: any) => void;
+  onDeleteUnit?: (unit: any) => void;
+  onAction?: (unit: any) => void;
+}
+
 export default function UnitCell({
   unit,
   cases = [],
+  hasLetter = false,
+  claimInfo = null,
   onEditUnit,
   onDeleteUnit,
   onAction,
-}) {
+}: Props) {
   const bgColor = "#fff";
   const hasCases = Array.isArray(cases) && cases.length > 0;
+  const hasOfficial = claimInfo?.official ?? false;
+  const claimColor = claimInfo?.color ?? null;
 
   return (
     <Paper
@@ -41,7 +58,9 @@ export default function UnitCell({
         flexDirection: "column",
         alignItems: "stretch",
         justifyContent: "flex-start",
-        border: `1.5px solid ${hasCases ? "#e53935" : "#dde2ee"}`,
+        border: `${hasCases ? 2 : 1.5}px solid ${
+          hasCases || hasOfficial ? "#e53935" : "#dde2ee"
+        }`,
         background: bgColor,
         borderRadius: "12px",
         boxShadow: hasCases ? "0 0 0 2px rgba(229,57,53,0.25)" : "0 1px 6px 0 #E3ECFB",
@@ -54,7 +73,7 @@ export default function UnitCell({
           boxShadow: hasCases
             ? "0 0 0 2px rgba(211,47,47,0.4)"
             : "0 4px 16px 0 #b5d2fa",
-          borderColor: hasCases ? "#d32f2f" : "#1976d2",
+          borderColor: hasCases || hasOfficial ? "#d32f2f" : "#1976d2",
           background: "#f6faff",
         },
         position: "relative",
@@ -71,6 +90,26 @@ export default function UnitCell({
       }}
       data-oid="21x1tb3"
     >
+      {claimColor && (
+        <Box
+          sx={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            height: 6,
+            bgcolor: claimColor,
+            borderTopLeftRadius: "12px",
+            borderTopRightRadius: "12px",
+          }}
+        />
+      )}
+      {hasLetter && (
+        <MailIcon
+          fontSize="small"
+          sx={{ position: "absolute", top: 2, right: 2, color: "#f0b400" }}
+        />
+      )}
       <Box
         sx={{
           flexGrow: 1,

--- a/src/shared/types/unitClaimInfo.ts
+++ b/src/shared/types/unitClaimInfo.ts
@@ -1,0 +1,7 @@
+export interface UnitClaimInfo {
+  /** Цвет статуса претензии */
+  color: string | null;
+  /** Есть ли официальная претензия */
+  official: boolean;
+}
+

--- a/src/widgets/StatusLegend.tsx
+++ b/src/widgets/StatusLegend.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Box, Typography } from '@mui/material';
+import MailIcon from '@mui/icons-material/Mail';
+import { useClaimStatuses } from '@/entities/claimStatus';
 
 
 /**
@@ -7,7 +9,7 @@ import { Box, Typography } from '@mui/material';
  * Отображает цвета статусов замечаний и пояснение к красной обводке.
  */
 export default function StatusLegend() {
-  const statuses: any[] = [];
+  const { data: statuses = [] } = useClaimStatuses();
 
   return (
     <Box sx={{ mt: 2, display: 'flex', flexDirection: 'column', gap: 1 }}>
@@ -29,7 +31,13 @@ export default function StatusLegend() {
         ))}
       </Box>
       <Typography variant="body2" color="text.secondary">
-        Красная обводка — квартиры с судебными делами
+        <MailIcon fontSize="small" sx={{ mr: 0.5, color: '#f0b400' }} /> — есть связанные письма
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        Тонкая красная обводка — официальная претензия
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        Жирная красная обводка — судебное дело
       </Typography>
     </Box>
   );

--- a/src/widgets/UnitsMatrix/UnitsMatrix.tsx
+++ b/src/widgets/UnitsMatrix/UnitsMatrix.tsx
@@ -36,6 +36,8 @@ export default function UnitsMatrix({
     handleAddFloor,
     fetchUnits,
     casesByUnit,
+    lettersByUnit,
+    claimsByUnit,
     units,
   } = useUnitsMatrix(projectId, building);
   const navigate = useNavigate();
@@ -183,6 +185,8 @@ export default function UnitsMatrix({
             floor={floor}
             units={unitsByFloor[floor] || []}
             casesByUnit={casesByUnit}
+            lettersByUnit={lettersByUnit}
+            claimsByUnit={claimsByUnit}
             onAddUnit={() => handleAddUnit(floor)}
             onEditFloor={handleEditFloor}
             onDeleteFloor={handleDeleteFloor}


### PR DESCRIPTION
## Summary
- show claim/letter info in unit grid
- color unit headers by claim status
- mark official claims with red border
- highlight court cases with bold border
- update legend explanations

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68586ea60d6c832e9b52430e2eebb591