### PR TITLE
Disable Official claim toggle for non-lawyers

### DIFF
--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -8,6 +8,7 @@ import {
   Row,
   Col,
   Switch,
+  Tooltip,
 } from 'antd';
 import ClaimAttachmentsBlock from './ClaimAttachmentsBlock';
 import dayjs from 'dayjs';
@@ -21,6 +22,7 @@ import { useNotify } from '@/shared/hooks/useNotify';
 import DefectEditableTable from '@/widgets/DefectEditableTable';
 import { useCreateDefects, type NewDefect } from '@/entities/defect';
 import { useAuthStore } from '@/shared/store/authStore';
+import type { RoleName } from '@/shared/types/rolePermission';
 
 export interface ClaimFormAntdProps {
   onCreated?: () => void;
@@ -76,6 +78,7 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
   const create = useCreateClaim();
   const notify = useNotify();
   const createDefects = useCreateDefects();
+  const role = useAuthStore((s) => s.profile?.role as RoleName | undefined);
   const defectsWatch = Form.useWatch('defects', form);
 
   const handleDropFiles = (dropped: File[]) => {
@@ -265,7 +268,9 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
             label="Официальная претензия"
             valuePropName="checked"
           >
-            <Switch />
+            <Tooltip title="Доступно юристам и администраторам">
+              <Switch disabled={role !== 'ADMIN' && role !== 'LAWYER'} />
+            </Tooltip>
           </Form.Item>
         </Col>
       </Row>

--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -10,6 +10,7 @@ import {
   Button,
   Skeleton,
   Switch,
+  Tooltip,
 } from 'antd';
 import {
   useClaim,
@@ -309,7 +310,9 @@ const ClaimFormAntdEdit = React.forwardRef<
             valuePropName="checked"
             style={highlight('is_official')}
           >
-            <Switch />
+            <Tooltip title="Доступно юристам и администраторам">
+              <Switch disabled={role !== 'ADMIN' && role !== 'LAWYER'} />
+            </Tooltip>
           </Form.Item>
         </Col>
       </Row>

--- a/src/shared/types/claim.ts
+++ b/src/shared/types/claim.ts
@@ -21,7 +21,10 @@ export interface Claim {
   resolved_on: string | null;
   /** Ответственный инженер */
   engineer_id: string | null;
-  /** Официальная претензия */
+  /**
+   * Официальная претензия.
+   * Переключатель доступен только ролям ADMIN и LAWYER.
+   */
   is_official?: boolean;
   /** Связанные дефекты */
   defect_ids?: number[];


### PR DESCRIPTION
## Summary
- restrict editing of 'Официальная претензия' to ADMIN and LAWYER roles
- document role restrictions in `Claim` type

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68587407b6ac832eaaab439dc9b5854b