### PR TITLE
Fix claim linking modal

### DIFF
--- a/src/features/claim/LinkClaimsDialog.tsx
+++ b/src/features/claim/LinkClaimsDialog.tsx
@@ -9,10 +9,12 @@ interface Props {
   claims: ClaimWithNames[];
   onClose: () => void;
   onSubmit: (ids: string[]) => void;
+  /** Признак выполнения операции связывания */
+  loading?: boolean;
 }
 
 /** Диалог выбора претензий для связывания */
-export default function LinkClaimsDialog({ open, parent, claims, onClose, onSubmit }: Props) {
+export default function LinkClaimsDialog({ open, parent, claims, onClose, onSubmit, loading }: Props) {
   const [selected, setSelected] = useState<string[]>([]);
   const [search, setSearch] = useState('');
 
@@ -62,6 +64,7 @@ export default function LinkClaimsDialog({ open, parent, claims, onClose, onSubm
           key="link"
           type="primary"
           disabled={selected.length === 0}
+          loading={loading}
           onClick={() => onSubmit(selected)}
         >
           Связать

--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -262,9 +262,19 @@ export default function ClaimsPage() {
           open={!!linkFor}
           parent={linkFor}
           claims={claimsWithNames}
+          loading={linkClaims.isPending}
           onClose={() => setLinkFor(null)}
           onSubmit={(ids) =>
-            linkClaims.mutate({ parentId: String(linkFor!.id), childIds: ids })
+            linkClaims.mutate(
+              { parentId: String(linkFor!.id), childIds: ids },
+              {
+                onSuccess: () => {
+                  message.success('Претензии связаны');
+                  setLinkFor(null);
+                },
+                onError: (e) => message.error(e.message),
+              },
+            )
           }
         />
         <TableColumnsDrawer

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -153,7 +153,8 @@ export default function ClaimsTable({
   const [pageSize, setPageSize] = React.useState(25);
 
   React.useEffect(() => {
-    setExpandedRowKeys(filtered.map((c) => c.id));
+    // По умолчанию все строки свернуты
+    setExpandedRowKeys([]);
   }, [filtered]);
 
   const rowClassName = (row: ClaimWithNames) => {


### PR DESCRIPTION
## Summary
- auto close link claims dialog with notification
- pass loading state to link claims dialog
- collapse claims table rows by default

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_685874b8c640832e880329fbd3235c12