### PR TITLE
Fix TS errors in claim form and correspondence entities

### DIFF
--- a/src/entities/correspondence/index.ts
+++ b/src/entities/correspondence/index.ts
@@ -112,9 +112,9 @@ export function useLetters() {
         arr.push({
           id: String(file.id),
           name,
-          file_type: file.file_type,
+          mime_type: file.file_type,
           storage_path: file.storage_path,
-          file_url: file.file_url,
+          path: file.file_url,
         } as CorrespondenceAttachment);
         attachmentsMap[row.letter_id] = arr;
       });
@@ -251,9 +251,9 @@ export function useAddLetter() {
                 return u.storage_path;
               }
             })(),
-          file_type: u.file_type,
+          mime_type: u.file_type,
           storage_path: u.storage_path,
-          file_url: u.file_url,
+          path: u.file_url,
         }));
         attachmentIds = uploaded.map((u) => u.id);
         if (attachmentIds.length) {
@@ -609,14 +609,17 @@ export function useUpdateLetter() {
       if (updatedAttachments.length) {
         // attachment type updates removed
       }
-      let uploaded: any[] = [];
-      if (newAttachments.length) {
-        uploaded = await addLetterAttachments(newAttachments, id);
-        if (uploaded.length) {
-          const rows = uploaded.map((u: any) => ({
-            letter_id: id,
-            attachment_id: u.id,
-          }));
+        let uploaded: any[] = [];
+        if (newAttachments.length) {
+          uploaded = await addLetterAttachments(
+            newAttachments.map((f) => ({ file: f.file, type_id: null })),
+            id,
+          );
+          if (uploaded.length) {
+            const rows = uploaded.map((u: any) => ({
+              letter_id: id,
+              attachment_id: u.id,
+            }));
           await supabase.from(LETTER_ATTACH_TABLE).insert(rows);
         }
         ids = ids.concat(uploaded.map((u) => u.id));

--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -26,13 +26,8 @@ import type { RoleName } from '@/shared/types/rolePermission';
 
 export interface ClaimFormAntdProps {
   onCreated?: () => void;
-  initialValues?: Partial<{
-    project_id: number;
-    unit_ids: number[];
-    engineer_id: string;
-    description: string;
-    resolved_on: string;
-  }>;
+  /** Начальные значения формы */
+  initialValues?: Partial<Omit<ClaimFormValues, 'defects'>>;
   /** Показывать форму добавления дефектов */
   showDefectsForm?: boolean;
   /** Показывать блок загрузки файлов */
@@ -174,6 +169,7 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
       is_warranty: d.is_warranty ?? false,
       received_at: d.received_at ? d.received_at.format('YYYY-MM-DD') : null,
       fixed_at: d.fixed_at ? d.fixed_at.format('YYYY-MM-DD') : null,
+      fixed_by: null,
     }));
     const defectIds = await createDefects.mutateAsync(newDefs);
     await create.mutateAsync({


### PR DESCRIPTION
## Summary
- widen `initialValues` type for ClaimFormAntd
- include `fixed_by` when creating new defects
- correct attachment mapping in correspondence entity
- map new attachments when updating letters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858e1eb28fc832e8f9ffdf713ef2303