### PR TITLE
Добавлена сортировка объектов на этаже

### DIFF
--- a/src/entities/floor/FloorCell.tsx
+++ b/src/entities/floor/FloorCell.tsx
@@ -4,6 +4,9 @@ import UnitCell from "@/entities/unit/UnitCell";
 import EditOutlined from "@mui/icons-material/EditOutlined";
 import DeleteOutline from "@mui/icons-material/DeleteOutline";
 import AddIcon from "@mui/icons-material/Add";
+import SortIcon from "@mui/icons-material/Sort";
+import { parseUnitNumber } from "@/shared/utils/parseUnitNumber";
+import type { SortOrder } from "@/shared/types/sortOrder";
 
 const CELL_SIZE = 54;
 const FLOOR_COLOR = "#1976d2";
@@ -14,6 +17,8 @@ const FLOOR_COLOR = "#1976d2";
 export default function FloorCell({
   floor,
   units,
+  sortOrder = 'asc',
+  onToggleSort,
   casesByUnit,
   lettersByUnit,
   claimsByUnit,
@@ -24,6 +29,22 @@ export default function FloorCell({
   onDeleteUnit,
   onUnitClick,
 }) {
+  const sortedUnits = [...units].sort((a, b) => {
+    const numA = parseUnitNumber(a.name);
+    const numB = parseUnitNumber(b.name);
+    if (!Number.isNaN(numA) && !Number.isNaN(numB) && numA !== numB) {
+      return sortOrder === 'asc' ? numA - numB : numB - numA;
+    }
+    if (!Number.isNaN(numA) && Number.isNaN(numB)) {
+      return sortOrder === 'asc' ? -1 : 1;
+    }
+    if (Number.isNaN(numA) && !Number.isNaN(numB)) {
+      return sortOrder === 'asc' ? 1 : -1;
+    }
+    return sortOrder === 'asc'
+      ? String(a.name).localeCompare(String(b.name))
+      : String(b.name).localeCompare(String(a.name));
+  });
   return (
     <Box
       sx={{
@@ -68,6 +89,30 @@ export default function FloorCell({
           }}
           data-oid="ry3jcl1"
         >
+          <Tooltip
+            title={
+              sortOrder === "asc"
+                ? "Сортировать по убыванию"
+                : "Сортировать по возрастанию"
+            }
+          >
+            <IconButton
+              size="small"
+              sx={{
+                color: "#b0b6be",
+                opacity: 0.8,
+                mb: 0.2,
+                background: "#F8FAFF",
+                "&:hover": { color: FLOOR_COLOR, background: "#e3ecfb" },
+              }}
+              onClick={() => onToggleSort?.(floor)}
+            >
+              <SortIcon
+                fontSize="small"
+                sx={{ transform: sortOrder === "asc" ? "rotate(180deg)" : "none" }}
+              />
+            </IconButton>
+          </Tooltip>
           <Tooltip title="Переименовать этаж" data-oid="w.a3.uu">
             <IconButton
               size="small"
@@ -102,7 +147,7 @@ export default function FloorCell({
           </Tooltip>
         </Box>
       </Box>
-      {units.map((unit) => (
+      {sortedUnits.map((unit) => (
         <UnitCell
           key={unit.id}
           unit={unit}

--- a/src/shared/types/sortOrder.ts
+++ b/src/shared/types/sortOrder.ts
@@ -1,0 +1,1 @@
+export type SortOrder = 'asc' | 'desc';

--- a/src/shared/utils/parseUnitNumber.ts
+++ b/src/shared/utils/parseUnitNumber.ts
@@ -1,0 +1,7 @@
+/**
+ * Возвращает числовую часть имени объекта. Если цифры не найдены, возвращает NaN.
+ */
+export function parseUnitNumber(name: string): number {
+  const match = String(name).match(/\d+/);
+  return match ? Number(match[0]) : NaN;
+}

--- a/src/widgets/UnitsMatrix/UnitsMatrix.tsx
+++ b/src/widgets/UnitsMatrix/UnitsMatrix.tsx
@@ -20,6 +20,7 @@ import { supabase } from "@/shared/api/supabaseClient";
 import HistoryDialog from "@/features/history/HistoryDialog";
 import { useNavigate, createSearchParams } from 'react-router-dom';
 import { useAuthStore } from '@/shared/store/authStore';
+import type { SortOrder } from '@/shared/types/sortOrder';
 
 /**
  * Шахматка квартир/этажей для заданного проекта и корпуса.
@@ -63,6 +64,8 @@ export default function UnitsMatrix({
     action: "",
   });
 
+  const [sortOrders, setSortOrders] = useState<Record<string, SortOrder>>({});
+
   // Прокидываем units (все объекты проекта) наверх для счетчиков
   useEffect(() => {
     if (typeof onUnitsChanged === "function") {
@@ -87,6 +90,13 @@ export default function UnitsMatrix({
     setConfirmDialog({ open: true, type: "unit", target: unit });
   const handleUnitAction = (unit) =>
     setActionDialog({ open: true, unit, action: "" });
+
+  const handleToggleSort = (floor: string | number) => {
+    setSortOrders((prev) => {
+      const current = prev[String(floor)] ?? 'asc';
+      return { ...prev, [String(floor)]: current === 'asc' ? 'desc' : 'asc' };
+    });
+  };
 
   // Сохранить (обновление в базе и fetchUnits)
   const handleSaveEdit = async () => {
@@ -184,6 +194,8 @@ export default function UnitsMatrix({
             key={floor}
             floor={floor}
             units={unitsByFloor[floor] || []}
+            sortOrder={sortOrders[String(floor)] ?? 'asc'}
+            onToggleSort={handleToggleSort}
             casesByUnit={casesByUnit}
             lettersByUnit={lettersByUnit}
             claimsByUnit={claimsByUnit}


### PR DESCRIPTION
## Summary
- добавлена функция `parseUnitNumber` для извлечения числа из имени объекта
- поддержана сортировка квартир на этаже с переключением порядка
- добавлен тип `SortOrder`

## Testing
- `npm test`
- `npm run lint` *(failed: eslint packages missing)*
- `npx tsc -p tsconfig.json` *(failed: modules not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593aa85a68832ea7bff7e8748b538e