### PR TITLE
Добавление сортировки номеров по этажам

### DIFF
--- a/src/entities/floor/FloorCell.tsx
+++ b/src/entities/floor/FloorCell.tsx
@@ -3,6 +3,7 @@ import { Box, Tooltip, IconButton } from "@mui/material";
 import UnitCell from "@/entities/unit/UnitCell";
 import EditOutlined from "@mui/icons-material/EditOutlined";
 import DeleteOutline from "@mui/icons-material/DeleteOutline";
+import SwapVertIcon from "@mui/icons-material/SwapVert";
 import AddIcon from "@mui/icons-material/Add";
 
 const CELL_SIZE = 54;
@@ -23,6 +24,8 @@ export default function FloorCell({
   onEditUnit,
   onDeleteUnit,
   onUnitClick,
+  onSortUnits,
+  sortDirection,
 }) {
   return (
     <Box
@@ -98,6 +101,24 @@ export default function FloorCell({
               data-oid="ha0rwke"
             >
               <DeleteOutline fontSize="small" data-oid="b.aximf" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Сортировать номера" data-oid="sortfloor">
+            <IconButton
+              size="small"
+              sx={{
+                color: sortDirection ? FLOOR_COLOR : "#b0b6be",
+                opacity: 0.8,
+                mt: 0.2,
+                background: "#F8FAFF",
+                "&:hover": { color: FLOOR_COLOR, background: "#e3ecfb" },
+              }}
+              onClick={() => onSortUnits?.(floor)}
+            >
+              <SwapVertIcon
+                fontSize="small"
+                sx={{ transform: sortDirection === 'desc' ? 'rotate(180deg)' : 'none' }}
+              />
             </IconButton>
           </Tooltip>
         </Box>

--- a/src/shared/utils/unitNumberSort.ts
+++ b/src/shared/utils/unitNumberSort.ts
@@ -1,0 +1,21 @@
+/**
+ * Извлекает первое целое число из строки.
+ * Если число не найдено, возвращается {@link Number.POSITIVE_INFINITY}.
+ */
+export function extractFirstNumber(value: string): number {
+  const match = value.match(/\d+/);
+  return match ? parseInt(match[0], 10) : Number.POSITIVE_INFINITY;
+}
+
+/**
+ * Возвращает компаратор для сортировки объектов по числовой части их поля `name`.
+ * @param direction Направление сортировки: 'asc' или 'desc'
+ */
+export function getUnitNameComparator<T extends { name: string }>(direction: 'asc' | 'desc') {
+  return (a: T, b: T) => {
+    const numA = extractFirstNumber(a.name);
+    const numB = extractFirstNumber(b.name);
+    if (numA === numB) return 0;
+    return direction === 'asc' ? numA - numB : numB - numA;
+  };
+}

--- a/src/widgets/UnitsMatrix/UnitsMatrix.tsx
+++ b/src/widgets/UnitsMatrix/UnitsMatrix.tsx
@@ -20,6 +20,7 @@ import { supabase } from "@/shared/api/supabaseClient";
 import HistoryDialog from "@/features/history/HistoryDialog";
 import { useNavigate, createSearchParams } from 'react-router-dom';
 import { useAuthStore } from '@/shared/store/authStore';
+import { getUnitNameComparator } from '@/shared/utils/unitNumberSort';
 
 /**
  * Шахматка квартир/этажей для заданного проекта и корпуса.
@@ -63,6 +64,12 @@ export default function UnitsMatrix({
     action: "",
   });
 
+  const [sortDirections, setSortDirections] = useState<Record<string, 'asc' | 'desc' | null>>({});
+
+  useEffect(() => {
+    setSortDirections({});
+  }, [projectId, building]);
+
   // Прокидываем units (все объекты проекта) наверх для счетчиков
   useEffect(() => {
     if (typeof onUnitsChanged === "function") {
@@ -87,6 +94,14 @@ export default function UnitsMatrix({
     setConfirmDialog({ open: true, type: "unit", target: unit });
   const handleUnitAction = (unit) =>
     setActionDialog({ open: true, unit, action: "" });
+
+  const handleSortFloor = (floor: string | number) => {
+    setSortDirections((prev) => {
+      const current = prev[floor] ?? null;
+      const next = current === 'asc' ? 'desc' : 'asc';
+      return { ...prev, [floor]: next };
+    });
+  };
 
   // Сохранить (обновление в базе и fetchUnits)
   const handleSaveEdit = async () => {
@@ -131,6 +146,19 @@ export default function UnitsMatrix({
     }
     setConfirmDialog({ open: false, type: "", target: null });
   };
+
+  const sortedUnitsByFloor = React.useMemo(() => {
+    const map: Record<string, any[]> = {};
+    for (const [fl, units] of Object.entries(unitsByFloor)) {
+      const dir = sortDirections[fl];
+      if (dir) {
+        map[fl] = [...units].sort(getUnitNameComparator(dir));
+      } else {
+        map[fl] = units;
+      }
+    }
+    return map;
+  }, [unitsByFloor, sortDirections]);
 
   if (!floors.length) {
     return (
@@ -183,7 +211,7 @@ export default function UnitsMatrix({
           <FloorCell
             key={floor}
             floor={floor}
-            units={unitsByFloor[floor] || []}
+            units={sortedUnitsByFloor[floor] || []}
             casesByUnit={casesByUnit}
             lettersByUnit={lettersByUnit}
             claimsByUnit={claimsByUnit}
@@ -193,6 +221,8 @@ export default function UnitsMatrix({
             onEditUnit={handleEditUnit}
             onDeleteUnit={handleDeleteUnit}
             onUnitClick={handleUnitAction}
+            onSortUnits={handleSortFloor}
+            sortDirection={sortDirections[floor] ?? null}
           />
         ))}
         {/* Кнопка добавления нового этажа */}


### PR DESCRIPTION
## Summary
- добавлена утилита `unitNumberSort` для сравнения номеров
- добавлена иконка сортировки этажей в `FloorCell`
- реализовано состояние сортировки этажей в `UnitsMatrix`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685958664a6c832e9e0589d28041ed3b