### PR TITLE
Добавление сортировки номеров по этажам

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -1237,5 +1237,40 @@
     "data_type": "uuid",
     "is_nullable": "YES",
     "column_default": null
+  },
+  {
+    "table_name": "unit_sort_orders",
+    "column_name": "id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": "nextval('unit_sort_orders_id_seq'::regclass)"
+  },
+  {
+    "table_name": "unit_sort_orders",
+    "column_name": "project_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": null
+  },
+  {
+    "table_name": "unit_sort_orders",
+    "column_name": "building",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": null
+  },
+  {
+    "table_name": "unit_sort_orders",
+    "column_name": "floor",
+    "data_type": "text",
+    "is_nullable": "NO",
+    "column_default": null
+  },
+  {
+    "table_name": "unit_sort_orders",
+    "column_name": "sort_direction",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": null
   }
 ]

--- a/sql/create_unit_sort_orders.sql
+++ b/sql/create_unit_sort_orders.sql
@@ -1,0 +1,9 @@
+-- Создание таблицы для хранения направления сортировки квартир на этажах
+CREATE TABLE IF NOT EXISTS unit_sort_orders (
+  id SERIAL PRIMARY KEY,
+  project_id INTEGER NOT NULL,
+  building TEXT,
+  floor TEXT NOT NULL,
+  sort_direction TEXT,
+  UNIQUE (project_id, building, floor)
+);

--- a/src/entities/floor/FloorCell.tsx
+++ b/src/entities/floor/FloorCell.tsx
@@ -3,6 +3,7 @@ import { Box, Tooltip, IconButton } from "@mui/material";
 import UnitCell from "@/entities/unit/UnitCell";
 import EditOutlined from "@mui/icons-material/EditOutlined";
 import DeleteOutline from "@mui/icons-material/DeleteOutline";
+import SwapVertIcon from "@mui/icons-material/SwapVert";
 import AddIcon from "@mui/icons-material/Add";
 
 const CELL_SIZE = 54;
@@ -23,6 +24,8 @@ export default function FloorCell({
   onEditUnit,
   onDeleteUnit,
   onUnitClick,
+  onSortUnits,
+  sortDirection,
 }) {
   return (
     <Box
@@ -55,27 +58,34 @@ export default function FloorCell({
         }}
         data-oid="b2o0a0s"
       >
-        <span data-oid="79w3yn4">{floor}</span>
-        <Box
-          sx={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            position: "absolute",
-            right: 8,
-            top: 6,
-            zIndex: 2,
-          }}
-          data-oid="ry3jcl1"
-        >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+          <span data-oid="79w3yn4">{floor}</span>
+          <Tooltip title="Сортировать номера" data-oid="sortfloor">
+            <IconButton
+              size="small"
+              sx={{
+                color: sortDirection ? FLOOR_COLOR : "#b0b6be",
+                background: "#F8FAFF",
+                "&:hover": { color: FLOOR_COLOR, background: "#e3ecfb" },
+                p: 0.5,
+              }}
+              onClick={() => onSortUnits?.(floor)}
+            >
+              <SwapVertIcon
+                fontSize="small"
+                sx={{ transform: sortDirection === 'desc' ? 'rotate(180deg)' : 'none' }}
+              />
+            </IconButton>
+          </Tooltip>
+        </Box>
+        <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
           <Tooltip title="Переименовать этаж" data-oid="w.a3.uu">
             <IconButton
               size="small"
               sx={{
                 color: "#b0b6be",
-                opacity: 0.8,
-                mb: 0.2,
                 background: "#F8FAFF",
+                mb: 0.2,
                 "&:hover": { color: FLOOR_COLOR, background: "#e3ecfb" },
               }}
               onClick={() => onEditFloor?.(floor)}
@@ -89,9 +99,8 @@ export default function FloorCell({
               size="small"
               sx={{
                 color: "#b0b6be",
-                opacity: 0.8,
-                mt: 0.2,
                 background: "#F8FAFF",
+                mt: 0.2,
                 "&:hover": { color: "#e53935", background: "#fdeaea" },
               }}
               onClick={() => onDeleteFloor?.(floor)}

--- a/src/entities/unitSortOrder.ts
+++ b/src/entities/unitSortOrder.ts
@@ -1,0 +1,49 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/shared/api/supabaseClient';
+import type { SortDirection } from '@/shared/types/sortDirection';
+import type { UnitSortOrder } from '@/shared/types/unitSortOrder';
+
+const TABLE = 'unit_sort_orders';
+
+/**
+ * Загрузка настроек сортировки объектов по этажам.
+ */
+export const useUnitSortOrders = (projectId?: number | null, building?: string | null) =>
+  useQuery<Record<string, SortDirection>>({
+    queryKey: [TABLE, projectId, building],
+    enabled: !!projectId,
+    queryFn: async () => {
+      if (!projectId) return {};
+      let query = supabase
+        .from(TABLE)
+        .select('floor, sort_direction')
+        .eq('project_id', projectId);
+      if (building) query = query.eq('building', building);
+      const { data, error } = await query;
+      if (error) throw error;
+      const map: Record<string, SortDirection> = {};
+      (data ?? []).forEach((row: any) => {
+        if (row.sort_direction) map[row.floor] = row.sort_direction as SortDirection;
+      });
+      return map;
+    },
+    staleTime: 5 * 60_000,
+  });
+
+/**
+ * Сохранить направление сортировки для этажа.
+ */
+export const useUpsertUnitSortOrder = () => {
+  const qc = useQueryClient();
+  return useMutation<void, Error, UnitSortOrder>({
+    mutationFn: async (payload) => {
+      const { error } = await supabase
+        .from(TABLE)
+        .upsert(payload, { onConflict: 'project_id,building,floor' });
+      if (error) throw error;
+    },
+    onSuccess: (_data, vars) => {
+      qc.invalidateQueries({ queryKey: [TABLE, vars.project_id, vars.building] });
+    },
+  });
+};

--- a/src/shared/types/sortDirection.ts
+++ b/src/shared/types/sortDirection.ts
@@ -1,0 +1,4 @@
+/**
+ * Возможные направления сортировки.
+ */
+export type SortDirection = 'asc' | 'desc';

--- a/src/shared/types/unitSortOrder.ts
+++ b/src/shared/types/unitSortOrder.ts
@@ -1,0 +1,7 @@
+export interface UnitSortOrder {
+  id?: number;
+  project_id: number;
+  building?: string | null;
+  floor: string;
+  sort_direction: import('./sortDirection').SortDirection | null;
+}

--- a/src/shared/utils/unitNumberSort.ts
+++ b/src/shared/utils/unitNumberSort.ts
@@ -1,0 +1,35 @@
+/**
+ * Извлекает первое целое число из строки. Если число не найдено,
+ * возвращается {@link Number.POSITIVE_INFINITY}.
+ */
+export function extractFirstNumber(value: string): number {
+  const match = value.match(/\d+/);
+  return match ? parseInt(match[0], 10) : Number.POSITIVE_INFINITY;
+}
+
+import type { SortDirection } from '@/shared/types/sortDirection';
+
+/**
+ * Создает компаратор для сортировки объектов по числовой части их имени.
+ * Если числовые значения совпадают, используется лексикографическое сравнение
+ * полей `name` в нижнем регистре.
+ *
+ * @param direction Направление сортировки
+ */
+export function getUnitNameComparator<T extends { name: string }>(
+  direction: SortDirection,
+) {
+  return (a: T, b: T) => {
+    const numA = extractFirstNumber(a.name);
+    const numB = extractFirstNumber(b.name);
+    if (numA !== numB) {
+      return direction === 'asc' ? numA - numB : numB - numA;
+    }
+    const nameA = a.name.toLowerCase();
+    const nameB = b.name.toLowerCase();
+    if (nameA === nameB) return 0;
+    return direction === 'asc'
+      ? nameA.localeCompare(nameB)
+      : nameB.localeCompare(nameA);
+  };
+}


### PR DESCRIPTION
## Summary
- добавлена типизация направления сортировки
- переработана верстка иконок в `FloorCell`
- сохранение порядка сортировки этажей в `localStorage`
- улучшен компаратор номеров объектов
- хранение порядка сортировки объектов в БД
- добавлен SQL-скрипт для создания таблицы unit_sort_orders

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685958664a6c832e9e0589d28041ed3b