### PR TITLE
Optimize project structure loading

### DIFF
--- a/sql/create_buildings_function.sql
+++ b/sql/create_buildings_function.sql
@@ -1,0 +1,9 @@
+-- Функция для получения списка корпусов проекта
+CREATE OR REPLACE FUNCTION buildings_by_project(pid integer)
+RETURNS TABLE(building text)
+LANGUAGE sql STABLE AS $$
+  SELECT DISTINCT building
+  FROM units
+  WHERE project_id = pid AND building IS NOT NULL
+  ORDER BY building;
+$$;

--- a/src/pages/ProjectStructurePage/ProjectStructurePage.tsx
+++ b/src/pages/ProjectStructurePage/ProjectStructurePage.tsx
@@ -21,6 +21,7 @@ import StatusLegend from "@/widgets/StatusLegend";
 import useProjectStructure from "@/shared/hooks/useProjectStructure";
 import { useProjectId } from '@/shared/hooks/useProjectId';
 import { useDeleteUnitsByBuilding } from '@/entities/unit';
+import { useUnitsCount } from '@/shared/hooks/useUnitsCount';
 // Новое:
 import HistoryDialog from "@/features/history/HistoryDialog"; // путь скорректируйте под ваш проект
 import { useNavigate } from 'react-router-dom';
@@ -63,8 +64,7 @@ export default function ProjectStructurePage() {
         value: '',
     });
 
-    // Массив всех объектов (units)
-    const [units, setUnits] = useState([]);
+    const { projectCount, buildingCount } = useUnitsCount(projectId, building);
 
     // --- Новое: стейты для истории и дела ---
     const [historyDialogOpen, setHistoryDialogOpen] = useState(false);
@@ -128,10 +128,8 @@ export default function ProjectStructurePage() {
     };
     const handleCancelDelete = () => setConfirmDialog({ open: false, value: '' });
 
-    const countProject = units.length;
-    const countBuilding = units.filter(
-        (u) => String(u.building) === String(building),
-    ).length;
+    const countProject = projectCount;
+    const countBuilding = buildingCount;
 
     // --- Пример вызова истории: вызывайте из нужного места, например из UnitsMatrix
     // function handleShowHistory(unit) {
@@ -371,7 +369,6 @@ export default function ProjectStructurePage() {
                 <UnitsMatrix
                     projectId={projectId}
                     building={building}
-                    onUnitsChanged={setUnits}
                     // здесь добавьте handleShowHistory в карточки, если хотите открыть историю по объекту
                 />
             )}

--- a/src/shared/hooks/useProjectStructure.ts
+++ b/src/shared/hooks/useProjectStructure.ts
@@ -57,10 +57,8 @@ export default function useProjectStructure() {
             return;
         }
         const { data: bld } = await supabase
-            .from('units')
-            .select('building')
-            .eq('project_id', projectId);
-        const bldList = Array.from(new Set((bld || []).map((u: any) => u.building).filter(Boolean)));
+            .rpc('buildings_by_project', { pid: Number(projectId) });
+        const bldList = (bld || []).map((r: any) => r.building).filter(Boolean);
         setBuildings(bldList);
         if (building && !bldList.includes(building)) {
             setBuildingState(bldList[0] ?? '');

--- a/src/shared/hooks/useUnitsCount.ts
+++ b/src/shared/hooks/useUnitsCount.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useState } from 'react';
+import { supabase } from '@/shared/api/supabaseClient';
+
+/**
+ * Получить количество объектов в проекте и в выбранном корпусе.
+ */
+export function useUnitsCount(projectId?: string | number, building?: string) {
+  const [projectCount, setProjectCount] = useState(0);
+  const [buildingCount, setBuildingCount] = useState(0);
+
+  const fetchCounts = useCallback(async () => {
+    if (!projectId) {
+      setProjectCount(0);
+      setBuildingCount(0);
+      return;
+    }
+    const { count: prjCount } = await supabase
+      .from('units')
+      .select('id', { count: 'exact', head: true })
+      .eq('project_id', projectId);
+    setProjectCount(prjCount ?? 0);
+
+    if (building) {
+      const { count: bldCount } = await supabase
+        .from('units')
+        .select('id', { count: 'exact', head: true })
+        .eq('project_id', projectId)
+        .eq('building', building);
+      setBuildingCount(bldCount ?? 0);
+    } else {
+      setBuildingCount(0);
+    }
+  }, [projectId, building]);
+
+  useEffect(() => {
+    fetchCounts();
+  }, [fetchCounts]);
+
+  useEffect(() => {
+    if (!projectId) return;
+    const channel = supabase
+      .channel('units-count-' + projectId)
+      .on('postgres_changes', {
+        event: '*',
+        schema: 'public',
+        table: 'units',
+        filter: `project_id=eq.${projectId}`,
+      }, fetchCounts);
+    channel.subscribe();
+    return () => {
+      channel.unsubscribe();
+    };
+  }, [projectId, fetchCounts]);
+
+  return { projectCount, buildingCount, refresh: fetchCounts };
+}

--- a/src/shared/hooks/useUnitsMatrix.js
+++ b/src/shared/hooks/useUnitsMatrix.js
@@ -14,7 +14,7 @@ import { useCourtCaseStatuses } from '@/entities/courtCaseStatus';
  * @param {string} building  Корпус
  */
 export default function useUnitsMatrix(projectId, building) {
-    const [units, setUnits] = useState([]); // <-- ВСЕ объекты проекта
+    const [units, setUnits] = useState([]); // объекты выбранного корпуса
     const [floors, setFloors] = useState([]);
     const [unitsByFloor, setUnitsByFloor] = useState({});
     const [casesByUnit, setCasesByUnit] = useState({});
@@ -36,17 +36,15 @@ export default function useUnitsMatrix(projectId, building) {
             setFilteredUnits([]);
             return;
         }
-        // Грузим ВСЕ units по проекту
+        // Грузим units только для выбранного корпуса
         let query = supabase
             .from('units')
             .select('*')
             .eq('project_id', projectId);
+        if (building) query = query.eq('building', building);
         const { data: unitsData } = await query;
         setUnits(unitsData || []);
-
-        // Сначала фильтруем по building для визуализации шахматки
-        let filtered = unitsData || [];
-        if (building) filtered = filtered.filter(u => String(u.building) === String(building));
+        const filtered = unitsData || [];
         setFilteredUnits(filtered);
 
         // Грузим замечания, письма и судебные дела только для отображаемых юнитов
@@ -192,7 +190,7 @@ export default function useUnitsMatrix(projectId, building) {
         unitsByFloor,
         handleAddUnit,
         handleAddFloor,
-        // Для счетчиков — ВСЕ объекты проекта
+        // Возвращаем объекты выбранного корпуса
         units,
         setUnits,
         fetchUnits,


### PR DESCRIPTION
## Summary
- add SQL helper for distinct building names
- fetch buildings via RPC in project structure hook
- add hook to count units without heavy queries
- load units only for selected building
- update structure page to use new counts

## Testing
- `npm install`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859a3a96e54832ea2d5b143df9f9a8f