### PR TITLE
Fix index summary and doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ VITE_ATTACH_BUCKET=<название корзины для вложений>
 
 ## Структура базы данных
 
-Описание таблиц и полей находится в файле [`database_structure.json`](database_structure.json).
+Описание БД: [database_structure.json](database_structure.json).
 
 
 ## Индексы базы данных
 
-Полный список индексов находится в файле [`db_indexes_summary.md`](db_indexes_summary.md).
+Индексы: [db_indexes_summary.md](db_indexes_summary.md).
 
 

--- a/db_indexes_summary.md
+++ b/db_indexes_summary.md
@@ -68,7 +68,6 @@
 ## defect_deadlines
 - `defect_deadlines_pkey` - `UNIQUE id`
 - `defect_deadlines_project_id_ticket_type_id_key` - `UNIQUE project_id, defect_type_id`
-
 ## defect_types
 - `ticket_types_pkey` - `UNIQUE id`
 
@@ -120,9 +119,6 @@
 
 ## statuses
 - `statuses_pkey` - `UNIQUE id`
-
-## unit_history
-- `unit_history_pkey` - `UNIQUE id`
 
 ## unit_sort_orders
 - `unit_sort_orders_pkey` - `UNIQUE id`


### PR DESCRIPTION
## Summary
- update README with shorter DB docs links
- remove obsolete `unit_history` section from db index summary

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6859ba6be458832e9caaf38aa9862eee