### PR TITLE
Add dynamic dashboard statistics

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "node tests/claim.test.js"
   },
   "dependencies": {
+    "@ant-design/plots": "2.5.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@hookform/resolvers": "^5.0.1",
@@ -27,6 +28,7 @@
     "busboy": "^1.6.0",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
+    "docx": "^8.3.1",
     "exceljs": "^4.4.0",
     "file-saver": "^2.0.5",
     "jszip": "^3.10.1",
@@ -40,7 +42,6 @@
     "react-table": "^7.8.0",
     "react-window": "^1.8.11",
     "slugify": "^1.6.6",
-    "docx": "^8.3.1",
     "yup": "^1.6.1",
     "zod": "^3.24.3",
     "zustand": "^5.0.3"

--- a/src/pages/DashboardPage/DashboardPage.tsx
+++ b/src/pages/DashboardPage/DashboardPage.tsx
@@ -1,61 +1,48 @@
-import React, { useEffect } from "react";
-import { Link as RouterLink } from "react-router-dom";
-import {
-  Paper,
-  Typography,
-  List,
-  ListItemButton,
-  ListItemText,
-  Stack,
-  Skeleton,
-} from "@mui/material";
-import { useSnackbar } from "notistack";
-import { useVisibleProjects } from "../../entities/project";
-import { useAuthStore } from "../../shared/store/authStore";
+import React, { useEffect } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import { Card, Typography, List, Skeleton, Space } from 'antd';
+import { useSnackbar } from 'notistack';
+import { useVisibleProjects } from '@/entities/project';
+import { useAuthStore } from '@/shared/store/authStore';
+import DashboardInfographics from '@/widgets/DashboardInfographics';
 
-const DashboardPage = () => {
+/** Главная страница с инфографикой. */
+export default function DashboardPage() {
   const { enqueueSnackbar } = useSnackbar();
   const { data: projects = [], isPending, error } = useVisibleProjects();
   const profile = useAuthStore((s) => s.profile);
 
   useEffect(() => {
-    if (error)
-      enqueueSnackbar("Ошибка загрузки проектов.", { variant: "error" });
+    if (error) enqueueSnackbar('Ошибка загрузки проектов.', { variant: 'error' });
   }, [error, enqueueSnackbar]);
 
-  if (isPending) return <Skeleton variant="rectangular" height={160} />;
+  if (isPending) return <Skeleton active />;
 
   return (
-    <Stack spacing={3}>
-      <Paper sx={{ p: 3 }}>
-        <Typography variant="h5" gutterBottom>
-          Добро пожаловать, {profile?.name ?? profile?.email ?? "гость"}!
-        </Typography>
-        <Typography>Всего проектов: {projects.length}</Typography>
-      </Paper>
+    <Space direction="vertical" size="large" style={{ width: '100%' }}>
+      <Card>
+        <Typography.Title level={5} style={{ margin: 0 }}>
+          Добро пожаловать, {profile?.name ?? profile?.email ?? 'гость'}!
+        </Typography.Title>
+        <Typography.Paragraph>Всего проектов: {projects.length}</Typography.Paragraph>
+      </Card>
 
-      <Paper sx={{ p: 3 }}>
-        <Typography variant="h6" gutterBottom>
-          Список проектов
-        </Typography>
+      <DashboardInfographics />
+
+      <Card title="Список проектов">
         {projects.length === 0 ? (
           <Typography>Проектов пока нет.</Typography>
         ) : (
-          <List dense>
-            {projects.map((p) => (
-              <ListItemButton
-                key={p.id}
-                component={RouterLink}
-                to={`/units?project=${p.id}`}
-              >
-                <ListItemText primary={p.name} />
-              </ListItemButton>
-            ))}
-          </List>
+          <List
+            dataSource={projects}
+            renderItem={(p) => (
+              <List.Item>
+                <RouterLink to={`/units?project=${p.id}`}>{p.name}</RouterLink>
+              </List.Item>
+            )}
+          />
         )}
-      </Paper>
-    </Stack>
+      </Card>
+    </Space>
   );
-};
-
-export default DashboardPage;
+}

--- a/src/shared/hooks/useDashboardStats.ts
+++ b/src/shared/hooks/useDashboardStats.ts
@@ -1,0 +1,94 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { supabase } from '@/shared/api/supabaseClient';
+import { useVisibleProjects } from '@/entities/project';
+import { useClaimStatuses } from '@/entities/claimStatus';
+import { useDefectStatuses } from '@/entities/defectStatus';
+import type { DashboardStats, ProjectStats } from '@/shared/types/dashboardStats';
+
+/**
+ * Загружает статистику для дашборда и подписывается на обновления.
+ */
+export function useDashboardStats() {
+  const qc = useQueryClient();
+  const { data: projects = [] } = useVisibleProjects();
+  const { data: claimStatuses = [] } = useClaimStatuses();
+  const { data: defectStatuses = [] } = useDefectStatuses();
+
+  const closedClaimId = claimStatuses.find((s) => /закры/i.test(s.name))?.id ?? null;
+  const closedDefectId = defectStatuses.find((s) => /закры/i.test(s.name))?.id ?? null;
+  const projectIds = projects.map((p) => p.id);
+
+  const statsQuery = useQuery<DashboardStats>({
+    queryKey: ['dashboard-stats', projectIds.join(','), closedClaimId, closedDefectId],
+    enabled: projectIds.length > 0,
+    queryFn: async () => {
+      const projectStats: ProjectStats[] = [];
+      for (const p of projects) {
+        const [{ count: unitCount }, { count: defectTotal }, { count: letterCount }] = await Promise.all([
+          supabase.from('units').select('id', { count: 'exact', head: true }).eq('project_id', p.id),
+          supabase.from('defects').select('id', { count: 'exact', head: true }).eq('project_id', p.id),
+          supabase.from('letters').select('id', { count: 'exact', head: true }).eq('project_id', p.id),
+        ]);
+        projectStats.push({
+          projectId: p.id,
+          projectName: p.name,
+          unitCount: unitCount ?? 0,
+          defectTotal: defectTotal ?? 0,
+          letterCount: letterCount ?? 0,
+        });
+      }
+
+      const [{ count: claimsTotal }, { count: claimsClosed }, { count: defectsTotal }, { count: defectsClosed }, { count: courtCases }] = await Promise.all([
+        supabase.from('claims').select('id', { count: 'exact', head: true }).in('project_id', projectIds),
+        closedClaimId
+          ? supabase
+              .from('claims')
+              .select('id', { count: 'exact', head: true })
+              .in('project_id', projectIds)
+              .eq('claim_status_id', closedClaimId)
+          : Promise.resolve({ count: 0 }),
+        supabase.from('defects').select('id', { count: 'exact', head: true }).in('project_id', projectIds),
+        closedDefectId
+          ? supabase
+              .from('defects')
+              .select('id', { count: 'exact', head: true })
+              .in('project_id', projectIds)
+              .eq('status_id', closedDefectId)
+          : Promise.resolve({ count: 0 }),
+        supabase.from('court_cases').select('id', { count: 'exact', head: true }).in('project_id', projectIds),
+      ]);
+
+      return {
+        projects: projectStats,
+        claimsOpen: (claimsTotal ?? 0) - (claimsClosed ?? 0),
+        claimsClosed: claimsClosed ?? 0,
+        defectsOpen: (defectsTotal ?? 0) - (defectsClosed ?? 0),
+        defectsClosed: defectsClosed ?? 0,
+        courtCases: courtCases ?? 0,
+      } as DashboardStats;
+    },
+    staleTime: 60_000,
+  });
+
+  useEffect(() => {
+    if (projectIds.length === 0) return;
+    const channel = supabase.channel('dashboard-stats');
+    const tables = ['units', 'claims', 'defects', 'court_cases', 'letters'];
+    tables.forEach((table) => {
+      projectIds.forEach((pid) => {
+        channel.on(
+          'postgres_changes',
+          { event: '*', schema: 'public', table, filter: `project_id=eq.${pid}` },
+          () => qc.invalidateQueries({ queryKey: ['dashboard-stats'] }),
+        );
+      });
+    });
+    channel.subscribe();
+    return () => {
+      channel.unsubscribe();
+    };
+  }, [projectIds.join(','), qc]);
+
+  return statsQuery;
+}

--- a/src/shared/types/dashboardStats.ts
+++ b/src/shared/types/dashboardStats.ts
@@ -1,0 +1,27 @@
+export interface ProjectStats {
+  /** ID проекта */
+  projectId: number;
+  /** Название проекта */
+  projectName: string;
+  /** Количество объектов */
+  unitCount: number;
+  /** Количество дефектов */
+  defectTotal: number;
+  /** Количество писем */
+  letterCount: number;
+}
+
+export interface DashboardStats {
+  /** Статистика по проектам */
+  projects: ProjectStats[];
+  /** Количество открытых претензий */
+  claimsOpen: number;
+  /** Количество закрытых претензий */
+  claimsClosed: number;
+  /** Количество открытых дефектов */
+  defectsOpen: number;
+  /** Количество закрытых дефектов */
+  defectsClosed: number;
+  /** Количество судебных дел */
+  courtCases: number;
+}

--- a/src/widgets/DashboardInfographics.tsx
+++ b/src/widgets/DashboardInfographics.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Card, Row, Col, Statistic, Skeleton } from 'antd';
+import { Column } from '@ant-design/plots';
+import { useDashboardStats } from '@/shared/hooks/useDashboardStats';
+
+/**
+ * Инфографика дашборда с динамическими графиками.
+ */
+export default function DashboardInfographics() {
+  const { data, isPending } = useDashboardStats();
+
+  if (isPending || !data) {
+    return <Skeleton active paragraph={{ rows: 4 }} />;
+  }
+
+  const unitData = data.projects.map((p) => ({ project: p.projectName, count: p.unitCount }));
+  const defectData = data.projects.map((p) => ({ project: p.projectName, count: p.defectTotal }));
+  const letterData = data.projects.map((p) => ({ project: p.projectName, count: p.letterCount }));
+
+  return (
+    <Row gutter={[16, 16]}>
+      <Col span={24}>
+        <Card>
+          <Row gutter={16}>
+            <Col span={6}>
+              <Statistic title="Открытых претензий" value={data.claimsOpen} />
+            </Col>
+            <Col span={6}>
+              <Statistic title="Закрытых претензий" value={data.claimsClosed} />
+            </Col>
+            <Col span={6}>
+              <Statistic title="Открытых дефектов" value={data.defectsOpen} />
+            </Col>
+            <Col span={6}>
+              <Statistic title="Закрытых дефектов" value={data.defectsClosed} />
+            </Col>
+          </Row>
+        </Card>
+      </Col>
+      <Col span={8}>
+        <Card title="Объекты по проектам">
+          <Column data={unitData} xField="project" yField="count" height={200} />
+        </Card>
+      </Col>
+      <Col span={8}>
+        <Card title="Дефекты по проектам">
+          <Column data={defectData} xField="project" yField="count" height={200} />
+        </Card>
+      </Col>
+      <Col span={8}>
+        <Card title="Письма по проектам">
+          <Column data={letterData} xField="project" yField="count" height={200} />
+        </Card>
+      </Col>
+      <Col span={24}>
+        <Card>
+          <Statistic title="Судебных дел" value={data.courtCases} />
+        </Card>
+      </Col>
+    </Row>
+  );
+}


### PR DESCRIPTION
## Summary
- integrate `@ant-design/plots`
- show dashboard infographics with charts
- add hook and types for dashboard stats
- switch DashboardPage to Ant Design components

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859b9be797c832e995d56227eccff0e