### PR TITLE
Fix project structure dropdown persistence

### DIFF
--- a/src/pages/ProjectStructurePage/ProjectStructurePage.tsx
+++ b/src/pages/ProjectStructurePage/ProjectStructurePage.tsx
@@ -18,21 +18,11 @@ import DeleteOutline from "@mui/icons-material/DeleteOutline";
 import AddBuildingDialog from "@/features/addBuilding/AddBuildingDialog";
 import UnitsMatrix from "@/widgets/UnitsMatrix/UnitsMatrix";
 import StatusLegend from "@/widgets/StatusLegend";
-import useProjectStructure from "@/shared/hooks/useProjectStructure";
+import useProjectStructure, { LS_KEY } from "@/shared/hooks/useProjectStructure";
 import { useProjectId } from '@/shared/hooks/useProjectId';
 import { useDeleteUnitsByBuilding } from '@/entities/unit';
 import { useUnitsCount } from '@/shared/hooks/useUnitsCount';
 // Новое:
-
-function getCurrentProfile() {
-    try {
-        return JSON.parse(localStorage.getItem("profile")) || {};
-    } catch {
-        return {};
-    }
-}
-
-const LS_KEY = "structurePageSelection";
 
 function pluralObj(n) {
     n = Number(n);
@@ -66,9 +56,8 @@ export default function ProjectStructurePage() {
 
     const deleteBuildingMutation = useDeleteUnitsByBuilding();
 
-    // Автоматический выбор проекта, корпуса, секции
+    // Автоматический выбор проекта и корпуса при загрузке
     useEffect(() => {
-        const profile = getCurrentProfile();
         const saved = JSON.parse(localStorage.getItem(LS_KEY) || "{}");
         if (!projectId) {
             if (

--- a/src/shared/hooks/useProjectStructure.ts
+++ b/src/shared/hooks/useProjectStructure.ts
@@ -5,7 +5,10 @@ import type { ProjectStructureSelection } from '@/shared/types/projectStructure'
 import { useVisibleProjects } from '@/entities/project';
 import { useAuthStore } from '@/shared/store/authStore';
 
-const LS_KEY = 'structurePageSelection';
+/**
+ * Ключ для хранения выбора проекта и корпуса в `localStorage`.
+ */
+export const LS_KEY = 'structurePageSelection';
 
 /**
  * Хук для выбора проекта, корпуса и секции.
@@ -58,7 +61,10 @@ export default function useProjectStructure() {
         }
         const { data: bld } = await supabase
             .rpc('buildings_by_project', { pid: Number(projectId) });
-        const bldList = (bld || []).map((r: any) => r.building).filter(Boolean);
+        const bldList = (bld || [])
+            .map((r: any) => r.building)
+            .filter(Boolean)
+            .sort((a: string, b: string) => a.localeCompare(b));
         setBuildings(bldList);
         if (building && !bldList.includes(building)) {
             setBuildingState(bldList[0] ?? '');


### PR DESCRIPTION
## Summary
- export LS_KEY from `useProjectStructure`
- sort building list alphabetically when loading
- reuse LS_KEY on ProjectStructurePage and clean up unused code

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859c86c44ec832e96da2a24ef62f4b9