### PR TITLE
Fix court case units and add UID support

### DIFF
--- a/migrations/20231005_add_case_uid.sql
+++ b/migrations/20231005_add_case_uid.sql
@@ -1,0 +1,13 @@
+-- Создание таблицы для уникальных идентификаторов дел
+create table if not exists case_uids (
+  id serial primary key,
+  uid text not null unique
+);
+
+-- Добавление ссылки на uid к судебным делам
+alter table court_cases
+  add column if not exists case_uid_id integer references case_uids(id);
+
+-- Добавление ссылки на uid к претензиям
+alter table claims
+  add column if not exists case_uid_id integer references case_uids(id);

--- a/src/entities/caseUid.ts
+++ b/src/entities/caseUid.ts
@@ -1,0 +1,35 @@
+import { supabase } from '@/shared/api/supabaseClient';
+import { useQuery } from '@tanstack/react-query';
+import type { CaseUid } from '@/shared/types/caseUid';
+
+const TABLE = 'case_uids';
+
+/** Получить список уникальных идентификаторов дел */
+export const useCaseUids = () =>
+  useQuery({
+    queryKey: [TABLE],
+    queryFn: async () => {
+      const { data, error } = await supabase.from(TABLE).select('id, uid').order('uid');
+      if (error) throw error;
+      return (data ?? []) as CaseUid[];
+    },
+    staleTime: 10 * 60_000,
+  });
+
+/** Возвращает id существующего идентификатора либо создаёт новый */
+export async function getOrCreateCaseUid(uid: string): Promise<number> {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .select('id')
+    .eq('uid', uid)
+    .maybeSingle();
+  if (error && error.code !== 'PGRST116') throw error;
+  if (data?.id) return data.id as number;
+  const { data: inserted, error: insErr } = await supabase
+    .from(TABLE)
+    .insert({ uid })
+    .select('id')
+    .single();
+  if (insErr) throw insErr;
+  return inserted!.id as number;
+}

--- a/src/shared/types/caseUid.ts
+++ b/src/shared/types/caseUid.ts
@@ -1,0 +1,5 @@
+export interface CaseUid {
+  id: number;
+  /** Уникальный идентификатор дела */
+  uid: string;
+}

--- a/src/shared/types/courtCase.ts
+++ b/src/shared/types/courtCase.ts
@@ -20,6 +20,8 @@ export interface CourtCase {
   /** Идентификатор родительского дела */
   parent_id?: number | null;
   project_id: number;
+  /** Ссылка на уникальный идентификатор дела */
+  case_uid_id?: number | null;
   /** Идентификаторы объектов проекта */
   unit_ids: number[];
   date: string;


### PR DESCRIPTION
## Summary
- show linked objects for court cases by loading `court_case_units`
- add field to capture unique case identifier when creating a case
- support storing identifiers in new `case_uids` table
- SQL migration to add the table and references

## Testing
- `npm test`
- `npm run lint` *(fails: parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ae4109cc8832eb0388ee607a7f9bb