### PR TITLE
Implement case UID requirement for official claims

### DIFF
--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -330,11 +330,26 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
         </Col>
         {isOfficialWatch && (
           <Col span={8}>
-            <Form.Item name="case_uid_id" label="Уникальный идентификатор дела">
+            <Form.Item
+              name="case_uid_id"
+              label="Уникальный идентификатор дела"
+              rules={[
+                {
+                  required: true,
+                  message: 'Выберите идентификатор',
+                },
+              ]}
+            >
               <Select
                 showSearch
                 allowClear
                 options={caseUids.map((c) => ({ value: c.id, label: c.uid }))}
+                filterOption={(input, option) =>
+                  (option?.label ?? '')
+                    .toString()
+                    .toLowerCase()
+                    .includes(input.toLowerCase())
+                }
               />
             </Form.Item>
           </Col>

--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -375,11 +375,27 @@ const ClaimFormAntdEdit = React.forwardRef<
         </Col>
         {isOfficialWatch && (
           <Col span={8}>
-            <Form.Item name="case_uid_id" label="Уникальный идентификатор дела" style={highlight('case_uid_id')}>
+            <Form.Item
+              name="case_uid_id"
+              label="Уникальный идентификатор дела"
+              rules={[
+                {
+                  required: true,
+                  message: 'Выберите идентификатор',
+                },
+              ]}
+              style={highlight('case_uid_id')}
+            >
               <Select
                 showSearch
                 allowClear
                 options={caseUids.map((c) => ({ value: c.id, label: c.uid }))}
+                filterOption={(input, option) =>
+                  (option?.label ?? '')
+                    .toString()
+                    .toLowerCase()
+                    .includes(input.toLowerCase())
+                }
               />
             </Form.Item>
           </Col>


### PR DESCRIPTION
## Summary
- require `case_uid_id` when creating or editing an official claim
- improve searching in UID selector

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b05f46350832eb40fb3cfaaeb839a