### PR TITLE
Update case UID logic

### DIFF
--- a/src/entities/caseUid.ts
+++ b/src/entities/caseUid.ts
@@ -1,12 +1,27 @@
 import { supabase } from '@/shared/api/supabaseClient';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
 import type { CaseUid } from '@/shared/types/caseUid';
 
 const TABLE = 'case_uids';
 
 /** Получить список уникальных идентификаторов дел */
-export const useCaseUids = () =>
-  useQuery({
+export const useCaseUids = () => {
+  const qc = useQueryClient();
+  useEffect(() => {
+    const channel = supabase
+      .channel('case_uids')
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: TABLE },
+        () => qc.invalidateQueries({ queryKey: [TABLE] }),
+      );
+    channel.subscribe();
+    return () => {
+      channel.unsubscribe();
+    };
+  }, [qc]);
+  return useQuery({
     queryKey: [TABLE],
     queryFn: async () => {
       const { data, error } = await supabase.from(TABLE).select('id, uid').order('uid');
@@ -15,6 +30,7 @@ export const useCaseUids = () =>
     },
     staleTime: 10 * 60_000,
   });
+};
 
 /** Возвращает id существующего идентификатора либо создаёт новый */
 export async function getOrCreateCaseUid(uid: string): Promise<number> {

--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -87,6 +87,7 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
   const deletePerson = useDeletePerson();
   const { data: caseUids = [] } = useCaseUids();
   const [personModal, setPersonModal] = useState<any | null>(null);
+  const isOfficialWatch = Form.useWatch('is_official', form);
 
   const handleDropFiles = (dropped: File[]) => {
     setFiles((p) => [...p, ...dropped]);
@@ -126,6 +127,12 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
       form.setFieldValue('registered_on', dayjs());
     }
   }, [form]);
+
+  useEffect(() => {
+    if (!isOfficialWatch) {
+      form.setFieldValue('case_uid_id', null);
+    }
+  }, [isOfficialWatch, form]);
 
   /**
    * Если статус не указан, подставляем первым из списка.
@@ -322,15 +329,17 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
             </Tooltip>
           </Form.Item>
         </Col>
-        <Col span={8}>
-          <Form.Item name="case_uid_id" label="Уникальный идентификатор дела">
-            <Select
-              showSearch
-              allowClear
-              options={caseUids.map((c) => ({ value: c.id, label: c.uid }))}
-            />
-          </Form.Item>
-        </Col>
+        {isOfficialWatch && (
+          <Col span={8}>
+            <Form.Item name="case_uid_id" label="Уникальный идентификатор дела">
+              <Select
+                showSearch
+                allowClear
+                options={caseUids.map((c) => ({ value: c.id, label: c.uid }))}
+              />
+            </Form.Item>
+          </Col>
+        )}
       </Row>
       {showDefectsForm && (
         <Form.List name="defects">

--- a/src/features/courtCase/AddCourtCaseFormAntd.tsx
+++ b/src/features/courtCase/AddCourtCaseFormAntd.tsx
@@ -156,6 +156,7 @@ export default function AddCourtCaseFormAntd({
   const handleAddCase = async (values: any) => {
     try {
       const uidId = await getOrCreateCaseUid(values.case_uid);
+      qc.invalidateQueries({ queryKey: ['case_uids'] });
       const newCase = await addCaseMutation.mutateAsync({
         project_id: values.project_id,
         unit_ids: values.unit_ids || [],

--- a/src/shared/hooks/useRealtimeUpdates.ts
+++ b/src/shared/hooks/useRealtimeUpdates.ts
@@ -53,13 +53,18 @@ export function useRealtimeUpdates() {
         );
     });
 
-    channel
-      .on(
-        'postgres_changes',
-        { event: '*', schema: 'public', table: 'defects' },
-        () => qc.invalidateQueries({ queryKey: ['defects'] }),
-      );
-    if (subscribeAllLetters) {
+  channel
+    .on(
+      'postgres_changes',
+      { event: '*', schema: 'public', table: 'defects' },
+      () => qc.invalidateQueries({ queryKey: ['defects'] }),
+    )
+    .on(
+      'postgres_changes',
+      { event: '*', schema: 'public', table: 'case_uids' },
+      () => qc.invalidateQueries({ queryKey: ['case_uids'] }),
+    );
+  if (subscribeAllLetters) {
       channel
         .on(
           'postgres_changes',


### PR DESCRIPTION
## Summary
- conditionally show `case_uid_id` when claim is official
- keep `case_uid_id` cleared if official toggle is off
- refresh case uid list after creating a court case
- subscribe to `case_uids` table updates

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_685b7bb7127c832ea634e28a329fcbd6