### PR TITLE
Remove official claim feature

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -126,13 +126,6 @@
     "column_default": null
   },
   {
-    "table_name": "claim_defects",
-    "column_name": "is_official",
-    "data_type": "boolean",
-    "is_nullable": "YES",
-    "column_default": "false"
-  },
-  {
     "table_name": "claim_links",
     "column_name": "id",
     "data_type": "bigint",
@@ -271,13 +264,6 @@
     "data_type": "timestamp with time zone",
     "is_nullable": "YES",
     "column_default": "now()"
-  },
-  {
-    "table_name": "claims",
-    "column_name": "is_official",
-    "data_type": "boolean",
-    "is_nullable": "YES",
-    "column_default": "false"
   },
   {
     "table_name": "claims",

--- a/src/entities/claim.ts
+++ b/src/entities/claim.ts
@@ -62,7 +62,6 @@ function mapClaim(r: any): ClaimWithNames {
     engineer_id: r.engineer_id,
     person_id: r.person_id ?? null,
     case_uid_id: r.case_uid_id ?? null,
-    is_official: r.is_official ?? false,
     defect_ids: r.defect_ids ?? [],
     description: r.description ?? '',
     projectName: r.projects?.name ?? '—',
@@ -125,7 +124,7 @@ export function useClaims() {
         .select(
           `id, project_id, claim_status_id, claim_no, claimed_on,
           accepted_on, registered_on, resolved_on,
-          engineer_id, person_id, case_uid_id, description, is_official, created_at,
+          engineer_id, person_id, case_uid_id, description, created_at,
           projects (id, name),
           persons(id, full_name),
           case_uids(id, uid),
@@ -176,7 +175,7 @@ export function useClaim(id?: number | string) {
         .select(
           `id, project_id, claim_status_id, claim_no, claimed_on,
           accepted_on, registered_on, resolved_on,
-          engineer_id, person_id, case_uid_id, description, is_official, created_at,
+          engineer_id, person_id, case_uid_id, description, created_at,
           projects (id, name),
           persons(id, full_name),
           case_uids(id, uid),
@@ -222,7 +221,7 @@ export function useClaimAll(id?: number | string) {
         .select(
           `id, project_id, claim_status_id, claim_no, claimed_on,
           accepted_on, registered_on, resolved_on,
-          engineer_id, person_id, case_uid_id, description, is_official, created_at,
+          engineer_id, person_id, case_uid_id, description, created_at,
           projects (id, name),
           persons(id, full_name),
           case_uids(id, uid),
@@ -264,7 +263,7 @@ export function useClaimsAll() {
         .select(
           `id, project_id, claim_status_id, claim_no, claimed_on,
           accepted_on, registered_on, resolved_on,
-          engineer_id, person_id, case_uid_id, description, is_official, created_at,
+          engineer_id, person_id, case_uid_id, description, created_at,
           projects (id, name),
           statuses (id, name, color),
           claim_units(unit_id),
@@ -305,7 +304,7 @@ export function useClaimsSimpleAll() {
     queryFn: async () => {
       const { data, error } = await supabase
         .from(TABLE)
-        .select('id, project_id, is_official');
+        .select('id, project_id');
       if (error) throw error;
       const ids = (data ?? []).map((r: any) => r.id) as number[];
 
@@ -322,7 +321,7 @@ export function useClaimsSimpleAll() {
       const { data: defectRows } = ids.length
         ? await supabase
             .from('claim_defects')
-            .select('claim_id, defect_id, is_official')
+            .select('claim_id, defect_id')
             .in('claim_id', ids)
         : { data: [] };
       const defectMap: Record<number, number[]> = {};
@@ -334,7 +333,6 @@ export function useClaimsSimpleAll() {
         claimDefectMap[d.claim_id].push({
           claim_id: d.claim_id,
           defect_id: d.defect_id,
-          is_official: d.is_official ?? false,
         });
       });
 
@@ -342,7 +340,6 @@ export function useClaimsSimpleAll() {
       return (data ?? []).map((r: any) => ({
         id: r.id,
         project_id: r.project_id,
-        is_official: r.is_official ?? false,
         unit_ids: unitMap[r.id] ?? [],
         defect_ids: defectMap[r.id] ?? [],
         claim_defects: claimDefectMap[r.id] ?? [],
@@ -363,7 +360,7 @@ export function useClaimsSimple() {
     queryFn: async () => {
       let q: any = supabase
         .from(TABLE)
-        .select('id, project_id, is_official');
+        .select('id, project_id');
       q = filterByProjects(q, projectId, projectIds, onlyAssigned);
       const { data, error } = await q;
       if (error) throw error;
@@ -382,7 +379,7 @@ export function useClaimsSimple() {
       const { data: defectRows } = ids.length
         ? await supabase
             .from('claim_defects')
-            .select('claim_id, defect_id, is_official')
+            .select('claim_id, defect_id')
             .in('claim_id', ids)
         : { data: [] };
       const defectMap: Record<number, number[]> = {};
@@ -394,13 +391,11 @@ export function useClaimsSimple() {
         claimDefectMap[d.claim_id].push({
           claim_id: d.claim_id,
           defect_id: d.defect_id,
-          is_official: d.is_official ?? false,
         });
       });
       return (data ?? []).map((r: any) => ({
         id: r.id,
         project_id: r.project_id,
-        is_official: r.is_official ?? false,
         unit_ids: unitMap[r.id] ?? [],
         defect_ids: defectMap[r.id] ?? [],
         claim_defects: claimDefectMap[r.id] ?? [],
@@ -427,7 +422,6 @@ export function useCreateClaim() {
 
       const insertData: any = {
         ...rest,
-        is_official: rest.is_official ?? false,
         project_id: rest.project_id ?? projectId,
         created_by: userId,
       };
@@ -435,7 +429,7 @@ export function useCreateClaim() {
       const { data: created, error } = await supabase
         .from(TABLE)
         .insert(insertData)
-        .select('id, project_id, is_official')
+        .select('id, project_id')
         .single();
       if (error) throw error;
 
@@ -448,7 +442,6 @@ export function useCreateClaim() {
         const rows = defect_ids.map((did: number) => ({
           claim_id: created.id,
           defect_id: did,
-          is_official: insertData.is_official ?? false,
         }));
         await supabase.from('claim_defects').insert(rows);
       }
@@ -472,7 +465,6 @@ export function useCreateClaim() {
       return {
         id: created.id,
         project_id: created.project_id,
-        is_official: created.is_official,
       } as Claim;
     },
     onSuccess: () => {

--- a/src/entities/unit/UnitCell.tsx
+++ b/src/entities/unit/UnitCell.tsx
@@ -45,7 +45,6 @@ export default function UnitCell({
 }: Props) {
   const bgColor = "#fff";
   const hasCases = Array.isArray(cases) && cases.length > 0;
-  const hasOfficial = claimInfo?.official ?? false;
   const claimColor = claimInfo?.color ?? null;
 
   return (
@@ -59,7 +58,7 @@ export default function UnitCell({
         alignItems: "stretch",
         justifyContent: "flex-start",
         border: `${hasCases ? 2 : 1.5}px solid ${
-          hasCases || hasOfficial ? "#e53935" : "#dde2ee"
+          hasCases ? "#e53935" : "#dde2ee"
         }`,
         background: bgColor,
         borderRadius: "12px",
@@ -73,7 +72,7 @@ export default function UnitCell({
           boxShadow: hasCases
             ? "0 0 0 2px rgba(211,47,47,0.4)"
             : "0 4px 16px 0 #b5d2fa",
-          borderColor: hasCases || hasOfficial ? "#d32f2f" : "#1976d2",
+          borderColor: hasCases ? "#d32f2f" : "#1976d2",
           background: "#f6faff",
         },
         position: "relative",

--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -53,7 +53,6 @@ export interface ClaimFormValues {
   engineer_id: string | null;
   person_id: number | null;
   case_uid_id: number | null;
-  is_official: boolean;
   description: string | null;
   defects?: Array<{
     type_id: number | null;
@@ -112,11 +111,6 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
     if (initialValues.description) form.setFieldValue('description', initialValues.description);
     if (initialValues.person_id != null) form.setFieldValue('person_id', initialValues.person_id);
     if (initialValues.case_uid_id != null) form.setFieldValue('case_uid_id', initialValues.case_uid_id);
-    if (initialValues.is_official != null) {
-      form.setFieldValue('is_official', initialValues.is_official);
-    } else {
-      form.setFieldValue('is_official', false);
-    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [globalProjectId, form]);
 
@@ -312,23 +306,8 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
       </Row>
       <Row gutter={16}>
         <Col span={8}>
-          <Form.Item
-            name="is_official"
-            label="Официальная претензия"
-            valuePropName="checked"
-          >
-            <Tooltip title="Доступно юристам и администраторам">
-              <Switch disabled={role !== 'ADMIN' && role !== 'LAWYER'} />
-            </Tooltip>
-          </Form.Item>
-        </Col>
-        <Col span={8}>
           <Form.Item name="case_uid_id" label="Уникальный идентификатор дела">
-            <Select
-              showSearch
-              allowClear
-              options={caseUids.map((c) => ({ value: c.id, label: c.uid }))}
-            />
+            <Select showSearch allowClear options={caseUids.map((c) => ({ value: c.id, label: c.uid }))} />
           </Form.Item>
         </Col>
       </Row>

--- a/src/features/claim/ClaimViewModal.tsx
+++ b/src/features/claim/ClaimViewModal.tsx
@@ -181,7 +181,7 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
     }
   };
 
-  const handleSaved = async (isOfficial: boolean) => {
+  const handleSaved = async () => {
     if (!claim) return;
     try {
       const createdIds = newDefs.length
@@ -194,7 +194,6 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
           createdIds.map((id) => ({
             claim_id: claim.id,
             defect_id: id,
-            is_official: isOfficial,
           })),
         );
         await closeDefectsForClaim(claim.id, claim.claim_status_id ?? null);

--- a/src/index.css
+++ b/src/index.css
@@ -100,14 +100,8 @@ body {
 .defect-confirmed-row {
   background: #f6ffed !important;
 }
-.defect-official-row {
-  background: #fff1f0 !important;
-}
 .claim-checking-row {
   background: #f6ffed !important;
-}
-.claim-official-row {
-  background: #fff1f0 !important;
 }
 .claim-closed-row {
   color: #aaa;

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -70,7 +70,7 @@ export default function DefectsPage() {
     // замена: no tickets
     const claimsMap = new Map<
       number,
-      { id: number; unit_ids: number[]; project_id: number; is_official: boolean }[]
+      { id: number; unit_ids: number[]; project_id: number }[]
     >();
     claims.forEach((c: any) => {
       (c.claim_defects || []).forEach((cd: any) => {
@@ -79,7 +79,6 @@ export default function DefectsPage() {
           id: c.id,
           unit_ids: c.unit_ids || [],
           project_id: c.project_id,
-          is_official: cd.is_official ?? false,
         });
         claimsMap.set(cd.defect_id, arr);
       });
@@ -106,7 +105,6 @@ export default function DefectsPage() {
           contractors.find((c) => c.id === d.contractor_id)?.name ||
           "Подрядчик";
       }
-      const isOfficial = linked.some((l) => l.is_official);
       return {
         ...d,
         claimIds: claimLinked.map((l) => l.id),
@@ -122,7 +120,6 @@ export default function DefectsPage() {
         defectTypeName: d.defect_type?.name ?? "",
         defectStatusName: d.defect_status?.name ?? "",
         defectStatusColor: d.defect_status?.color ?? null,
-        isOfficial,
       } as DefectWithInfo;
     });
   }, [defects, claims, units, projects]);

--- a/src/shared/hooks/useUnitsMatrix.ts
+++ b/src/shared/hooks/useUnitsMatrix.ts
@@ -98,7 +98,7 @@ export default function useUnitsMatrix(projectId: number | null, building?: stri
 
         const { data: claimRows } = await supabase
           .from('claim_units')
-          .select('unit_id, claims!inner(id, project_id, is_official, claim_status_id, statuses(color))')
+          .select('unit_id, claims!inner(id, project_id, claim_status_id, statuses(color))')
           .in('unit_id', unitIds)
           .eq('claims.project_id', projectId);
         (claimRows || []).forEach((row) => {
@@ -107,7 +107,6 @@ export default function useUnitsMatrix(projectId: number | null, building?: stri
           if (!claimsByUnit[row.unit_id]) {
             claimsByUnit[row.unit_id] = {
               color: cl.statuses?.color ?? null,
-              official: cl.is_official ?? false,
             };
           }
         });

--- a/src/shared/types/claim.ts
+++ b/src/shared/types/claim.ts
@@ -25,11 +25,6 @@ export interface Claim {
   person_id: number | null;
   /** Уникальный идентификатор судебного дела */
   case_uid_id: number | null;
-  /**
-   * Официальная претензия.
-   * Переключатель доступен только ролям ADMIN и LAWYER.
-   */
-  is_official?: boolean;
   /** Связанные дефекты */
   defect_ids?: number[];
   /** Дополнительное описание */

--- a/src/shared/types/claimDefect.ts
+++ b/src/shared/types/claimDefect.ts
@@ -3,6 +3,4 @@ export interface ClaimDefect {
   claim_id: number;
   /** Идентификатор дефекта */
   defect_id: number;
-  /** Дефект по официальной претензии */
-  is_official?: boolean;
 }

--- a/src/shared/types/claimSimple.ts
+++ b/src/shared/types/claimSimple.ts
@@ -3,8 +3,6 @@ export interface ClaimSimple {
   id: number;
   /** Проект, к которому относится претензия */
   project_id: number;
-  /** Претензия официальная */
-  is_official?: boolean;
   /** Связанные объекты */
   unit_ids: number[];
   /** Идентификаторы связанных дефектов */

--- a/src/shared/types/claimWithNames.ts
+++ b/src/shared/types/claimWithNames.ts
@@ -30,6 +30,4 @@ export interface ClaimWithNames extends Claim {
   attachments?: import('./claimFile').RemoteClaimFile[];
   /** Есть связанные дефекты со статусом "На проверке" */
   hasCheckingDefect?: boolean;
-  /** Признак официальной претензии */
-  is_official?: boolean;
 }

--- a/src/shared/types/defect.ts
+++ b/src/shared/types/defect.ts
@@ -62,6 +62,4 @@ export interface DefectWithInfo extends DefectRecord {
   projectNames?: string;
   /** Прошло дней с даты получения */
   days?: number | null;
-  /** Дефект из официальной претензии */
-  isOfficial?: boolean;
 }

--- a/src/shared/types/unitClaimInfo.ts
+++ b/src/shared/types/unitClaimInfo.ts
@@ -1,7 +1,5 @@
 export interface UnitClaimInfo {
   /** Цвет статуса претензии */
   color: string | null;
-  /** Есть ли официальная претензия */
-  official: boolean;
 }
 

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -158,7 +158,6 @@ export default function ClaimsTable({
   }, [filtered]);
 
   const rowClassName = (row: ClaimWithNames) => {
-    if (row.is_official) return 'claim-official-row';
     const checking = row.statusName?.toLowerCase().includes('провер');
     const closed = row.statusName?.toLowerCase().includes('закры');
     if (checking || row.hasCheckingDefect) return 'claim-checking-row';

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -173,7 +173,6 @@ export default function DefectsTable({
 
   const rowClassName = (row: DefectWithInfo) => {
     const classes = ["main-defect-row"];
-    if (row.isOfficial) classes.push("defect-official-row");
     const checking = row.defectStatusName?.toLowerCase().includes("провер");
     const closed = row.defectStatusName?.toLowerCase().includes("закры");
     if (checking) classes.push("defect-confirmed-row");

--- a/src/widgets/StatusLegend.tsx
+++ b/src/widgets/StatusLegend.tsx
@@ -34,9 +34,6 @@ export default function StatusLegend() {
         <MailIcon fontSize="small" sx={{ mr: 0.5, color: '#f0b400' }} /> — есть связанные письма
       </Typography>
       <Typography variant="body2" color="text.secondary">
-        Тонкая красная обводка — официальная претензия
-      </Typography>
-      <Typography variant="body2" color="text.secondary">
         Жирная красная обводка — судебное дело
       </Typography>
     </Box>


### PR DESCRIPTION
## Summary
- drop all UI toggles and code related to `is_official`
- clean up tables/queries and types
- update CSS and status legend
- keep database structure in sync

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c4c211860832e827b3b6e699432f7