### PR TITLE
Add pre-trial claim option

### DIFF
--- a/sql/pretrial_columns.sql
+++ b/sql/pretrial_columns.sql
@@ -1,0 +1,3 @@
+-- Добавление признака досудебной претензии
+ALTER TABLE claims ADD COLUMN pre_trial_claim boolean NOT NULL DEFAULT false;
+ALTER TABLE claim_defects ADD COLUMN pre_trial_claim boolean NOT NULL DEFAULT false;

--- a/src/entities/claim.ts
+++ b/src/entities/claim.ts
@@ -62,6 +62,7 @@ function mapClaim(r: any): ClaimWithNames {
     engineer_id: r.engineer_id,
     person_id: r.person_id ?? null,
     case_uid_id: r.case_uid_id ?? null,
+    pre_trial_claim: r.pre_trial_claim ?? false,
     defect_ids: r.defect_ids ?? [],
     description: r.description ?? '',
     projectName: r.projects?.name ?? '—',
@@ -124,7 +125,7 @@ export function useClaims() {
         .select(
           `id, project_id, claim_status_id, claim_no, claimed_on,
           accepted_on, registered_on, resolved_on,
-          engineer_id, person_id, case_uid_id, description, created_at,
+          engineer_id, person_id, case_uid_id, pre_trial_claim, description, created_at,
           projects (id, name),
           persons(id, full_name),
           case_uids(id, uid),
@@ -175,7 +176,7 @@ export function useClaim(id?: number | string) {
         .select(
           `id, project_id, claim_status_id, claim_no, claimed_on,
           accepted_on, registered_on, resolved_on,
-          engineer_id, person_id, case_uid_id, description, created_at,
+          engineer_id, person_id, case_uid_id, pre_trial_claim, description, created_at,
           projects (id, name),
           persons(id, full_name),
           case_uids(id, uid),
@@ -221,7 +222,7 @@ export function useClaimAll(id?: number | string) {
         .select(
           `id, project_id, claim_status_id, claim_no, claimed_on,
           accepted_on, registered_on, resolved_on,
-          engineer_id, person_id, case_uid_id, description, created_at,
+          engineer_id, person_id, case_uid_id, pre_trial_claim, description, created_at,
           projects (id, name),
           persons(id, full_name),
           case_uids(id, uid),
@@ -263,7 +264,7 @@ export function useClaimsAll() {
         .select(
           `id, project_id, claim_status_id, claim_no, claimed_on,
           accepted_on, registered_on, resolved_on,
-          engineer_id, person_id, case_uid_id, description, created_at,
+          engineer_id, person_id, case_uid_id, pre_trial_claim, description, created_at,
           projects (id, name),
           statuses (id, name, color),
           claim_units(unit_id),
@@ -321,7 +322,7 @@ export function useClaimsSimpleAll() {
       const { data: defectRows } = ids.length
         ? await supabase
             .from('claim_defects')
-            .select('claim_id, defect_id')
+            .select('claim_id, defect_id, pre_trial_claim')
             .in('claim_id', ids)
         : { data: [] };
       const defectMap: Record<number, number[]> = {};
@@ -333,6 +334,7 @@ export function useClaimsSimpleAll() {
         claimDefectMap[d.claim_id].push({
           claim_id: d.claim_id,
           defect_id: d.defect_id,
+          pre_trial_claim: d.pre_trial_claim ?? false,
         });
       });
 
@@ -379,7 +381,7 @@ export function useClaimsSimple() {
       const { data: defectRows } = ids.length
         ? await supabase
             .from('claim_defects')
-            .select('claim_id, defect_id')
+            .select('claim_id, defect_id, pre_trial_claim')
             .in('claim_id', ids)
         : { data: [] };
       const defectMap: Record<number, number[]> = {};
@@ -391,6 +393,7 @@ export function useClaimsSimple() {
         claimDefectMap[d.claim_id].push({
           claim_id: d.claim_id,
           defect_id: d.defect_id,
+          pre_trial_claim: d.pre_trial_claim ?? false,
         });
       });
       return (data ?? []).map((r: any) => ({
@@ -442,6 +445,7 @@ export function useCreateClaim() {
         const rows = defect_ids.map((did: number) => ({
           claim_id: created.id,
           defect_id: did,
+          pre_trial_claim: insertData.pre_trial_claim ?? false,
         }));
         await supabase.from('claim_defects').insert(rows);
       }

--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -53,6 +53,8 @@ export interface ClaimFormValues {
   engineer_id: string | null;
   person_id: number | null;
   case_uid_id: number | null;
+  /** Является ли претензия досудебной */
+  pre_trial_claim: boolean;
   description: string | null;
   defects?: Array<{
     type_id: number | null;
@@ -86,6 +88,7 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
   const deletePerson = useDeletePerson();
   const { data: caseUids = [] } = useCaseUids();
   const [personModal, setPersonModal] = useState<any | null>(null);
+  const preTrialWatch = Form.useWatch('pre_trial_claim', form);
 
   const handleDropFiles = (dropped: File[]) => {
     setFiles((p) => [...p, ...dropped]);
@@ -111,6 +114,11 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
     if (initialValues.description) form.setFieldValue('description', initialValues.description);
     if (initialValues.person_id != null) form.setFieldValue('person_id', initialValues.person_id);
     if (initialValues.case_uid_id != null) form.setFieldValue('case_uid_id', initialValues.case_uid_id);
+    if (initialValues.pre_trial_claim != null) {
+      form.setFieldValue('pre_trial_claim', initialValues.pre_trial_claim);
+    } else {
+      form.setFieldValue('pre_trial_claim', false);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [globalProjectId, form]);
 
@@ -202,6 +210,17 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
   return (
     <>
     <Form form={form} layout="vertical" onFinish={onFinish} autoComplete="off">
+      <Row gutter={16}>
+        <Col span={8}>
+          <Form.Item
+            name="pre_trial_claim"
+            label="Досудебная претензия"
+            valuePropName="checked"
+          >
+            <Switch />
+          </Form.Item>
+        </Col>
+      </Row>
       <Row gutter={16}>
         <Col span={8}>
           <Form.Item name="project_id" label="Проект" rules={[{ required: true }]}> 
@@ -306,8 +325,17 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
       </Row>
       <Row gutter={16}>
         <Col span={8}>
-          <Form.Item name="case_uid_id" label="Уникальный идентификатор дела">
-            <Select showSearch allowClear options={caseUids.map((c) => ({ value: c.id, label: c.uid }))} />
+          <Form.Item
+            name="case_uid_id"
+            label="Уникальный идентификатор дела"
+            hidden={!preTrialWatch}
+          >
+            <Select
+              showSearch
+              allowClear
+              disabled={!preTrialWatch}
+              options={caseUids.map((c) => ({ value: c.id, label: c.uid }))}
+            />
           </Form.Item>
         </Col>
       </Row>

--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { ConfigProvider, Alert, Card, Button, Tooltip, Popconfirm, message, Space } from 'antd';
+import { ConfigProvider, Alert, Card, Button, Tooltip, Popconfirm, message, Space, Switch } from 'antd';
 import ruRU from 'antd/locale/ru_RU';
 import {
   SettingOutlined,
@@ -77,6 +77,7 @@ export default function ClaimsPage() {
   const [showAddForm, setShowAddForm] = useState(
     searchParams.get('open_form') === '1',
   );
+  const [preTrial, setPreTrial] = useState(false);
   const LS_SHOW_FILTERS = 'claims:showFilters';
   const [showFilters, setShowFilters] = useState<boolean>(() => {
     try {
@@ -247,6 +248,10 @@ export default function ClaimsPage() {
           {showFilters ? 'Скрыть фильтры' : 'Показать фильтры'}
         </Button>
         <Button icon={<SettingOutlined />} style={{ marginLeft: 8 }} onClick={() => setShowColumnsDrawer(true)} />
+        <span style={{ marginLeft: 8 }}>
+          Досудебная:&nbsp;
+          <Switch checked={preTrial} onChange={setPreTrial} />
+        </span>
         <span style={{ marginLeft: 8, display: 'inline-block' }}>
           <ExportClaimsButton claims={claimsWithNames} filters={filters} />
         </span>
@@ -254,7 +259,7 @@ export default function ClaimsPage() {
           <div style={{ marginTop: 16 }}>
             <ClaimFormAntd
               onCreated={() => setShowAddForm(false)}
-              initialValues={initialValues}
+              initialValues={{ ...initialValues, pre_trial_claim: preTrial }}
             />
           </div>
         )}

--- a/src/shared/types/claim.ts
+++ b/src/shared/types/claim.ts
@@ -25,6 +25,8 @@ export interface Claim {
   person_id: number | null;
   /** Уникальный идентификатор судебного дела */
   case_uid_id: number | null;
+  /** Признак досудебной претензии */
+  pre_trial_claim: boolean;
   /** Связанные дефекты */
   defect_ids?: number[];
   /** Дополнительное описание */

--- a/src/shared/types/claimDefect.ts
+++ b/src/shared/types/claimDefect.ts
@@ -3,4 +3,6 @@ export interface ClaimDefect {
   claim_id: number;
   /** Идентификатор дефекта */
   defect_id: number;
+  /** Досудебная претензия */
+  pre_trial_claim: boolean;
 }


### PR DESCRIPTION
## Summary
- add `pre_trial_claim` flag to claim creation form
- allow editing unique case ID only for pre-trial claims
- update claims page UI with pre-trial switch
- persist the flag in `claims` and `claim_defects`
- document DB migration script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c509273a0832e83669969d752eca0