### PR TITLE
Implement improvements on claims page

### DIFF
--- a/src/entities/unit.ts
+++ b/src/entities/unit.ts
@@ -10,6 +10,7 @@ import { useProjectFilter } from '@/shared/hooks/useProjectFilter';
 import { useAuthStore } from '@/shared/store/authStore';
 import { filterByProjects } from '@/shared/utils/projectQuery';
 import { useNotify } from '@/shared/hooks/useNotify';
+import { getUnitNameComparator } from '@/shared/utils/unitNumberSort';
 
 /* ---------- базовый SELECT ---------- */
 const SELECT = `
@@ -68,10 +69,15 @@ export const useUnitsByProject = (projectId, building) =>
 
             if (error) throw error;
 
-            return (data ?? []).map((u) => ({
+            const units = (data ?? []).map((u) => ({
                 ...u,
                 persons: [], // unit_persons removed
             }));
+
+            // Natural sort by unit name (e.g. 1, 1A, 2B)
+            units.sort(getUnitNameComparator('asc'));
+
+            return units;
         },
         staleTime: 5 * 60_000,
     });

--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -226,6 +226,20 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
             <Switch />
           </Form.Item>
         </Col>
+        <Col span={8}>
+          <Form.Item
+            name="case_uid_id"
+            label="Уникальный идентификатор дела"
+            hidden={!preTrialWatch}
+          >
+            <Select
+              showSearch
+              allowClear
+              disabled={!preTrialWatch}
+              options={caseUids.map((c) => ({ value: c.id, label: c.uid }))}
+            />
+          </Form.Item>
+        </Col>
       </Row>
       <Row gutter={16}>
         <Col span={8}>
@@ -331,22 +345,6 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
         <Col span={24}>
           <Form.Item name="description" label="Дополнительная информация">
             <Input.TextArea rows={2} />
-          </Form.Item>
-        </Col>
-      </Row>
-      <Row gutter={16}>
-        <Col span={8}>
-          <Form.Item
-            name="case_uid_id"
-            label="Уникальный идентификатор дела"
-            hidden={!preTrialWatch}
-          >
-            <Select
-              showSearch
-              allowClear
-              disabled={!preTrialWatch}
-              options={caseUids.map((c) => ({ value: c.id, label: c.uid }))}
-            />
           </Form.Item>
         </Col>
       </Row>

--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { ConfigProvider, Alert, Card, Button, Tooltip, Popconfirm, message, Space, Switch } from 'antd';
+import { ConfigProvider, Alert, Card, Button, Tooltip, Popconfirm, message, Space } from 'antd';
 import ruRU from 'antd/locale/ru_RU';
 import {
   SettingOutlined,
@@ -77,7 +77,6 @@ export default function ClaimsPage() {
   const [showAddForm, setShowAddForm] = useState(
     searchParams.get('open_form') === '1',
   );
-  const [preTrial, setPreTrial] = useState(false);
   const LS_SHOW_FILTERS = 'claims:showFilters';
   const [showFilters, setShowFilters] = useState<boolean>(() => {
     try {
@@ -259,10 +258,6 @@ export default function ClaimsPage() {
           {showFilters ? 'Скрыть фильтры' : 'Показать фильтры'}
         </Button>
         <Button icon={<SettingOutlined />} style={{ marginLeft: 8 }} onClick={() => setShowColumnsDrawer(true)} />
-        <span style={{ marginLeft: 8 }}>
-          Досудебная:&nbsp;
-          <Switch checked={preTrial} onChange={setPreTrial} />
-        </span>
         <span style={{ marginLeft: 8, display: 'inline-block' }}>
           <ExportClaimsButton claims={claimsWithNames} filters={filters} />
         </span>
@@ -270,7 +265,7 @@ export default function ClaimsPage() {
           <div style={{ marginTop: 16 }}>
             <ClaimFormAntd
               onCreated={() => setShowAddForm(false)}
-              initialValues={{ ...initialValues, pre_trial_claim: preTrial }}
+              initialValues={initialValues}
             />
           </div>
         )}


### PR DESCRIPTION
## Summary
- refine claims UI: remove global pre-trial switch and keep case UID near the form switch
- natural sort units by name when selecting project

## Testing
- `npm test`
- `npm run lint` *(fails: eslint config issues)*

------
https://chatgpt.com/codex/tasks/task_e_685c5723205c832eba2be724bc6be695