### PR TITLE
Add pre-trial claim controls

### DIFF
--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -68,6 +68,7 @@ export interface ClaimFormAntdEditValues {
   engineer_id: string | null;
   person_id: number | null;
   case_uid_id: number | null;
+  pre_trial_claim: boolean;
   description: string | null;
 }
 
@@ -111,6 +112,7 @@ const ClaimFormAntdEdit = React.forwardRef<
   const attachments =
     attachmentsState ?? useClaimAttachments({ claim: claim as any });
   const { changedFields, handleValuesChange } = useChangedFields(form, [claim]);
+  const preTrialWatch = Form.useWatch('pre_trial_claim', form);
 
   useImperativeHandle(ref, () => ({
     submit: () => form.submit(),
@@ -135,6 +137,7 @@ const ClaimFormAntdEdit = React.forwardRef<
       engineer_id: claim.engineer_id ?? null,
       person_id: claim.person_id ?? null,
       case_uid_id: claim.case_uid_id ?? null,
+      pre_trial_claim: claim.pre_trial_claim ?? false,
       description: claim.description ?? '',
     });
   }, [claim, form]);
@@ -161,6 +164,7 @@ const ClaimFormAntdEdit = React.forwardRef<
           engineer_id: values.engineer_id ?? null,
           person_id: values.person_id ?? null,
           case_uid_id: values.case_uid_id ?? null,
+          pre_trial_claim: values.pre_trial_claim ?? false,
           description: values.description ?? '',
           updated_by: userId ?? undefined,
         } as any,
@@ -208,6 +212,33 @@ const ClaimFormAntdEdit = React.forwardRef<
       style={{ maxWidth: embedded ? 'none' : 640 }}
       autoComplete="off"
     >
+      <Row gutter={16}>
+        <Col span={8}>
+          <Form.Item
+            name="pre_trial_claim"
+            label="Досудебная претензия"
+            valuePropName="checked"
+            style={highlight('pre_trial_claim')}
+          >
+            <Switch />
+          </Form.Item>
+        </Col>
+        <Col span={8}>
+          <Form.Item
+            name="case_uid_id"
+            label="Уникальный идентификатор дела"
+            hidden={!preTrialWatch}
+            style={highlight('case_uid_id')}
+          >
+            <Select
+              showSearch
+              allowClear
+              disabled={!preTrialWatch}
+              options={caseUids.map((c) => ({ value: c.id, label: c.uid }))}
+            />
+          </Form.Item>
+        </Col>
+      </Row>
       <Row gutter={16}>
         <Col span={8}>
           <Form.Item
@@ -329,13 +360,6 @@ const ClaimFormAntdEdit = React.forwardRef<
         <Col span={24}>
           <Form.Item name="description" label="Дополнительная информация" style={highlight('description')}>
             <Input.TextArea rows={2} />
-          </Form.Item>
-        </Col>
-      </Row>
-      <Row gutter={16}>
-        <Col span={8}>
-          <Form.Item name="case_uid_id" label="Уникальный идентификатор дела" style={highlight('case_uid_id')}>
-            <Select showSearch allowClear options={caseUids.map((c) => ({ value: c.id, label: c.uid }))} />
           </Form.Item>
         </Col>
       </Row>

--- a/src/index.css
+++ b/src/index.css
@@ -107,6 +107,9 @@ body {
   color: #aaa;
   background: inherit !important;
 }
+.claim-pretrial-row {
+  background: #fff1f0 !important;
+}
 .defect-closed-row {
   color: #aaa;
   background: inherit !important;

--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -24,7 +24,7 @@ import { useUnitsByIds } from '@/entities/unit';
 import { useRolePermission } from '@/entities/rolePermission';
 import { useAuthStore } from '@/shared/store/authStore';
 import type { RoleName } from '@/shared/types/rolePermission';
-import formatUnitName from '@/shared/utils/formatUnitName';
+import formatUnitShortName from '@/shared/utils/formatUnitShortName';
 import ClaimsTable from '@/widgets/ClaimsTable';
 import ClaimsFilters from '@/widgets/ClaimsFilters';
 import ClaimFormAntd from '@/features/claim/ClaimFormAntd';
@@ -130,7 +130,7 @@ export default function ClaimsPage() {
   const unitMap = useMemo(() => {
     const map = {} as Record<number, string>;
     (units ?? []).forEach((u) => {
-      map[u.id] = formatUnitName(u);
+      map[u.id] = formatUnitShortName(u);
     });
     return map;
   }, [units]);

--- a/src/shared/utils/formatUnitShortName.ts
+++ b/src/shared/utils/formatUnitShortName.ts
@@ -1,0 +1,20 @@
+/**
+ * Формирует краткое название объекта без корпуса.
+ * Возвращает строку вида "Этаж N, Объект <номер>".
+ * Пустые части пропускаются.
+ *
+ * @param unit данные объекта
+ */
+export default function formatUnitShortName(
+  unit: {
+    name: string;
+    floor?: number | null;
+  },
+): string {
+  const parts: string[] = [];
+  if (unit.floor !== undefined && unit.floor !== null) {
+    parts.push(`Этаж ${unit.floor}`);
+  }
+  parts.push(`Объект ${unit.name}`);
+  return parts.join(', ');
+}

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -165,7 +165,9 @@ export default function ClaimsTable({
   const rowClassName = (row: ClaimWithNames) => {
     const checking = row.statusName?.toLowerCase().includes('провер');
     const closed = row.statusName?.toLowerCase().includes('закры');
+    const preTrial = row.statusName?.toLowerCase().includes('досудеб');
     if (checking || row.hasCheckingDefect) return 'claim-checking-row';
+    if (preTrial) return 'claim-pretrial-row';
     if (closed) return 'claim-closed-row';
     return '';
   };


### PR DESCRIPTION
## Summary
- shorten displayed unit names in claims table
- highlight pre-trial claims in red
- support editing pre-trial flag and case UID in claim view form
- add helper `formatUnitShortName`
- style rows with `.claim-pretrial-row`

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error)*
- `npx tsc --noEmit` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685c58b8ba4c832e97053211a70a54fb