### PR TITLE
Добавлено переименование корпуса

### DIFF
--- a/src/features/renameBuilding/RenameBuildingDialog.tsx
+++ b/src/features/renameBuilding/RenameBuildingDialog.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useState } from 'react';
+import {
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    TextField,
+    Button,
+} from '@mui/material';
+import { useRenameBuilding } from '@/entities/unit';
+import type { BuildingRename } from '@/shared/types/buildingRename';
+
+interface RenameBuildingDialogProps {
+    open: boolean;
+    onClose: () => void;
+    projectId: string | number;
+    currentName: string;
+    onSuccess?: (name: string) => void;
+}
+
+/**
+ * Диалог переименования корпуса.
+ */
+export default function RenameBuildingDialog({
+    open,
+    onClose,
+    projectId,
+    currentName,
+    onSuccess,
+}: RenameBuildingDialogProps) {
+    const [value, setValue] = useState(currentName);
+    const rename = useRenameBuilding();
+
+    useEffect(() => setValue(currentName), [currentName]);
+
+    const handleConfirm = async () => {
+        const name = value.trim();
+        if (!name || name === currentName) {
+            onClose();
+            return;
+        }
+        const payload: BuildingRename = {
+            project_id: projectId,
+            old_name: currentName,
+            new_name: name,
+        };
+        await rename.mutateAsync(payload);
+        onSuccess?.(name);
+        onClose();
+    };
+
+    return (
+        <Dialog open={open} onClose={onClose}>
+            <DialogTitle>Переименовать корпус</DialogTitle>
+            <DialogContent>
+                <TextField
+                    autoFocus
+                    fullWidth
+                    label="Новое название корпуса"
+                    value={value}
+                    onChange={(e) => setValue(e.target.value)}
+                    sx={{ mt: 1 }}
+                />
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose}>Отмена</Button>
+                <Button
+                    onClick={handleConfirm}
+                    variant="contained"
+                    disabled={!value.trim() || rename.isPending}
+                >
+                    Сохранить
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+}

--- a/src/pages/ProjectStructurePage/ProjectStructurePage.tsx
+++ b/src/pages/ProjectStructurePage/ProjectStructurePage.tsx
@@ -15,7 +15,9 @@ import {
 } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import DeleteOutline from "@mui/icons-material/DeleteOutline";
+import EditIcon from "@mui/icons-material/Edit";
 import AddBuildingDialog from "@/features/addBuilding/AddBuildingDialog";
+import RenameBuildingDialog from "@/features/renameBuilding/RenameBuildingDialog";
 import UnitsMatrix from "@/widgets/UnitsMatrix/UnitsMatrix";
 import StatusLegend from "@/widgets/StatusLegend";
 import useProjectStructure, { LS_KEY } from "@/shared/hooks/useProjectStructure";
@@ -47,6 +49,7 @@ export default function ProjectStructurePage() {
 
     // Диалоги для корпусов/секций
     const [addDialogOpen, setAddDialogOpen] = useState(false);
+    const [editDialogOpen, setEditDialogOpen] = useState(false);
     const [confirmDialog, setConfirmDialog] = useState({
         open: false,
         value: '',
@@ -97,6 +100,8 @@ export default function ProjectStructurePage() {
     // --- Диалоги ---
     const handleOpenAddDialog = () => setAddDialogOpen(true);
     const handleCloseAddDialog = () => setAddDialogOpen(false);
+    const handleOpenEditDialog = () => setEditDialogOpen(true);
+    const handleCloseEditDialog = () => setEditDialogOpen(false);
 
     const handleDeleteBuilding = () => {
         if (!building) return;
@@ -277,6 +282,19 @@ export default function ProjectStructurePage() {
                         {Boolean(building) && (
                             <IconButton
                                 size="small"
+                                onClick={handleOpenEditDialog}
+                                sx={{
+                                    color: "#fff",
+                                    opacity: 0.88,
+                                    p: "6px",
+                                }}
+                            >
+                                <EditIcon fontSize="small" />
+                            </IconButton>
+                        )}
+                        {Boolean(building) && (
+                            <IconButton
+                                size="small"
                                 onClick={handleDeleteBuilding}
                                 sx={{
                                     color: "#fff",
@@ -300,6 +318,19 @@ export default function ProjectStructurePage() {
                 projectId={projectId}
                 afterAdd={(name) => {
                     setBuildings((b) => Array.from(new Set([...b, name])));
+                    refreshAll();
+                }}
+            />
+
+            {/* Диалог переименования корпуса */}
+            <RenameBuildingDialog
+                open={editDialogOpen}
+                onClose={handleCloseEditDialog}
+                projectId={projectId}
+                currentName={building || ''}
+                onSuccess={(name) => {
+                    setBuildings((b) => b.map((v) => (v === building ? name : v)));
+                    setBuilding(name);
                     refreshAll();
                 }}
             />

--- a/src/shared/types/buildingRename.ts
+++ b/src/shared/types/buildingRename.ts
@@ -1,0 +1,5 @@
+export interface BuildingRename {
+  project_id: number | string;
+  old_name: string;
+  new_name: string;
+}


### PR DESCRIPTION
## Summary
- добавлен тип `BuildingRename`
- реализован `useRenameBuilding` для обновления корпусов в базе
- создан диалог `RenameBuildingDialog`
- на странице структуры добавлена иконка редактирования корпуса и логика переименования

## Testing
- `npm run --silent lint` *(fails: @eslint/eslintrc not found)*
- `npm run --silent test`

------
https://chatgpt.com/codex/tasks/task_e_685c597eefbc832ea329949b464fe3d4