### PR TITLE
Add building filter and column to defects page

### DIFF
--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -64,7 +64,8 @@ export default function DefectsPage() {
   const userProjectIds = useAuthStore((s) => s.profile?.project_ids) ?? [];
 
   const data: DefectWithInfo[] = useMemo(() => {
-    const unitMap = new Map(units.map((u) => [u.id, formatUnitName(u)]));
+    const unitMap = new Map(units.map((u) => [u.id, formatUnitName(u, false)]));
+    const buildingMap = new Map(units.map((u) => [u.id, u.building || ""]));
     const projectMap = new Map(projects.map((p) => [p.id, p.name]));
     const ticketsMap = new Map<number, { id: number; unit_ids: number[]; project_id: number }[]>();
     // замена: no tickets
@@ -91,6 +92,10 @@ export default function DefectsPage() {
         .map((id) => unitMap.get(id))
         .filter(Boolean);
       const unitNames = unitNamesList.join(", ");
+      const buildingNamesList = Array.from(
+        new Set(unitIds.map((id) => buildingMap.get(id)).filter(Boolean)),
+      );
+      const buildingNames = buildingNamesList.join(", ");
       const projectIds = Array.from(new Set(linked.map((l) => l.project_id)));
       const projectNames = projectIds
         .map((id) => projectMap.get(id))
@@ -111,6 +116,8 @@ export default function DefectsPage() {
         unitIds,
         unitNames,
         unitNamesList,
+        buildingNamesList,
+        buildingNames,
         projectIds,
         projectNames,
         fixByName,
@@ -147,6 +154,9 @@ export default function DefectsPage() {
         value: id,
       })),
       units: units.map((u) => ({ label: u.name, value: u.id })),
+      buildings: Array.from(new Set(units.map((u) => u.building).filter(Boolean))).map(
+        (b) => ({ label: String(b), value: String(b) }),
+      ),
       projects: projects.map((p) => ({ label: p.name, value: p.id })),
       types: uniq(filteredData.map((d) => [d.type_id, d.defectTypeName])),
       statuses: uniq(filteredData.map((d) => [d.status_id, d.defectStatusName])),
@@ -204,6 +214,12 @@ export default function DefectsPage() {
         dataIndex: "projectNames",
         sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
           (a.projectNames || "").localeCompare(b.projectNames || ""),
+      },
+      building: {
+        title: "Корпус",
+        dataIndex: "buildingNames",
+        sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
+          (a.buildingNames || "").localeCompare(b.buildingNames || ""),
       },
       units: {
         title: "Объекты",
@@ -345,6 +361,7 @@ export default function DefectsPage() {
     "claims",
     "days",
     "project",
+    "building",
     "units",
     "description",
     "type",

--- a/src/shared/types/defect.ts
+++ b/src/shared/types/defect.ts
@@ -46,6 +46,10 @@ export interface DefectWithInfo extends DefectRecord {
   unitNames?: string;
   /** Названия объектов в виде массива */
   unitNamesList?: string[];
+  /** Названия корпусов в виде массива */
+  buildingNamesList?: string[];
+  /** Корпуса, объединённые в строку */
+  buildingNames?: string;
   /** Название типа дефекта */
   defectTypeName?: string;
   /** Название статуса дефекта */

--- a/src/shared/types/defectFilters.ts
+++ b/src/shared/types/defectFilters.ts
@@ -9,6 +9,8 @@ export interface DefectFilters {
   typeId?: number[];
   statusId?: number[];
   fixBy?: string[];
+  /** Корпус */
+  building?: string[];
   period?: [Dayjs, Dayjs];
   hideClosed?: boolean;
 }

--- a/src/shared/utils/defectFilter.ts
+++ b/src/shared/utils/defectFilter.ts
@@ -15,6 +15,7 @@ export function filterDefects<T extends {
   status_id: number | null;
   defectStatusName?: string;
   fixByName?: string;
+  buildingNamesList?: string[];
 }>(rows: T[], f: DefectFilters): T[] {
   return rows.filter((d) => {
     if (Array.isArray(f.id) && f.id.length > 0 && !f.id.includes(d.id)) {
@@ -24,6 +25,13 @@ export function filterDefects<T extends {
       Array.isArray(f.units) &&
       f.units.length > 0 &&
       !d.unitIds.some((u) => f.units!.includes(u))
+    ) {
+      return false;
+    }
+    if (
+      Array.isArray(f.building) &&
+      f.building.length > 0 &&
+      (!d.buildingNamesList || !d.buildingNamesList.some((b) => f.building!.includes(b)))
     ) {
       return false;
     }

--- a/src/shared/utils/formatUnitName.ts
+++ b/src/shared/utils/formatUnitName.ts
@@ -4,6 +4,7 @@
  * Пустые части пропускаются.
  *
  * @param unit - данные объекта
+ * @param includeBuilding - включать ли корпус в итоговую строку
  */
 export default function formatUnitName(
   unit: {
@@ -11,10 +12,11 @@ export default function formatUnitName(
     building?: string | null;
     floor?: number | null;
   },
+  includeBuilding = true,
 ): string {
   const parts: string[] = [];
 
-  if (unit.building) {
+  if (includeBuilding && unit.building) {
     const b = unit.building.trim();
     parts.push(/^\s*корпус/i.test(b) ? b : `Корпус ${b}`);
   }

--- a/src/widgets/DefectsFilters.tsx
+++ b/src/widgets/DefectsFilters.tsx
@@ -14,6 +14,7 @@ interface Options {
   types: { label: string; value: number }[];
   statuses: { label: string; value: number }[];
   fixBy: { label: string; value: string }[];
+  buildings: { label: string; value: string }[];
 }
 
 /** Форма фильтров дефектов */
@@ -79,6 +80,9 @@ export default function DefectsFilters({
       </Form.Item>
       <Form.Item name="projectId" label="Проекты">
         <Select mode="multiple" allowClear options={options.projects} showSearch optionFilterProp="label" />
+      </Form.Item>
+      <Form.Item name="building" label="Корпус">
+        <Select mode="multiple" allowClear options={options.buildings} showSearch optionFilterProp="label" />
       </Form.Item>
       <Form.Item name="units" label="Объекты">
         <Select mode="multiple" allowClear options={options.units} showSearch optionFilterProp="label" />

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -71,6 +71,12 @@ export default function DefectsTable({
         (a.projectNames || "").localeCompare(b.projectNames || ""),
     },
     {
+      title: "Корпус",
+      dataIndex: "buildingNames",
+      sorter: (a, b) =>
+        (a.buildingNames || "").localeCompare(b.buildingNames || ""),
+    },
+    {
       title: "Объекты",
       dataIndex: "unitNamesList",
       sorter: (a, b) => (a.unitNames || "").localeCompare(b.unitNames || ""),


### PR DESCRIPTION
## Summary
- show unit names without building info
- include building information separately in defects tables
- support filtering defects by building

## Testing
- `npm run lint`
- `npm test`
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_685c5a2809b8832eaf04b4e2c69056ce