### PR TITLE
Sync defect receive date with claim

### DIFF
--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -88,6 +88,7 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
   const createDefects = useCreateDefects();
   const role = useAuthStore((s) => s.profile?.role as RoleName | undefined);
   const defectsWatch = Form.useWatch('defects', form);
+  const acceptedOnWatch = Form.useWatch('accepted_on', form) ?? null;
   const { data: persons = [] } = usePersons();
   const deletePerson = useDeletePerson();
   const { data: caseUids = [] } = useCaseUids();
@@ -357,6 +358,7 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
               remove={remove}
               projectId={projectId}
               showFiles={false}
+              defaultReceivedAt={acceptedOnWatch}
             />
           )}
         </Form.List>

--- a/src/features/claim/ClaimViewModal.tsx
+++ b/src/features/claim/ClaimViewModal.tsx
@@ -6,6 +6,7 @@ import ClaimAttachmentsBlock from './ClaimAttachmentsBlock';
 import TicketDefectsEditorTable from '@/widgets/TicketDefectsEditorTable';
 import DefectAddModal from '@/features/defect/DefectAddModal';
 import DefectViewModal from '@/features/defect/DefectViewModal';
+import dayjs from 'dayjs';
 import {
   useCreateDefects,
   useDeleteDefect,
@@ -301,6 +302,7 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
       <DefectAddModal
         open={showAdd}
         projectId={claim?.project_id}
+        defaultReceivedAt={claim?.accepted_on ? dayjs(claim.accepted_on) : null}
         onClose={() => setShowAdd(false)}
         onSubmit={handleAddDefs}
       />

--- a/src/features/defect/DefectAddModal.tsx
+++ b/src/features/defect/DefectAddModal.tsx
@@ -8,6 +8,8 @@ import { useAuthStore } from '@/shared/store/authStore';
 interface Props {
   open: boolean;
   projectId?: number | null;
+  /** Значение по умолчанию для поля "Дата получения" */
+  defaultReceivedAt?: dayjs.Dayjs | null;
   onClose: () => void;
   onSubmit: (defs: NewDefect[]) => void;
 }
@@ -15,7 +17,7 @@ interface Props {
 /**
  * Модальное окно добавления дефектов к претензии.
  */
-export default function DefectAddModal({ open, projectId, onClose, onSubmit }: Props) {
+export default function DefectAddModal({ open, projectId, defaultReceivedAt, onClose, onSubmit }: Props) {
   const [form] = Form.useForm();
 
   const handleOk = async () => {
@@ -58,6 +60,7 @@ export default function DefectAddModal({ open, projectId, onClose, onSubmit }: P
               remove={remove}
               projectId={projectId ?? null}
               showFiles={false}
+              defaultReceivedAt={defaultReceivedAt}
             />
           )}
         </Form.List>

--- a/src/widgets/DefectEditableTable.tsx
+++ b/src/widgets/DefectEditableTable.tsx
@@ -40,6 +40,8 @@ interface Props {
   onFilesChange?: (index: number, files: NewDefectFile[]) => void;
   /** Показывать колонку загрузки файлов */
   showFiles?: boolean;
+  /** Дата по умолчанию для поля "Дата получения" */
+  defaultReceivedAt?: dayjs.Dayjs | null;
 }
 
 /**
@@ -121,7 +123,7 @@ const FixByField: React.FC<FixByFieldProps> = React.memo(
  * Editable table for adding defects inside ticket form.
  * Shows skeleton until defect types and statuses are loaded.
  */
-export default function DefectEditableTable({ fields, add, remove, projectId, fileMap = {}, onFilesChange, showFiles = true }: Props) {
+export default function DefectEditableTable({ fields, add, remove, projectId, fileMap = {}, onFilesChange, showFiles = true, defaultReceivedAt }: Props) {
   const { data: defectTypes = [], isPending: loadingTypes } = useDefectTypes();
   const { data: defectStatuses = [], isPending: loadingStatuses } = useDefectStatuses();
   const { data: deadlines = [] } = useDefectDeadlines();
@@ -246,7 +248,7 @@ export default function DefectEditableTable({ fields, add, remove, projectId, fi
               name={[field.name, 'received_at']}
               noStyle
               rules={[{ required: true, message: 'Укажите дату' }]}
-              initialValue={dayjs()}
+              initialValue={defaultReceivedAt ?? dayjs()}
             >
               <DatePicker size="small" format="DD.MM.YYYY" style={{ width: '100%' }} />
             </Form.Item>
@@ -396,7 +398,7 @@ export default function DefectEditableTable({ fields, add, remove, projectId, fi
               status_id: defectStatuses[0]?.id ?? null,
               type_id: null,
               is_warranty: false,
-              received_at: dayjs(),
+              received_at: defaultReceivedAt ?? dayjs(),
               fixed_at: null,
               brigade_id: null,
               contractor_id: null,


### PR DESCRIPTION
## Summary
- default defect receive date to claim's accepted date
- pass claim's accepted date to defect add flow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c5b7dcfcc832ebb7c5cc94a94d2bf