### PR TITLE
Highlight pretrial rows in claims and defects tables

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -110,6 +110,9 @@ body {
 .claim-pretrial-row {
   background: #fff1f0 !important;
 }
+.defect-pretrial-row {
+  background: #fff1f0 !important;
+}
 .defect-closed-row {
   color: #aaa;
   background: inherit !important;

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -71,7 +71,7 @@ export default function DefectsPage() {
     // замена: no tickets
     const claimsMap = new Map<
       number,
-      { id: number; unit_ids: number[]; project_id: number }[]
+      { id: number; unit_ids: number[]; project_id: number; pre_trial_claim: boolean }[]
     >();
     claims.forEach((c: any) => {
       (c.claim_defects || []).forEach((cd: any) => {
@@ -80,6 +80,7 @@ export default function DefectsPage() {
           id: c.id,
           unit_ids: c.unit_ids || [],
           project_id: c.project_id,
+          pre_trial_claim: cd.pre_trial_claim ?? false,
         });
         claimsMap.set(cd.defect_id, arr);
       });
@@ -87,6 +88,7 @@ export default function DefectsPage() {
     return defects.map((d: any) => {
       const claimLinked = claimsMap.get(d.id) || [];
       const linked = claimLinked;
+      const hasPretrial = linked.some((l) => l.pre_trial_claim);
       const unitIds = Array.from(new Set(linked.flatMap((l) => l.unit_ids)));
       const unitNamesList = unitIds
         .map((id) => unitMap.get(id))
@@ -113,6 +115,7 @@ export default function DefectsPage() {
       return {
         ...d,
         claimIds: claimLinked.map((l) => l.id),
+        hasPretrialClaim: hasPretrial,
         unitIds,
         unitNames,
         unitNamesList,

--- a/src/shared/types/defect.ts
+++ b/src/shared/types/defect.ts
@@ -66,4 +66,6 @@ export interface DefectWithInfo extends DefectRecord {
   projectNames?: string;
   /** Прошло дней с даты получения */
   days?: number | null;
+  /** Есть ли среди связанных претензий досудебная */
+  hasPretrialClaim?: boolean;
 }

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -165,7 +165,8 @@ export default function ClaimsTable({
   const rowClassName = (row: ClaimWithNames) => {
     const checking = row.statusName?.toLowerCase().includes('провер');
     const closed = row.statusName?.toLowerCase().includes('закры');
-    const preTrial = row.statusName?.toLowerCase().includes('досудеб');
+    const preTrial = row.pre_trial_claim ||
+      row.statusName?.toLowerCase().includes('досудеб');
     if (checking || row.hasCheckingDefect) return 'claim-checking-row';
     if (preTrial) return 'claim-pretrial-row';
     if (closed) return 'claim-closed-row';

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -181,7 +181,9 @@ export default function DefectsTable({
     const classes = ["main-defect-row"];
     const checking = row.defectStatusName?.toLowerCase().includes("провер");
     const closed = row.defectStatusName?.toLowerCase().includes("закры");
+    const preTrial = row.hasPretrialClaim;
     if (checking) classes.push("defect-confirmed-row");
+    if (preTrial) classes.push("defect-pretrial-row");
     if (closed) classes.push("defect-closed-row");
     return classes.join(" ");
   };


### PR DESCRIPTION
## Summary
- style rows for pretrial claims and defects
- mark pretrial claims directly in claims table
- compute pretrial flag for defects via related claims
- expose `hasPretrialClaim` in `DefectWithInfo`

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error)*
- `npx tsc --noEmit` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685c603d5fa4832e8fcf3c94dc60c9df