### PR TITLE
Enhance cross-filtering on defects and claims

### DIFF
--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -37,6 +37,9 @@ import type { TableColumnSetting } from '@/shared/types/tableColumnSetting';
 import type { ColumnsType } from 'antd/es/table';
 import { useSearchParams } from 'react-router-dom';
 import type { ClaimWithNames } from '@/shared/types/claimWithNames';
+import { filterClaims } from '@/shared/utils/claimFilter';
+import { naturalCompare } from '@/shared/utils/naturalSort';
+import type { ClaimFilters } from '@/shared/types/claimFilters';
 
 export default function ClaimsPage() {
   const { enqueueSnackbar } = useSnackbar();
@@ -164,16 +167,37 @@ export default function ClaimsPage() {
   );
 
   const options = useMemo(() => {
-    const uniq = (arr: any[], key: string) => Array.from(new Set(arr.map((i) => i[key]).filter(Boolean))).map((v) => ({ label: v, value: v }));
-    return {
-      projects: uniq(claimsWithNames, 'projectName'),
-      units: Array.from(new Set((units ?? []).map((u) => u.name))).map((v) => ({ label: v, value: v })),
-      buildings: Array.from(new Set((units ?? []).map((u) => u.building).filter(Boolean))).map((v) => ({ label: v, value: v })),
-      statuses: uniq(claimsWithNames, 'statusName'),
-      responsibleEngineers: uniq(claimsWithNames, 'responsibleEngineerName'),
-      ids: uniq(claimsWithNames, 'id'),
+    const without = <K extends keyof ClaimFilters>(key: K) => {
+      const { [key]: _omit, ...rest } = filters;
+      return rest as ClaimFilters;
     };
-  }, [claimsWithNames, units]);
+    const filtered = <K extends keyof ClaimFilters>(key: K) =>
+      filterClaims(claimsWithNames, without(key));
+
+    const uniq = (values: (string | number | undefined | null)[]) =>
+      Array.from(new Set(values.filter(Boolean) as (string | number)[])).sort(naturalCompare);
+    const mapOptions = (vals: (string | number | undefined | null)[]) =>
+      uniq(vals).map((v) => ({ label: String(v), value: v }));
+
+    return {
+      projects: mapOptions(filtered('project').map((c) => c.projectName)),
+      units: mapOptions(
+        filtered('units').flatMap((c) =>
+          c.unitNumbers ? c.unitNumbers.split(',').map((n) => n.trim()) : [],
+        ),
+      ),
+      buildings: mapOptions(
+        filtered('building').flatMap((c) =>
+          c.buildings ? c.buildings.split(',').map((n) => n.trim()) : [],
+        ),
+      ),
+      statuses: mapOptions(filtered('status').map((c) => c.statusName)),
+      responsibleEngineers: mapOptions(
+        filtered('responsible').map((c) => c.responsibleEngineerName),
+      ),
+      ids: mapOptions(filtered('id').map((c) => c.id)),
+    };
+  }, [claimsWithNames, filters]);
 
   function getBaseColumns() {
     return {

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -37,6 +37,7 @@ import ExportDefectsButton from "@/features/defect/ExportDefectsButton";
 import DefectFixModal from "@/features/defect/DefectFixModal";
 import { useCancelDefectFix } from "@/entities/defect";
 import { filterDefects } from "@/shared/utils/defectFilter";
+import { naturalCompare } from "@/shared/utils/naturalSort";
 import formatUnitName from "@/shared/utils/formatUnitName";
 import type { DefectWithInfo } from "@/shared/types/defect";
 import type { DefectFilters } from "@/shared/types/defectFilters";
@@ -140,33 +141,56 @@ export default function DefectsPage() {
     return data;
   }, [data, perm?.only_assigned_project, userProjectIds]);
 
+  const [filters, setFilters] = useState<DefectFilters>({});
+
   const options = useMemo(() => {
-    const uniq = (entries: [number | null, string | null][]) => {
+    const without = <K extends keyof DefectFilters>(key: K) => {
+      const { [key]: _omit, ...rest } = filters;
+      return rest as DefectFilters;
+    };
+    const filtered = <K extends keyof DefectFilters>(key: K) =>
+      filterDefects(filteredData, without(key));
+
+    const uniq = (values: (string | number | null | undefined)[]) =>
+      Array.from(new Set(values.filter(Boolean) as (string | number)[])).sort(naturalCompare);
+    const mapOptions = (vals: (string | number | null | undefined)[]) =>
+      uniq(vals).map((v) => ({ label: String(v), value: v }));
+
+    const uniqPairs = (pairs: [number | null, string | null][]) => {
       const map = new Map<number, string>();
-      entries.forEach(([id, name]) => {
+      pairs.forEach(([id, name]) => {
         if (id != null && name) map.set(id, name);
       });
-      return Array.from(map.entries()).map(([value, label]) => ({ value, label }));
+      return Array.from(map.entries())
+        .sort((a, b) => naturalCompare(a[1], b[1]))
+        .map(([value, label]) => ({ value, label }));
     };
-    return {
-      ids: Array.from(new Set(filteredData.map((d) => d.id))).map((id) => ({
-        label: String(id),
-        value: id,
-      })),
-      units: units.map((u) => ({ label: u.name, value: u.id })),
-      buildings: Array.from(new Set(units.map((u) => u.building).filter(Boolean))).map(
-        (b) => ({ label: String(b), value: String(b) }),
-      ),
-      projects: projects.map((p) => ({ label: p.name, value: p.id })),
-      types: uniq(filteredData.map((d) => [d.type_id, d.defectTypeName])),
-      statuses: uniq(filteredData.map((d) => [d.status_id, d.defectStatusName])),
-      fixBy: Array.from(new Set(filteredData.map((d) => d.fixByName).filter(Boolean))).map(
-        (name) => ({ label: String(name), value: String(name) })
-      ),
-    };
-  }, [filteredData, units, projects]);
 
-  const [filters, setFilters] = useState<DefectFilters>({});
+    const unitMap = new Map(units.map((u) => [u.id, u.name]));
+    const projectMap = new Map(projects.map((p) => [p.id, p.name]));
+
+    return {
+      ids: mapOptions(filtered('id').map((d) => d.id)),
+      units: Array.from(
+        new Set(filtered('units').flatMap((d) => d.unitIds)),
+      )
+        .map((id) => ({ label: unitMap.get(id) ?? String(id), value: id }))
+        .sort((a, b) => naturalCompare(a.label, b.label)),
+      buildings: mapOptions(
+        filtered('building').flatMap((d) => d.buildingNamesList || []),
+      ),
+      projects: Array.from(
+        new Set(filtered('projectId').flatMap((d) => d.projectIds || [])),
+      )
+        .map((id) => ({ label: projectMap.get(id) ?? String(id), value: id }))
+        .sort((a, b) => naturalCompare(a.label, b.label)),
+      types: uniqPairs(filtered('typeId').map((d) => [d.type_id, d.defectTypeName])),
+      statuses: uniqPairs(
+        filtered('statusId').map((d) => [d.status_id, d.defectStatusName]),
+      ),
+      fixBy: mapOptions(filtered('fixBy').map((d) => d.fixByName)),
+    };
+  }, [filteredData, filters, units, projects]);
   const [viewId, setViewId] = useState<number | null>(null);
   const [fixId, setFixId] = useState<number | null>(null);
   const { mutateAsync: removeDefect, isPending: removing } = useDeleteDefect();

--- a/src/shared/utils/naturalSort.ts
+++ b/src/shared/utils/naturalSort.ts
@@ -1,0 +1,10 @@
+/**
+ * Естественное сравнение строк и чисел.
+ * Позволяет корректно сортировать значения содержащие цифры.
+ *
+ * @param a первое значение
+ * @param b второе значение
+ */
+export function naturalCompare(a: string | number, b: string | number): number {
+  return String(a).localeCompare(String(b), undefined, { numeric: true, sensitivity: 'base' });
+}


### PR DESCRIPTION
## Summary
- introduce `naturalCompare` helper for natural sorting
- rebuild filter option lists on `/claims` and `/defects` pages using cross-filtering
- fix missing `filterClaims` import and order of `filters` state

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c5eaeb540832e9a6d471f9ae65a4d