### PR TITLE
Handle pre-trial claim defects

### DIFF
--- a/src/entities/claim.ts
+++ b/src/entities/claim.ts
@@ -113,6 +113,18 @@ async function closeDefectsForClaim(claimId: number, statusId: number | null) {
 }
 
 /**
+ * Помечает все дефекты претензии как относящиеся к досудебной.
+ * @param claimId идентификатор претензии
+ */
+async function markClaimDefectsPreTrial(claimId: number) {
+  await supabase
+    .from('claim_defects')
+    .update({ pre_trial_claim: true })
+    .eq('claim_id', claimId)
+    .eq('pre_trial_claim', false);
+}
+
+/**
  * Хук получения списка претензий с учётом фильтров проекта.
  */
 export function useClaims() {
@@ -727,5 +739,5 @@ export function useUnlinkClaim() {
   });
 }
 
-export { closeDefectsForClaim };
+export { closeDefectsForClaim, markClaimDefectsPreTrial };
 

--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -21,6 +21,7 @@ import {
   useAddClaimAttachments,
   useRemoveClaimAttachment,
   signedUrl,
+  markClaimDefectsPreTrial,
 } from '@/entities/claim';
 import { supabase } from '@/shared/api/supabaseClient';
 import { useVisibleProjects } from '@/entities/project';
@@ -169,6 +170,10 @@ const ClaimFormAntdEdit = React.forwardRef<
           updated_by: userId ?? undefined,
         } as any,
       });
+
+      if (!claim.pre_trial_claim && values.pre_trial_claim) {
+        await markClaimDefectsPreTrial(claim.id);
+      }
 
       for (const id of attachments.removedIds) {
         await removeAtt.mutateAsync({

--- a/src/features/claim/ClaimViewModal.tsx
+++ b/src/features/claim/ClaimViewModal.tsx
@@ -195,6 +195,7 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
           createdIds.map((id) => ({
             claim_id: claim.id,
             defect_id: id,
+            pre_trial_claim: claim.pre_trial_claim ?? false,
           })),
         );
         await closeDefectsForClaim(claim.id, claim.claim_status_id ?? null);


### PR DESCRIPTION
## Summary
- add helper to mark all claim defects as pre-trial
- mark defects when user toggles "pre-trial" flag on edit form
- set `pre_trial_claim` on defects created from claim view

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c613d9828832eac093cf1a75bf060