### PR TITLE
Highlight pre‑trial claims in structure

### DIFF
--- a/src/entities/unit/UnitCell.tsx
+++ b/src/entities/unit/UnitCell.tsx
@@ -46,6 +46,7 @@ export default function UnitCell({
   const bgColor = "#fff";
   const hasCases = Array.isArray(cases) && cases.length > 0;
   const claimColor = claimInfo?.color ?? null;
+  const hasPretrial = claimInfo?.hasPretrialClaim ?? false;
 
   return (
     <Paper
@@ -58,7 +59,7 @@ export default function UnitCell({
         alignItems: "stretch",
         justifyContent: "flex-start",
         border: `${hasCases ? 2 : 1.5}px solid ${
-          hasCases ? "#e53935" : "#dde2ee"
+          hasCases || hasPretrial ? "#e53935" : "#dde2ee"
         }`,
         background: bgColor,
         borderRadius: "12px",
@@ -96,10 +97,11 @@ export default function UnitCell({
             top: 0,
             left: 0,
             right: 0,
-            height: 6,
-            bgcolor: claimColor,
-            borderTopLeftRadius: "12px",
-            borderTopRightRadius: "12px",
+            height: '50%',
+            bgcolor: getSemiTransparent(claimColor, 0.35),
+            borderTopLeftRadius: '12px',
+            borderTopRightRadius: '12px',
+            pointerEvents: 'none',
           }}
         />
       )}

--- a/src/shared/hooks/useUnitsMatrix.ts
+++ b/src/shared/hooks/useUnitsMatrix.ts
@@ -98,7 +98,9 @@ export default function useUnitsMatrix(projectId: number | null, building?: stri
 
         const { data: claimRows } = await supabase
           .from('claim_units')
-          .select('unit_id, claims!inner(id, project_id, claim_status_id, statuses(color))')
+          .select(
+            'unit_id, claims!inner(id, project_id, pre_trial_claim, claim_status_id, statuses(color))',
+          )
           .in('unit_id', unitIds)
           .eq('claims.project_id', projectId);
         (claimRows || []).forEach((row) => {
@@ -107,7 +109,10 @@ export default function useUnitsMatrix(projectId: number | null, building?: stri
           if (!claimsByUnit[row.unit_id]) {
             claimsByUnit[row.unit_id] = {
               color: cl.statuses?.color ?? null,
+              hasPretrialClaim: cl.pre_trial_claim ?? false,
             };
+          } else if (cl.pre_trial_claim) {
+            claimsByUnit[row.unit_id].hasPretrialClaim = true;
           }
         });
       }

--- a/src/shared/types/unitClaimInfo.ts
+++ b/src/shared/types/unitClaimInfo.ts
@@ -1,5 +1,8 @@
 export interface UnitClaimInfo {
   /** Цвет статуса претензии */
   color: string | null;
+  /** Есть ли среди претензий досудебная */
+  hasPretrialClaim: boolean;
 }
+
 


### PR DESCRIPTION
## Summary
- show pretrial claim info in unit data
- highlight units with pretrial claims in matrix
- mark pretrial info while loading units

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c6b9ce32c832e8f34eb68c7f53170