### PR TITLE
Remove person_id from claims

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -274,8 +274,8 @@
   },
   {
     "table_name": "claims",
-    "column_name": "person_id",
-    "data_type": "integer",
+    "column_name": "owner",
+    "data_type": "text",
     "is_nullable": "YES",
     "column_default": null
   },

--- a/sql/claims_owner.sql
+++ b/sql/claims_owner.sql
@@ -1,0 +1,3 @@
+-- Удаляем связь с физлицом и добавляем поле владельца объекта
+ALTER TABLE claims DROP COLUMN IF EXISTS person_id;
+ALTER TABLE claims ADD COLUMN IF NOT EXISTS owner text;

--- a/src/entities/claim.ts
+++ b/src/entities/claim.ts
@@ -60,7 +60,7 @@ function mapClaim(r: any): ClaimWithNames {
     registered_on: r.registered_on,
     resolved_on: r.resolved_on,
     engineer_id: r.engineer_id,
-    person_id: r.person_id ?? null,
+    owner: r.owner ?? null,
     case_uid_id: r.case_uid_id ?? null,
     pre_trial_claim: r.pre_trial_claim ?? false,
     defect_ids: r.defect_ids ?? [],
@@ -69,7 +69,6 @@ function mapClaim(r: any): ClaimWithNames {
     statusName: r.statuses?.name ?? '—',
     statusColor: r.statuses?.color ?? null,
     responsibleEngineerName: null,
-    personName: r.persons?.full_name ?? null,
     caseUid: r.case_uids?.uid ?? null,
     unitNames: '',
     // convert strings to dayjs for consumer convenience
@@ -137,9 +136,8 @@ export function useClaims() {
         .select(
           `id, project_id, claim_status_id, claim_no, claimed_on,
           accepted_on, registered_on, resolved_on,
-          engineer_id, person_id, case_uid_id, pre_trial_claim, description, created_at,
+          engineer_id, owner, case_uid_id, pre_trial_claim, description, created_at,
           projects (id, name),
-          persons(id, full_name),
           case_uids(id, uid),
           statuses (id, name, color),
           claim_units(unit_id),
@@ -188,9 +186,8 @@ export function useClaim(id?: number | string) {
         .select(
           `id, project_id, claim_status_id, claim_no, claimed_on,
           accepted_on, registered_on, resolved_on,
-          engineer_id, person_id, case_uid_id, pre_trial_claim, description, created_at,
+          engineer_id, owner, case_uid_id, pre_trial_claim, description, created_at,
           projects (id, name),
-          persons(id, full_name),
           case_uids(id, uid),
           statuses (id, name, color),
           claim_units(unit_id),
@@ -234,9 +231,8 @@ export function useClaimAll(id?: number | string) {
         .select(
           `id, project_id, claim_status_id, claim_no, claimed_on,
           accepted_on, registered_on, resolved_on,
-          engineer_id, person_id, case_uid_id, pre_trial_claim, description, created_at,
+          engineer_id, owner, case_uid_id, pre_trial_claim, description, created_at,
           projects (id, name),
-          persons(id, full_name),
           case_uids(id, uid),
           statuses (id, name, color),
           claim_units(unit_id),
@@ -276,7 +272,7 @@ export function useClaimsAll() {
         .select(
           `id, project_id, claim_status_id, claim_no, claimed_on,
           accepted_on, registered_on, resolved_on,
-          engineer_id, person_id, case_uid_id, pre_trial_claim, description, created_at,
+          engineer_id, owner, case_uid_id, pre_trial_claim, description, created_at,
           projects (id, name),
           statuses (id, name, color),
           claim_units(unit_id),

--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -28,8 +28,7 @@ import { useVisibleProjects } from '@/entities/project';
 import { useUnitsByProject } from '@/entities/unit';
 import { useUsers } from '@/entities/user';
 import { useClaimStatuses } from '@/entities/claimStatus';
-import { usePersons, useDeletePerson } from '@/entities/person';
-import PersonModalId from '@/features/person/PersonModalId';
+
 import { useCaseUids } from '@/entities/caseUid';
 import { useNotify } from '@/shared/hooks/useNotify';
 import { useProjectId } from '@/shared/hooks/useProjectId';
@@ -42,7 +41,7 @@ import FileDropZone from '@/shared/ui/FileDropZone';
 import { useClaimAttachments } from './model/useClaimAttachments';
 import type { RemoteClaimFile } from '@/shared/types/claimFile';
 import type { ClaimFormAntdEditRef } from '@/shared/types/claimFormAntdEditRef';
-import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
+
 
 export interface ClaimFormAntdEditProps {
   claimId: string | number;
@@ -67,7 +66,7 @@ export interface ClaimFormAntdEditValues {
   accepted_on: Dayjs | null;
   registered_on: Dayjs | null;
   engineer_id: string | null;
-  person_id: number | null;
+  owner: string | null;
   case_uid_id: number | null;
   pre_trial_claim: boolean;
   description: string | null;
@@ -101,10 +100,7 @@ const ClaimFormAntdEdit = React.forwardRef<
   const { data: units = [] } = useUnitsByProject(projectId);
   const { data: users = [] } = useUsers();
   const { data: statuses = [] } = useClaimStatuses();
-  const { data: persons = [] } = usePersons();
-  const deletePerson = useDeletePerson();
   const { data: caseUids = [] } = useCaseUids();
-  const [personModal, setPersonModal] = React.useState<any | null>(null);
   const update = useUpdateClaim();
   const addAtt = useAddClaimAttachments();
   const removeAtt = useRemoveClaimAttachment();
@@ -136,7 +132,7 @@ const ClaimFormAntdEdit = React.forwardRef<
       accepted_on: claim.acceptedOn ?? null,
       registered_on: claim.registeredOn ?? null,
       engineer_id: claim.engineer_id ?? null,
-      person_id: claim.person_id ?? null,
+      owner: claim.owner ?? null,
       case_uid_id: claim.case_uid_id ?? null,
       pre_trial_claim: claim.pre_trial_claim ?? false,
       description: claim.description ?? '',
@@ -163,7 +159,7 @@ const ClaimFormAntdEdit = React.forwardRef<
             ? values.registered_on.format('YYYY-MM-DD')
             : null,
           engineer_id: values.engineer_id ?? null,
-          person_id: values.person_id ?? null,
+          owner: values.owner ?? null,
           case_uid_id: values.case_uid_id ?? null,
           pre_trial_claim: values.pre_trial_claim ?? false,
           description: values.description ?? '',
@@ -270,37 +266,8 @@ const ClaimFormAntdEdit = React.forwardRef<
           </Form.Item>
         </Col>
         <Col span={8}>
-          <Form.Item label="Физлицо" name="person_id" style={highlight('person_id')}>
-            <Space.Compact style={{ width: '100%' }}>
-              <Select
-                allowClear
-                showSearch
-                options={persons.map((p) => ({ value: p.id, label: p.full_name }))}
-              />
-              <Button icon={<PlusOutlined />} onClick={() => setPersonModal({})} />
-              <Button
-                icon={<EditOutlined />}
-                disabled={!form.getFieldValue('person_id')}
-                onClick={() => {
-                  const id = form.getFieldValue('person_id');
-                  const data = persons.find((p) => p.id === id) || null;
-                  setPersonModal(data);
-                }}
-              />
-              <Popconfirm
-                title="Удалить физлицо?"
-                okText="Да"
-                cancelText="Нет"
-                onConfirm={() => {
-                  const id = form.getFieldValue('person_id');
-                  if (!id) return;
-                  deletePerson.mutate(id);
-                }}
-                disabled={!form.getFieldValue('person_id')}
-              >
-                <Button icon={<DeleteOutlined />} disabled={!form.getFieldValue('person_id')} />
-              </Popconfirm>
-            </Space.Compact>
+          <Form.Item label="Собственник объекта" name="owner" style={highlight('owner')}>
+            <Input />
           </Form.Item>
         </Col>
         <Col span={8}>
@@ -408,15 +375,6 @@ const ClaimFormAntdEdit = React.forwardRef<
         </Form.Item>
       )}
     </Form>
-    <PersonModalId
-      open={!!personModal}
-      onClose={() => setPersonModal(null)}
-      unitId={Form.useWatch('unit_ids', form)?.[0] ?? null}
-      onSelect={(id) => {
-        form.setFieldValue('person_id', id);
-      }}
-      initialData={personModal}
-    />
     </>
   );
 });

--- a/src/shared/types/claim.ts
+++ b/src/shared/types/claim.ts
@@ -21,8 +21,8 @@ export interface Claim {
   resolved_on: string | null;
   /** Ответственный инженер */
   engineer_id: string | null;
-  /** Связь с физлицом */
-  person_id: number | null;
+  /** Собственник объекта */
+  owner: string | null;
   /** Уникальный идентификатор судебного дела */
   case_uid_id: number | null;
   /** Признак досудебной претензии */

--- a/src/shared/types/claimWithNames.ts
+++ b/src/shared/types/claimWithNames.ts
@@ -10,8 +10,6 @@ export interface ClaimWithNames extends Claim {
   statusColor: string | null;
   /** ФИО ответственного инженера */
   responsibleEngineerName: string | null;
-  /** ФИО выбранного физлица */
-  personName?: string | null;
   /** Уникальный идентификатор судебного дела */
   caseUid?: string | null;
   /** Список объектов одной строкой */


### PR DESCRIPTION
## Summary
- drop `person_id` support for claims
- store object owner instead
- update database structure and provide SQL script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685cccb31a64832eaef152c7937e4ccb