### PR TITLE
Add dashboard engineer and unit charts

### DIFF
--- a/src/shared/hooks/useDashboardStats.ts
+++ b/src/shared/hooks/useDashboardStats.ts
@@ -39,7 +39,12 @@ export function useDashboardStats() {
         });
       }
 
-      const [{ count: claimsTotal }, { count: claimsClosed }, { count: defectsTotal }, { count: defectsClosed }, { count: courtCases }] = await Promise.all([
+      const claimsQuery = supabase
+        .from('claims')
+        .select('id, engineer_id')
+        .in('project_id', projectIds);
+
+      const [{ count: claimsTotal }, { count: claimsClosed }, { count: defectsTotal }, { count: defectsClosed }, { count: courtCases }, { data: claimsRows }] = await Promise.all([
         supabase.from('claims').select('id', { count: 'exact', head: true }).in('project_id', projectIds),
         closedClaimId
           ? supabase
@@ -57,7 +62,80 @@ export function useDashboardStats() {
               .eq('status_id', closedDefectId)
           : Promise.resolve({ count: 0 }),
         supabase.from('court_cases').select('id', { count: 'exact', head: true }).in('project_id', projectIds),
+        claimsQuery,
       ]);
+
+      const claimIds = (claimsRows ?? []).map((r: any) => r.id);
+
+      const engineerMap: Record<string, number> = {};
+      (claimsRows ?? []).forEach((row: any) => {
+        if (row.engineer_id) {
+          engineerMap[row.engineer_id] = (engineerMap[row.engineer_id] || 0) + 1;
+        }
+      });
+
+      const { data: engineerNames } = Object.keys(engineerMap).length
+        ? await supabase
+            .from('profiles')
+            .select('id, name')
+            .in('id', Object.keys(engineerMap))
+        : { data: [] };
+      const engineerNameMap = new Map(
+        (engineerNames ?? []).map((u: any) => [u.id, u.name]),
+      );
+      const claimsByEngineer = Object.entries(engineerMap).map(([id, count]) => ({
+        engineerName: engineerNameMap.get(id) ?? '—',
+        count,
+      }));
+
+      const { data: claimUnitRows } = claimIds.length
+        ? await supabase
+            .from('claim_units')
+            .select('unit_id')
+            .in('claim_id', claimIds)
+        : { data: [] };
+      const unitCountMap: Record<number, number> = {};
+      (claimUnitRows ?? []).forEach((row: any) => {
+        unitCountMap[row.unit_id] = (unitCountMap[row.unit_id] || 0) + 1;
+      });
+      const unitIds = Object.keys(unitCountMap).map((v) => Number(v));
+      const { data: unitNames } = unitIds.length
+        ? await supabase
+            .from('units')
+            .select('id, name')
+            .in('id', unitIds)
+        : { data: [] };
+      const unitNameMap = new Map((unitNames ?? []).map((u: any) => [u.id, u.name]));
+      const claimsByUnit = unitIds.map((id) => ({
+        unitName: unitNameMap.get(id) ?? `#${id}`,
+        count: unitCountMap[id],
+      }));
+
+      const { data: defectRows } = await supabase
+        .from('defects')
+        .select('fixed_by')
+        .in('project_id', projectIds);
+      const defectEngineerMap: Record<string, number> = {};
+      (defectRows ?? []).forEach((row: any) => {
+        if (row.fixed_by) {
+          defectEngineerMap[row.fixed_by] = (defectEngineerMap[row.fixed_by] || 0) + 1;
+        }
+      });
+      const { data: defectEngineerNames } = Object.keys(defectEngineerMap).length
+        ? await supabase
+            .from('profiles')
+            .select('id, name')
+            .in('id', Object.keys(defectEngineerMap))
+        : { data: [] };
+      const defectEngineerNameMap = new Map(
+        (defectEngineerNames ?? []).map((u: any) => [u.id, u.name]),
+      );
+      const defectsByEngineer = Object.entries(defectEngineerMap).map(
+        ([id, count]) => ({
+          engineerName: defectEngineerNameMap.get(id) ?? '—',
+          count,
+        }),
+      );
 
       return {
         projects: projectStats,
@@ -66,6 +144,9 @@ export function useDashboardStats() {
         defectsOpen: (defectsTotal ?? 0) - (defectsClosed ?? 0),
         defectsClosed: defectsClosed ?? 0,
         courtCases: courtCases ?? 0,
+        claimsByUnit: claimsByUnit ?? [],
+        claimsByEngineer: claimsByEngineer ?? [],
+        defectsByEngineer: defectsByEngineer ?? [],
       } as DashboardStats;
     },
     staleTime: 60_000,

--- a/src/shared/types/dashboardStats.ts
+++ b/src/shared/types/dashboardStats.ts
@@ -24,4 +24,10 @@ export interface DashboardStats {
   defectsClosed: number;
   /** Количество судебных дел */
   courtCases: number;
+  /** Претензии по объектам */
+  claimsByUnit: Array<{ unitName: string; count: number }>;
+  /** Претензии по закрепленным инженерам */
+  claimsByEngineer: Array<{ engineerName: string; count: number }>;
+  /** Дефекты по закрепленным инженерам */
+  defectsByEngineer: Array<{ engineerName: string; count: number }>;
 }

--- a/src/widgets/DashboardInfographics.tsx
+++ b/src/widgets/DashboardInfographics.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Card, Row, Col, Statistic, Skeleton } from 'antd';
-import { Column } from '@ant-design/plots';
+import { Card, Row, Col, Statistic, Skeleton, Select } from 'antd';
+import { Bar } from '@ant-design/plots';
 import { useDashboardStats } from '@/shared/hooks/useDashboardStats';
 
 /**
@@ -9,13 +9,39 @@ import { useDashboardStats } from '@/shared/hooks/useDashboardStats';
 export default function DashboardInfographics() {
   const { data, isPending } = useDashboardStats();
 
+  const [unitOrder, setUnitOrder] = React.useState<'asc' | 'desc'>('desc');
+  const [defectOrder, setDefectOrder] = React.useState<'asc' | 'desc'>('desc');
+  const [letterOrder, setLetterOrder] = React.useState<'asc' | 'desc'>('desc');
+  const [claimUnitOrder, setClaimUnitOrder] = React.useState<'asc' | 'desc'>('desc');
+  const [claimEngOrder, setClaimEngOrder] = React.useState<'asc' | 'desc'>('desc');
+  const [defectEngOrder, setDefectEngOrder] = React.useState<'asc' | 'desc'>('desc');
+
   if (isPending || !data) {
     return <Skeleton active paragraph={{ rows: 4 }} />;
   }
 
-  const unitData = data.projects.map((p) => ({ project: p.projectName, count: p.unitCount }));
-  const defectData = data.projects.map((p) => ({ project: p.projectName, count: p.defectTotal }));
-  const letterData = data.projects.map((p) => ({ project: p.projectName, count: p.letterCount }));
+  const unitData = data.projects.map((p) => ({ name: p.projectName, count: p.unitCount }));
+  const defectData = data.projects.map((p) => ({ name: p.projectName, count: p.defectTotal }));
+  const letterData = data.projects.map((p) => ({ name: p.projectName, count: p.letterCount }));
+
+  const sortData = (arr: { name: string; count: number }[], dir: 'asc' | 'desc') =>
+    [...arr].sort((a, b) => (dir === 'asc' ? a.count - b.count : b.count - a.count));
+
+  const sortedUnits = sortData(unitData, unitOrder);
+  const sortedDefects = sortData(defectData, defectOrder);
+  const sortedLetters = sortData(letterData, letterOrder);
+  const sortedClaimUnits = sortData(
+    (data.claimsByUnit ?? []).map((c) => ({ name: c.unitName, count: c.count })),
+    claimUnitOrder,
+  );
+  const sortedClaimEng = sortData(
+    (data.claimsByEngineer ?? []).map((c) => ({ name: c.engineerName, count: c.count })),
+    claimEngOrder,
+  );
+  const sortedDefectEng = sortData(
+    (data.defectsByEngineer ?? []).map((c) => ({ name: c.engineerName, count: c.count })),
+    defectEngOrder,
+  );
 
   return (
     <Row gutter={[16, 16]}>
@@ -38,18 +64,33 @@ export default function DashboardInfographics() {
         </Card>
       </Col>
       <Col span={8}>
-        <Card title="Объекты по проектам">
-          <Column data={unitData} xField="project" yField="count" height={200} />
+        <Card title="Объекты по проектам" extra={<Select size="small" value={unitOrder} onChange={setUnitOrder} options={[{value:'desc',label:'По убыв.'},{value:'asc',label:'По возр.'}]} />}> 
+          <Bar data={sortedUnits} xField="count" yField="name" height={200} />
         </Card>
       </Col>
       <Col span={8}>
-        <Card title="Дефекты по проектам">
-          <Column data={defectData} xField="project" yField="count" height={200} />
+        <Card title="Дефекты по проектам" extra={<Select size="small" value={defectOrder} onChange={setDefectOrder} options={[{value:'desc',label:'По убыв.'},{value:'asc',label:'По возр.'}]} />}> 
+          <Bar data={sortedDefects} xField="count" yField="name" height={200} />
         </Card>
       </Col>
       <Col span={8}>
-        <Card title="Письма по проектам">
-          <Column data={letterData} xField="project" yField="count" height={200} />
+        <Card title="Письма по проектам" extra={<Select size="small" value={letterOrder} onChange={setLetterOrder} options={[{value:'desc',label:'По убыв.'},{value:'asc',label:'По возр.'}]} />}> 
+          <Bar data={sortedLetters} xField="count" yField="name" height={200} />
+        </Card>
+      </Col>
+      <Col span={8}>
+        <Card title="Претензии по объектам" extra={<Select size="small" value={claimUnitOrder} onChange={setClaimUnitOrder} options={[{value:'desc',label:'По убыв.'},{value:'asc',label:'По возр.'}]} />}> 
+          <Bar data={sortedClaimUnits} xField="count" yField="name" height={200} />
+        </Card>
+      </Col>
+      <Col span={8}>
+        <Card title="Претензии по инженерам" extra={<Select size="small" value={claimEngOrder} onChange={setClaimEngOrder} options={[{value:'desc',label:'По убыв.'},{value:'asc',label:'По возр.'}]} />}> 
+          <Bar data={sortedClaimEng} xField="count" yField="name" height={200} />
+        </Card>
+      </Col>
+      <Col span={8}>
+        <Card title="Дефекты по инженерам" extra={<Select size="small" value={defectEngOrder} onChange={setDefectEngOrder} options={[{value:'desc',label:'По убыв.'},{value:'asc',label:'По возр.'}]} />}> 
+          <Bar data={sortedDefectEng} xField="count" yField="name" height={200} />
         </Card>
       </Col>
       <Col span={24}>


### PR DESCRIPTION
## Summary
- extend dashboard stats with claims/defects by units and engineers
- switch infographics to use Bar charts and add sorting controls
- fix missing array fallbacks for new dashboard stats

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685cce16723c832e8160273f36dd0ab2