### PR TITLE
Fix page size toggle on defects page

### DIFF
--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -188,12 +188,18 @@ export default function DefectsTable({
     return classes.join(" ");
   };
 
+  const [pageSize, setPageSize] = React.useState(25);
+
   return (
     <Table
       rowKey="id"
       columns={columns}
       dataSource={filtered}
-      pagination={{ pageSize: 25, showSizeChanger: true }}
+      pagination={{
+        pageSize,
+        showSizeChanger: true,
+        onChange: (_p, size) => size && setPageSize(size),
+      }}
       size="middle"
       /** Стилизуем строки аналогично таблице писем */
       rowClassName={rowClassName}


### PR DESCRIPTION
## Summary
- manage pagination state in `DefectsTable` so users can change page size

## Testing
- `npm run lint` *(fails: Parsing errors due to missing packages)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e1b1a748c832eb2792c6e2ccabcab