### PR TITLE
Fix page size hook order

### DIFF
--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -174,6 +174,7 @@ export default function DefectsTable({
   ];
 
   const columns = columnsProp ?? defaultColumns;
+  const [pageSize, setPageSize] = React.useState(25);
 
   if (loading) return <Skeleton active paragraph={{ rows: 6 }} />;
 
@@ -193,7 +194,11 @@ export default function DefectsTable({
       rowKey="id"
       columns={columns}
       dataSource={filtered}
-      pagination={{ pageSize: 25, showSizeChanger: true }}
+      pagination={{
+        pageSize,
+        showSizeChanger: true,
+        onChange: (_p, size) => size && setPageSize(size),
+      }}
       size="middle"
       /** Стилизуем строки аналогично таблице писем */
       rowClassName={rowClassName}


### PR DESCRIPTION
## Summary
- ensure `pageSize` state is defined before any conditional return

## Testing
- `npm run lint` *(fails: Parsing errors due to missing packages)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e1b1a748c832eb2792c6e2ccabcab