### PR TITLE
Restrict pre-trial claim toggle to lawyers

### DIFF
--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -85,6 +85,7 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
   const notify = useNotify();
   const createDefects = useCreateDefects();
   const role = useAuthStore((s) => s.profile?.role as RoleName | undefined);
+  const isLawyer = role === 'LAWYER';
   const defectsWatch = Form.useWatch('defects', form);
   const acceptedOnWatch = Form.useWatch('accepted_on', form) ?? null;
   const { data: caseUids = [] } = useCaseUids();
@@ -219,7 +220,7 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
             label="Досудебная претензия"
             valuePropName="checked"
           >
-            <Switch />
+            <Switch disabled={!isLawyer} />
           </Form.Item>
         </Col>
         <Col span={8}>
@@ -231,7 +232,7 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
             <Select
               showSearch
               allowClear
-              disabled={!preTrialWatch}
+              disabled={!isLawyer || !preTrialWatch}
               options={caseUids.map((c) => ({ value: c.id, label: c.uid }))}
             />
           </Form.Item>

--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -89,6 +89,7 @@ const ClaimFormAntdEdit = React.forwardRef<
 ) {
   const [form] = Form.useForm<ClaimFormAntdEditValues>();
   const role = useAuthStore((s) => s.profile?.role as RoleName | undefined);
+  const isLawyer = role === 'LAWYER';
   const { data: perm } = useRolePermission(role);
   const claimAssigned = useClaim(claimId);
   const claimAll = useClaimAll(claimId);
@@ -218,26 +219,26 @@ const ClaimFormAntdEdit = React.forwardRef<
           <Form.Item
             name="pre_trial_claim"
             label="Досудебная претензия"
-            valuePropName="checked"
-            style={highlight('pre_trial_claim')}
-          >
-            <Switch />
-          </Form.Item>
-        </Col>
-        <Col span={8}>
-          <Form.Item
-            name="case_uid_id"
-            label="Уникальный идентификатор дела"
-            hidden={!preTrialWatch}
-            style={highlight('case_uid_id')}
-          >
-            <Select
-              showSearch
-              allowClear
-              disabled={!preTrialWatch}
-              options={caseUids.map((c) => ({ value: c.id, label: c.uid }))}
-            />
-          </Form.Item>
+          valuePropName="checked"
+          style={highlight('pre_trial_claim')}
+        >
+            <Switch disabled={!isLawyer} />
+        </Form.Item>
+      </Col>
+      <Col span={8}>
+        <Form.Item
+          name="case_uid_id"
+          label="Уникальный идентификатор дела"
+          hidden={!preTrialWatch}
+          style={highlight('case_uid_id')}
+        >
+          <Select
+            showSearch
+            allowClear
+            disabled={!isLawyer || !preTrialWatch}
+            options={caseUids.map((c) => ({ value: c.id, label: c.uid }))}
+          />
+        </Form.Item>
         </Col>
       </Row>
       <Row gutter={16}>


### PR DESCRIPTION
## Summary
- pre-trial claim fields should be editable only by LAWYER role
- disable switch and related field when role is not LAWYER

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e271835b0832e8ec72d5cdd684a5a