### PR TITLE
Restrict pre-trial switch by role

### DIFF
--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -85,6 +85,8 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
   const notify = useNotify();
   const createDefects = useCreateDefects();
   const role = useAuthStore((s) => s.profile?.role as RoleName | undefined);
+  /** Пользователь может менять признак досудебной претензии */
+  const canEditPreTrial = role === 'LAWYER' || role === 'ADMIN';
   const defectsWatch = Form.useWatch('defects', form);
   const acceptedOnWatch = Form.useWatch('accepted_on', form) ?? null;
   const { data: caseUids = [] } = useCaseUids();
@@ -219,7 +221,7 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
             label="Досудебная претензия"
             valuePropName="checked"
           >
-            <Switch />
+            <Switch disabled={!canEditPreTrial} />
           </Form.Item>
         </Col>
         <Col span={8}>
@@ -231,7 +233,7 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
             <Select
               showSearch
               allowClear
-              disabled={!preTrialWatch}
+              disabled={!preTrialWatch || !canEditPreTrial}
               options={caseUids.map((c) => ({ value: c.id, label: c.uid }))}
             />
           </Form.Item>

--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -89,6 +89,8 @@ const ClaimFormAntdEdit = React.forwardRef<
 ) {
   const [form] = Form.useForm<ClaimFormAntdEditValues>();
   const role = useAuthStore((s) => s.profile?.role as RoleName | undefined);
+  /** Разрешено ли редактирование признака досудебной претензии */
+  const canEditPreTrial = role === 'LAWYER' || role === 'ADMIN';
   const { data: perm } = useRolePermission(role);
   const claimAssigned = useClaim(claimId);
   const claimAll = useClaimAll(claimId);
@@ -221,7 +223,7 @@ const ClaimFormAntdEdit = React.forwardRef<
             valuePropName="checked"
             style={highlight('pre_trial_claim')}
           >
-            <Switch />
+            <Switch disabled={!canEditPreTrial} />
           </Form.Item>
         </Col>
         <Col span={8}>
@@ -234,7 +236,7 @@ const ClaimFormAntdEdit = React.forwardRef<
             <Select
               showSearch
               allowClear
-              disabled={!preTrialWatch}
+              disabled={!preTrialWatch || !canEditPreTrial}
               options={caseUids.map((c) => ({ value: c.id, label: c.uid }))}
             />
           </Form.Item>


### PR DESCRIPTION
## Summary
- restrict the 'Досудебная претензия' switch by role when creating and editing claims

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_685ec8fd2010832eb3476f206494335c