### PR TITLE
Add pretrial claim permission toggle

### DIFF
--- a/src/entities/rolePermission.ts
+++ b/src/entities/rolePermission.ts
@@ -4,7 +4,8 @@ import type { RolePermission, RoleName } from '@/shared/types/rolePermission';
 import { DEFAULT_ROLE_PERMISSIONS } from '@/shared/types/rolePermission';
 
 const TABLE = 'role_permissions';
-const FIELDS = 'role_name, pages, edit_tables, delete_tables, only_assigned_project';
+const FIELDS =
+  'role_name, pages, edit_tables, delete_tables, only_assigned_project, allow_pretrial_claim';
 
 /** Получить настройки ролей */
 export const useRolePermissions = () =>

--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -26,6 +26,7 @@ import DefectEditableTable from '@/widgets/DefectEditableTable';
 import { useCreateDefects, type NewDefect } from '@/entities/defect';
 import { useAuthStore } from '@/shared/store/authStore';
 import type { RoleName } from '@/shared/types/rolePermission';
+import { useRolePermission } from '@/entities/rolePermission';
 import { useCaseUids } from '@/entities/caseUid';
 import useProjectBuildings from '@/shared/hooks/useProjectBuildings';
 
@@ -85,6 +86,7 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
   const notify = useNotify();
   const createDefects = useCreateDefects();
   const role = useAuthStore((s) => s.profile?.role as RoleName | undefined);
+  const { data: perm } = useRolePermission(role);
   const defectsWatch = Form.useWatch('defects', form);
   const acceptedOnWatch = Form.useWatch('accepted_on', form) ?? null;
   const { data: caseUids = [] } = useCaseUids();
@@ -213,16 +215,16 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
     <>
     <Form form={form} layout="vertical" onFinish={onFinish} autoComplete="off">
       <Row gutter={16}>
-        <Col span={8}>
+        <Col span={8} hidden={!perm?.allow_pretrial_claim}>
           <Form.Item
             name="pre_trial_claim"
             label="Досудебная претензия"
             valuePropName="checked"
           >
-            <Switch />
+            <Switch disabled={!perm?.allow_pretrial_claim} />
           </Form.Item>
         </Col>
-        <Col span={8}>
+        <Col span={8} hidden={!perm?.allow_pretrial_claim}>
           <Form.Item
             name="case_uid_id"
             label="Уникальный идентификатор дела"
@@ -231,7 +233,7 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
             <Select
               showSearch
               allowClear
-              disabled={!preTrialWatch}
+              disabled={!preTrialWatch || !perm?.allow_pretrial_claim}
               options={caseUids.map((c) => ({ value: c.id, label: c.uid }))}
             />
           </Form.Item>

--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -214,17 +214,17 @@ const ClaimFormAntdEdit = React.forwardRef<
       autoComplete="off"
     >
       <Row gutter={16}>
-        <Col span={8}>
+        <Col span={8} hidden={!perm?.allow_pretrial_claim}>
           <Form.Item
             name="pre_trial_claim"
             label="Досудебная претензия"
             valuePropName="checked"
             style={highlight('pre_trial_claim')}
           >
-            <Switch />
+            <Switch disabled={!perm?.allow_pretrial_claim} />
           </Form.Item>
         </Col>
-        <Col span={8}>
+        <Col span={8} hidden={!perm?.allow_pretrial_claim}>
           <Form.Item
             name="case_uid_id"
             label="Уникальный идентификатор дела"
@@ -234,7 +234,7 @@ const ClaimFormAntdEdit = React.forwardRef<
             <Select
               showSearch
               allowClear
-              disabled={!preTrialWatch}
+              disabled={!preTrialWatch || !perm?.allow_pretrial_claim}
               options={caseUids.map((c) => ({ value: c.id, label: c.uid }))}
             />
           </Form.Item>

--- a/src/shared/types/rolePermission.ts
+++ b/src/shared/types/rolePermission.ts
@@ -5,6 +5,8 @@ export interface RolePermission {
   delete_tables: string[];
   /** Ограничить видимость только назначенным проектом */
   only_assigned_project: boolean;
+  /** Разрешить работу с досудебными претензиями */
+  allow_pretrial_claim: boolean;
 }
 
 export type RoleName = 'ADMIN' | 'ENGINEER' | 'LAWYER' | 'CONTRACTOR';
@@ -25,6 +27,7 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<RoleName, RolePermission> = {
     edit_tables: ['defects', 'court_cases', 'letters', 'claims'],
     delete_tables: ['defects', 'court_cases', 'letters', 'claims'],
     only_assigned_project: false,
+    allow_pretrial_claim: true,
   },
   ENGINEER: {
     role_name: 'ENGINEER',
@@ -33,6 +36,7 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<RoleName, RolePermission> = {
     edit_tables: ['defects', 'letters', 'claims'],
     delete_tables: ['defects', 'letters', 'claims'],
     only_assigned_project: false,
+    allow_pretrial_claim: true,
   },
   LAWYER: {
     role_name: 'LAWYER',
@@ -40,6 +44,7 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<RoleName, RolePermission> = {
     edit_tables: ['court_cases', 'letters'],
     delete_tables: ['court_cases', 'letters'],
     only_assigned_project: false,
+    allow_pretrial_claim: true,
   },
   CONTRACTOR: {
     role_name: 'CONTRACTOR',
@@ -47,5 +52,6 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<RoleName, RolePermission> = {
     edit_tables: [],
     delete_tables: [],
     only_assigned_project: false,
+    allow_pretrial_claim: true,
   },
 };

--- a/src/widgets/RolePermissionsAdmin.tsx
+++ b/src/widgets/RolePermissionsAdmin.tsx
@@ -47,6 +47,11 @@ export default function RolePermissionsAdmin() {
     upsert.mutate({ ...current, only_assigned_project: value });
   };
 
+  const handlePretrialToggle = (role: RoleName, value: boolean) => {
+    const current = merged.find((m) => m.role_name === role)!;
+    upsert.mutate({ ...current, allow_pretrial_claim: value });
+  };
+
   const columns: ColumnsType<RolePermission> = [
     {
       title: 'Роль',
@@ -61,6 +66,19 @@ export default function RolePermissionsAdmin() {
           checked={record.only_assigned_project}
           onChange={(checked) =>
             handleProjectToggle(record.role_name as RoleName, checked)
+          }
+        />
+      ),
+    },
+    {
+      title: 'Досудебные претензии',
+      dataIndex: 'allow_pretrial_claim',
+      render: (_, record) => (
+        <Switch
+          size="small"
+          checked={record.allow_pretrial_claim}
+          onChange={(checked) =>
+            handlePretrialToggle(record.role_name as RoleName, checked)
           }
         />
       ),


### PR DESCRIPTION
## Summary
- add `allow_pretrial_claim` to role permissions types
- include new field in role permissions API
- show toggle for pretrial claims in admin
- hide pretrial claim controls in claim forms if forbidden

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ee0c04bb0832e87e2a25ab9da5552