### PR TITLE
Add resizable columns to claims table

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-router-dom": "^7.5.2",
     "react-table": "^7.8.0",
     "react-window": "^1.8.11",
+    "react-resizable": "^3.0.5",
     "slugify": "^1.6.6",
     "yup": "^1.6.1",
     "zod": "^3.24.3",

--- a/src/index.css
+++ b/src/index.css
@@ -128,3 +128,14 @@ body {
   padding: 4px;
   border-radius: 2px;
 }
+
+/* Ручка изменения ширины колонок таблицы */
+.resize-handle {
+  position: absolute;
+  right: -5px;
+  top: 0;
+  bottom: 0;
+  width: 10px;
+  cursor: col-resize;
+  z-index: 1;
+}

--- a/src/shared/hooks/useResizableColumns.tsx
+++ b/src/shared/hooks/useResizableColumns.tsx
@@ -1,0 +1,69 @@
+import { useState, useEffect, useMemo } from 'react';
+import { Resizable } from 'react-resizable';
+import type { ColumnsType } from 'antd/es/table';
+
+export interface UseResizableColumnsResult<T> {
+  /** Колонки с возможностью изменения ширины */
+  columns: ColumnsType<T>;
+  /** Компоненты таблицы для Ant Design */
+  components: Record<string, any>;
+  /** Установить новое состояние колонок */
+  setColumns: React.Dispatch<React.SetStateAction<ColumnsType<T>>>;
+}
+
+/**
+ * Хук добавляет возможность изменять ширину колонок Ant Design таблицы.
+ * @param initial исходный массив колонок
+ */
+export function useResizableColumns<T>(
+  initial: ColumnsType<T>,
+): UseResizableColumnsResult<T> {
+  const [cols, setCols] = useState(initial);
+
+  useEffect(() => setCols(initial), [initial]);
+
+  const handleResize = (index: number) => (_: any, { size }: any) => {
+    setCols((prev) => {
+      const next = [...prev];
+      next[index] = { ...next[index], width: size.width };
+      return next;
+    });
+  };
+
+  const columns = useMemo(
+    () =>
+      cols.map((col, index) => ({
+        ...col,
+        onHeaderCell: (column: any) => ({
+          width: column.width,
+          onResize: handleResize(index),
+        }),
+      })),
+    [cols],
+  );
+
+  const components = useMemo(
+    () => ({
+      header: {
+        cell: (props: any) => {
+          const { onResize, width, ...rest } = props;
+          if (!width) return <th {...rest} />;
+          return (
+            <Resizable
+              width={width}
+              height={0}
+              handle={<span className="resize-handle" />}
+              onResize={onResize}
+              draggableOpts={{ enableUserSelectHack: false }}
+            >
+              <th {...rest} />
+            </Resizable>
+          );
+        },
+      },
+    }),
+    [],
+  );
+
+  return { columns, components, setColumns: setCols };
+}

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -14,6 +14,7 @@ import { useDeleteClaim } from '@/entities/claim';
 import type { ClaimFilters } from '@/shared/types/claimFilters';
 import type { ClaimWithNames } from '@/shared/types/claimWithNames';
 import ClaimStatusSelect from '@/features/claim/ClaimStatusSelect';
+import { useResizableColumns } from '@/shared/hooks/useResizableColumns';
 
 const fmt = (d: any) => (d && dayjs.isDayjs(d) && d.isValid() ? d.format('DD.MM.YYYY') : '—');
 
@@ -109,7 +110,8 @@ export default function ClaimsTable({
     [onView, remove, isPending],
   );
 
-  const columns = columnsProp ?? defaultColumns;
+  const { columns: columnsWithResize, components } =
+    useResizableColumns(columnsProp ?? defaultColumns);
 
   const filtered = useMemo(() => {
     return claims.filter((c) => {
@@ -176,7 +178,8 @@ export default function ClaimsTable({
   return (
     <Table
       rowKey="id"
-      columns={columns}
+      columns={columnsWithResize}
+      components={components}
       dataSource={treeData}
       loading={loading}
       pagination={{


### PR DESCRIPTION
## Summary
- enable column width adjustments via useResizableColumns hook
- integrate resizable columns in ClaimsTable
- style resize handle

## Testing
- `npm run lint`
- `npm test`
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_685ee11ad948832e8d4cd67e8e543f01