### PR TITLE
Add pretrial claim permission toggle

### DIFF
--- a/src/entities/rolePermission.ts
+++ b/src/entities/rolePermission.ts
@@ -4,7 +4,8 @@ import type { RolePermission, RoleName } from '@/shared/types/rolePermission';
 import { DEFAULT_ROLE_PERMISSIONS } from '@/shared/types/rolePermission';
 
 const TABLE = 'role_permissions';
-const FIELDS = 'role_name, pages, edit_tables, delete_tables, only_assigned_project';
+const FIELDS =
+  'role_name, pages, edit_tables, delete_tables, only_assigned_project';
 
 /** Получить настройки ролей */
 export const useRolePermissions = () =>

--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -26,6 +26,8 @@ import DefectEditableTable from '@/widgets/DefectEditableTable';
 import { useCreateDefects, type NewDefect } from '@/entities/defect';
 import { useAuthStore } from '@/shared/store/authStore';
 import type { RoleName } from '@/shared/types/rolePermission';
+import { useRolePermission } from '@/entities/rolePermission';
+import { PRETRIAL_FLAG } from '@/shared/types/rolePermission';
 import { useCaseUids } from '@/entities/caseUid';
 import useProjectBuildings from '@/shared/hooks/useProjectBuildings';
 
@@ -85,6 +87,8 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
   const notify = useNotify();
   const createDefects = useCreateDefects();
   const role = useAuthStore((s) => s.profile?.role as RoleName | undefined);
+  const { data: perm } = useRolePermission(role);
+  const allowPretrial = perm?.pages.includes(PRETRIAL_FLAG);
   const defectsWatch = Form.useWatch('defects', form);
   const acceptedOnWatch = Form.useWatch('accepted_on', form) ?? null;
   const { data: caseUids = [] } = useCaseUids();
@@ -213,16 +217,16 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
     <>
     <Form form={form} layout="vertical" onFinish={onFinish} autoComplete="off">
       <Row gutter={16}>
-        <Col span={8}>
+        <Col span={8} hidden={!allowPretrial}>
           <Form.Item
             name="pre_trial_claim"
             label="Досудебная претензия"
             valuePropName="checked"
           >
-            <Switch />
+            <Switch disabled={!allowPretrial} />
           </Form.Item>
         </Col>
-        <Col span={8}>
+        <Col span={8} hidden={!allowPretrial}>
           <Form.Item
             name="case_uid_id"
             label="Уникальный идентификатор дела"
@@ -231,7 +235,7 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
             <Select
               showSearch
               allowClear
-              disabled={!preTrialWatch}
+              disabled={!preTrialWatch || !allowPretrial}
               options={caseUids.map((c) => ({ value: c.id, label: c.uid }))}
             />
           </Form.Item>

--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -35,6 +35,7 @@ import { useProjectId } from '@/shared/hooks/useProjectId';
 import { useAuthStore } from '@/shared/store/authStore';
 import { useRolePermission } from '@/entities/rolePermission';
 import type { RoleName } from '@/shared/types/rolePermission';
+import { PRETRIAL_FLAG } from '@/shared/types/rolePermission';
 import { useChangedFields } from '@/shared/hooks/useChangedFields';
 import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
 import FileDropZone from '@/shared/ui/FileDropZone';
@@ -90,6 +91,7 @@ const ClaimFormAntdEdit = React.forwardRef<
   const [form] = Form.useForm<ClaimFormAntdEditValues>();
   const role = useAuthStore((s) => s.profile?.role as RoleName | undefined);
   const { data: perm } = useRolePermission(role);
+  const allowPretrial = perm?.pages.includes(PRETRIAL_FLAG);
   const claimAssigned = useClaim(claimId);
   const claimAll = useClaimAll(claimId);
   const claim = perm?.only_assigned_project ? claimAssigned.data : claimAll.data;
@@ -214,17 +216,17 @@ const ClaimFormAntdEdit = React.forwardRef<
       autoComplete="off"
     >
       <Row gutter={16}>
-        <Col span={8}>
+        <Col span={8} hidden={!allowPretrial}>
           <Form.Item
             name="pre_trial_claim"
             label="Досудебная претензия"
             valuePropName="checked"
             style={highlight('pre_trial_claim')}
           >
-            <Switch />
+            <Switch disabled={!allowPretrial} />
           </Form.Item>
         </Col>
-        <Col span={8}>
+        <Col span={8} hidden={!allowPretrial}>
           <Form.Item
             name="case_uid_id"
             label="Уникальный идентификатор дела"
@@ -234,7 +236,7 @@ const ClaimFormAntdEdit = React.forwardRef<
             <Select
               showSearch
               allowClear
-              disabled={!preTrialWatch}
+              disabled={!preTrialWatch || !allowPretrial}
               options={caseUids.map((c) => ({ value: c.id, label: c.uid }))}
             />
           </Form.Item>

--- a/src/shared/types/rolePermission.ts
+++ b/src/shared/types/rolePermission.ts
@@ -7,6 +7,9 @@ export interface RolePermission {
   only_assigned_project: boolean;
 }
 
+/** Специальная отметка в массиве pages для разрешения досудебных претензий */
+export const PRETRIAL_FLAG = 'pretrial-claim';
+
 export type RoleName = 'ADMIN' | 'ENGINEER' | 'LAWYER' | 'CONTRACTOR';
 
 export const DEFAULT_ROLE_PERMISSIONS: Record<RoleName, RolePermission> = {
@@ -20,6 +23,7 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<RoleName, RolePermission> = {
       'court-cases',
       'correspondence',
       'admin',
+      PRETRIAL_FLAG,
     ],
     // Администратор имеет полные права на все справочники
     edit_tables: ['defects', 'court_cases', 'letters', 'claims'],
@@ -28,7 +32,15 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<RoleName, RolePermission> = {
   },
   ENGINEER: {
     role_name: 'ENGINEER',
-    pages: ['dashboard', 'structure', 'claims', 'defects', 'court-cases', 'correspondence'],
+    pages: [
+      'dashboard',
+      'structure',
+      'claims',
+      'defects',
+      'court-cases',
+      'correspondence',
+      PRETRIAL_FLAG,
+    ],
     // Инженер теперь может управлять претензиями
     edit_tables: ['defects', 'letters', 'claims'],
     delete_tables: ['defects', 'letters', 'claims'],
@@ -36,14 +48,22 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<RoleName, RolePermission> = {
   },
   LAWYER: {
     role_name: 'LAWYER',
-    pages: ['dashboard', 'structure', 'claims', 'defects', 'court-cases', 'correspondence'],
+    pages: [
+      'dashboard',
+      'structure',
+      'claims',
+      'defects',
+      'court-cases',
+      'correspondence',
+      PRETRIAL_FLAG,
+    ],
     edit_tables: ['court_cases', 'letters'],
     delete_tables: ['court_cases', 'letters'],
     only_assigned_project: false,
   },
   CONTRACTOR: {
     role_name: 'CONTRACTOR',
-    pages: ['defects'],
+    pages: ['defects', PRETRIAL_FLAG],
     edit_tables: [],
     delete_tables: [],
     only_assigned_project: false,

--- a/src/widgets/RolePermissionsAdmin.tsx
+++ b/src/widgets/RolePermissionsAdmin.tsx
@@ -6,7 +6,7 @@ import {
   useUpsertRolePermission,
 } from '@/entities/rolePermission';
 import type { RolePermission, RoleName } from '@/shared/types/rolePermission';
-import { DEFAULT_ROLE_PERMISSIONS } from '@/shared/types/rolePermission';
+import { DEFAULT_ROLE_PERMISSIONS, PRETRIAL_FLAG } from '@/shared/types/rolePermission';
 
 const PAGES = [
   'dashboard',
@@ -47,6 +47,14 @@ export default function RolePermissionsAdmin() {
     upsert.mutate({ ...current, only_assigned_project: value });
   };
 
+  const handlePretrialToggle = (role: RoleName, value: boolean) => {
+    const current = merged.find((m) => m.role_name === role)!;
+    const pages = new Set(current.pages);
+    if (value) pages.add(PRETRIAL_FLAG);
+    else pages.delete(PRETRIAL_FLAG);
+    upsert.mutate({ ...current, pages: Array.from(pages) });
+  };
+
   const columns: ColumnsType<RolePermission> = [
     {
       title: 'Роль',
@@ -61,6 +69,18 @@ export default function RolePermissionsAdmin() {
           checked={record.only_assigned_project}
           onChange={(checked) =>
             handleProjectToggle(record.role_name as RoleName, checked)
+          }
+        />
+      ),
+    },
+    {
+      title: 'Досудебные претензии',
+      render: (_, record) => (
+        <Switch
+          size="small"
+          checked={record.pages.includes(PRETRIAL_FLAG)}
+          onChange={(checked) =>
+            handlePretrialToggle(record.role_name as RoleName, checked)
           }
         />
       ),


### PR DESCRIPTION
## Summary
- store pretrial access in `pages` array
- expose `PRETRIAL_FLAG` constant
- update admin widget to toggle flag
- hide controls for pretrial claim if flag absent

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ee0c04bb0832e87e2a25ab9da5552