### PR TITLE
Add resizable columns for defects table

### DIFF
--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -216,11 +216,13 @@ export default function DefectsPage() {
       id: {
         title: "ID дефекта",
         dataIndex: "id",
+        width: 80,
         sorter: (a: DefectWithInfo, b: DefectWithInfo) => a.id - b.id,
       },
       claims: {
         title: "ID претензии",
         dataIndex: "claimIds",
+        width: 120,
         sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
           a.claimIds.join(",").localeCompare(b.claimIds.join(",")),
         render: (v: number[]) => v.join(", "),
@@ -233,24 +235,28 @@ export default function DefectsPage() {
           </span>
         ),
         dataIndex: "days",
+        width: 120,
         sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
           (a.days ?? -1) - (b.days ?? -1),
       },
       project: {
         title: "Проект",
         dataIndex: "projectNames",
+        width: 180,
         sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
           (a.projectNames || "").localeCompare(b.projectNames || ""),
       },
       building: {
         title: "Корпус",
         dataIndex: "buildingNames",
+        width: 120,
         sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
           (a.buildingNames || "").localeCompare(b.buildingNames || ""),
       },
       units: {
         title: "Объекты",
         dataIndex: "unitNamesList",
+        width: 160,
         sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
           (a.unitNames || "").localeCompare(b.unitNames || ""),
         render: (_: string[], row: DefectWithInfo) => (
@@ -266,18 +272,21 @@ export default function DefectsPage() {
       description: {
         title: "Описание",
         dataIndex: "description",
+        width: 220,
         sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
           a.description.localeCompare(b.description),
       },
       type: {
         title: "Тип",
         dataIndex: "defectTypeName",
+        width: 120,
         sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
           (a.defectTypeName || "").localeCompare(b.defectTypeName || ""),
       },
       status: {
         title: "Статус",
         dataIndex: "status_id",
+        width: 160,
         sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
           (a.defectStatusName || "").localeCompare(b.defectStatusName || ""),
         render: (_: number, row: DefectWithInfo) => (
@@ -292,12 +301,14 @@ export default function DefectsPage() {
       fixBy: {
         title: "Кем устраняется",
         dataIndex: "fixByName",
+        width: 180,
         sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
           (a.fixByName || "").localeCompare(b.fixByName || ""),
       },
       received: {
         title: "Дата получения",
         dataIndex: "received_at",
+        width: 120,
         sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
           (a.received_at ? dayjs(a.received_at).valueOf() : 0) -
           (b.received_at ? dayjs(b.received_at).valueOf() : 0),
@@ -306,6 +317,7 @@ export default function DefectsPage() {
       created: {
         title: "Дата устранения",
         dataIndex: "fixed_at",
+        width: 120,
         sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
           (a.fixed_at ? dayjs(a.fixed_at).valueOf() : 0) -
           (b.fixed_at ? dayjs(b.fixed_at).valueOf() : 0),

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -16,6 +16,7 @@ import DefectStatusSelect from "@/features/defect/DefectStatusSelect";
 import type { DefectWithInfo } from "@/shared/types/defect";
 import type { DefectFilters } from "@/shared/types/defectFilters";
 import { filterDefects } from "@/shared/utils/defectFilter";
+import { useResizableColumns } from "@/shared/hooks/useResizableColumns";
 
 const fmt = (v: string | null) => (v ? dayjs(v).format("DD.MM.YYYY") : "—");
 
@@ -45,11 +46,13 @@ export default function DefectsTable({
     {
       title: "ID дефекта",
       dataIndex: "id",
+      width: 80,
       sorter: (a, b) => a.id - b.id,
     },
     {
       title: "ID претензии",
       dataIndex: "claimIds",
+      width: 120,
       sorter: (a, b) =>
         a.claimIds.join(",").localeCompare(b.claimIds.join(",")),
       render: (v: number[]) => v.join(", "),
@@ -62,23 +65,27 @@ export default function DefectsTable({
         </span>
       ),
       dataIndex: "days",
+      width: 120,
       sorter: (a, b) => (a.days ?? -1) - (b.days ?? -1),
     },
     {
       title: "Проект",
       dataIndex: "projectNames",
+      width: 180,
       sorter: (a, b) =>
         (a.projectNames || "").localeCompare(b.projectNames || ""),
     },
     {
       title: "Корпус",
       dataIndex: "buildingNames",
+      width: 120,
       sorter: (a, b) =>
         (a.buildingNames || "").localeCompare(b.buildingNames || ""),
     },
     {
       title: "Объекты",
       dataIndex: "unitNamesList",
+      width: 160,
       sorter: (a, b) => (a.unitNames || "").localeCompare(b.unitNames || ""),
       render: (_: string[], row) => (
         <>
@@ -93,17 +100,20 @@ export default function DefectsTable({
     {
       title: "Описание",
       dataIndex: "description",
+      width: 220,
       sorter: (a, b) => a.description.localeCompare(b.description),
     },
     {
       title: "Тип",
       dataIndex: "defectTypeName",
+      width: 120,
       sorter: (a, b) =>
         (a.defectTypeName || "").localeCompare(b.defectTypeName || ""),
     },
     {
       title: "Статус",
       dataIndex: "status_id",
+      width: 160,
       sorter: (a, b) =>
         (a.defectStatusName || "").localeCompare(b.defectStatusName || ""),
       render: (_: number, row) => (
@@ -118,11 +128,13 @@ export default function DefectsTable({
     {
       title: "Кем устраняется",
       dataIndex: "fixByName",
+      width: 180,
       sorter: (a, b) => (a.fixByName || "").localeCompare(b.fixByName || ""),
     },
     {
       title: "Дата получения",
       dataIndex: "received_at",
+      width: 120,
       sorter: (a, b) =>
         (a.received_at ? dayjs(a.received_at).valueOf() : 0) -
         (b.received_at ? dayjs(b.received_at).valueOf() : 0),
@@ -131,6 +143,7 @@ export default function DefectsTable({
     {
       title: "Дата устранения",
       dataIndex: "fixed_at",
+      width: 120,
       sorter: (a, b) =>
         (a.fixed_at ? dayjs(a.fixed_at).valueOf() : 0) -
         (b.fixed_at ? dayjs(b.fixed_at).valueOf() : 0),
@@ -173,7 +186,8 @@ export default function DefectsTable({
     },
   ];
 
-  const columns = columnsProp ?? defaultColumns;
+  const { columns: columnsWithResize, components } =
+    useResizableColumns(columnsProp ?? defaultColumns);
   const [pageSize, setPageSize] = React.useState(25);
 
   if (loading) return <Skeleton active paragraph={{ rows: 6 }} />;
@@ -192,7 +206,8 @@ export default function DefectsTable({
   return (
     <Table
       rowKey="id"
-      columns={columns}
+      columns={columnsWithResize}
+      components={components}
       dataSource={filtered}
       pagination={{
         pageSize,


### PR DESCRIPTION
## Summary
- enable column resizing in the defects table
- add initial widths for defect table columns

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ee6d589d8832e81e824a3c6a74375