### PR TITLE
Add pagination to /structure page

### DIFF
--- a/src/pages/ProjectStructurePage/ProjectStructurePage.tsx
+++ b/src/pages/ProjectStructurePage/ProjectStructurePage.tsx
@@ -57,6 +57,9 @@ export default function ProjectStructurePage() {
 
     const { projectCount, buildingCount } = useUnitsCount(projectId, building);
 
+    const [page, setPage] = useState(1);
+    const PAGE_SIZE = 50;
+
     const deleteBuildingMutation = useDeleteUnitsByBuilding();
 
     // Автоматический выбор проекта и корпуса при загрузке
@@ -95,6 +98,10 @@ export default function ProjectStructurePage() {
             LS_KEY,
             JSON.stringify({ projectId, building }),
         );
+    }, [projectId, building]);
+
+    useEffect(() => {
+        setPage(1);
     }, [projectId, building]);
 
     // --- Диалоги ---
@@ -364,7 +371,13 @@ export default function ProjectStructurePage() {
             )}
 
             {projectId && building && buildings.length > 0 && (
-                <UnitsMatrix projectId={projectId} building={building} />
+                <UnitsMatrix
+                    projectId={projectId}
+                    building={building}
+                    page={page}
+                    pageSize={PAGE_SIZE}
+                    onPageChange={setPage}
+                />
             )}
             <StatusLegend />
         </Stack>

--- a/src/shared/types/unitsMatrix.ts
+++ b/src/shared/types/unitsMatrix.ts
@@ -11,4 +11,6 @@ export interface UnitsMatrixData {
   lettersByUnit: Record<string | number, boolean>;
   /** Информация о претензиях по квартирам */
   claimsByUnit: Record<string | number, import('./unitClaimInfo').UnitClaimInfo>;
+  /** Общее количество квартир в корпусе */
+  total: number;
 }

--- a/src/widgets/UnitsMatrix/UnitsMatrix.tsx
+++ b/src/widgets/UnitsMatrix/UnitsMatrix.tsx
@@ -11,7 +11,7 @@ import {
   Typography,
   Tooltip,
 } from "@mui/material";
-import { Modal, Button as AntButton, ConfigProvider } from 'antd';
+import { Modal, Button as AntButton, ConfigProvider, Pagination, Skeleton } from 'antd';
 import ruRU from 'antd/locale/ru_RU';
 import AddIcon from "@mui/icons-material/Add";
 import FloorCell from "@/entities/floor/FloorCell";
@@ -34,10 +34,16 @@ export default function UnitsMatrix({
   projectId,
   building,
   onUnitsChanged,
+  page = 1,
+  pageSize = 50,
+  onPageChange,
 }: {
   projectId: number | string;
   building?: string | null;
   onUnitsChanged?: (units: any[]) => void;
+  page?: number;
+  pageSize?: number;
+  onPageChange?: (p: number) => void;
 }) {
   const {
     floors,
@@ -49,7 +55,9 @@ export default function UnitsMatrix({
     lettersByUnit,
     claimsByUnit,
     units,
-  } = useUnitsMatrix(projectId, building);
+    total,
+    isLoading,
+  } = useUnitsMatrix(projectId, building, page, pageSize);
   const navigate = useNavigate();
   const profileId = useAuthStore((s) => s.profile?.id);
 
@@ -178,6 +186,10 @@ export default function UnitsMatrix({
     }
     return map;
   }, [unitsByFloor, sortDirections]);
+
+  if (isLoading) {
+    return <Skeleton active paragraph={{ rows: 4 }} />;
+  }
 
   if (!floors.length) {
     return (
@@ -421,6 +433,13 @@ export default function UnitsMatrix({
           )}
         </Modal>
       </ConfigProvider>
+      <Pagination
+        style={{ marginTop: 16 }}
+        current={page}
+        pageSize={pageSize}
+        total={total}
+        onChange={onPageChange}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- extend `UnitsMatrixData` with total field
- paginate units retrieval in `useUnitsMatrix`
- render pagination controls in `UnitsMatrix`
- manage pagination state on `ProjectStructurePage`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685eea356dd8832e9cf1a02e90ab4d61