### PR TITLE
Implement paginated claims loading

### DIFF
--- a/src/entities/claim.ts
+++ b/src/entities/claim.ts
@@ -10,6 +10,7 @@ import type { ClaimWithNames } from '@/shared/types/claimWithNames';
 import type { ClaimDeleteParams } from '@/shared/types/claimDelete';
 import type { ClaimDefect } from '@/shared/types/claimDefect';
 import type { ClaimSimple } from '@/shared/types/claimSimple';
+import type { PagedResult } from '@/shared/types/pagedResult';
 import {
   addClaimAttachments,
   getAttachmentsByIds,
@@ -411,6 +412,121 @@ export function useClaimsSimple() {
         defect_ids: defectMap[r.id] ?? [],
         claim_defects: claimDefectMap[r.id] ?? [],
       })) as ClaimSimple[];
+    },
+    staleTime: 5 * 60_000,
+  });
+}
+
+/**
+ * Получить список претензий постранично.
+ */
+export function useClaimsPage(page: number, pageSize: number) {
+  const { projectId, projectIds, onlyAssigned, enabled } = useProjectFilter();
+  return useQuery({
+    queryKey: [TABLE, 'page', page, pageSize, projectId, projectIds.join(',')],
+    enabled,
+    keepPreviousData: true,
+    queryFn: async () => {
+      let q: any = supabase
+        .from(TABLE)
+        .select(
+          `id, project_id, claim_status_id, claim_no, claimed_on,
+          accepted_on, registered_on, resolved_on,
+          engineer_id, owner, case_uid_id, pre_trial_claim, description, created_at,
+          projects (id, name),
+          statuses (id, name, color),
+          claim_units(unit_id),
+          claim_defects(defect_id),
+          claim_attachments(attachments(id, storage_path, file_url:path, file_type:mime_type, original_name))`,
+          { count: 'exact' },
+        );
+      q = filterByProjects(q, projectId, projectIds, onlyAssigned);
+      q = q.order('created_at', { ascending: false });
+      const from = (page - 1) * pageSize;
+      const to = from + pageSize - 1;
+      q = q.range(from, to);
+      const { data, error, count } = await q;
+      if (error && error.code !== 'PGRST103') throw error;
+      if (error && error.code === 'PGRST103') {
+        return { total: count ?? 0, data: [] } as PagedResult<ClaimWithNames>;
+      }
+      const ids = (data ?? []).map((r: any) => r.id);
+      const { data: links } = ids.length
+        ? await supabase
+            .from(LINK_TABLE)
+            .select('parent_id, child_id')
+            .in('child_id', ids)
+        : { data: [] };
+      const linkMap = new Map<number, number>();
+      (links ?? []).forEach((l: any) => linkMap.set(l.child_id, l.parent_id));
+      return {
+        total: count ?? 0,
+        data: (data ?? []).map((r: any) =>
+          mapClaim({
+            ...r,
+            parent_id: linkMap.get(r.id) ?? null,
+            unit_ids: (r.claim_units ?? []).map((u: any) => u.unit_id),
+            defect_ids: (r.claim_defects ?? []).map((d: any) => d.defect_id),
+            attachments: (r.claim_attachments ?? []).map((a: any) => a.attachments),
+          }),
+        ),
+      } as PagedResult<ClaimWithNames>;
+    },
+    staleTime: 5 * 60_000,
+  });
+}
+
+/**
+ * Получить список претензий по всем проектам постранично.
+ */
+export function useClaimsPageAll(page: number, pageSize: number) {
+  return useQuery({
+    queryKey: ['claims-all-page', page, pageSize],
+    keepPreviousData: true,
+    queryFn: async () => {
+      let q: any = supabase
+        .from(TABLE)
+        .select(
+          `id, project_id, claim_status_id, claim_no, claimed_on,
+          accepted_on, registered_on, resolved_on,
+          engineer_id, owner, case_uid_id, pre_trial_claim, description, created_at,
+          projects (id, name),
+          statuses (id, name, color),
+          claim_units(unit_id),
+          claim_defects(defect_id),
+          claim_attachments(attachments(id, storage_path, file_url:path, file_type:mime_type, original_name))`,
+          { count: 'exact' },
+        )
+        .order('created_at', { ascending: false });
+      const from = (page - 1) * pageSize;
+      const to = from + pageSize - 1;
+      q = q.range(from, to);
+      const { data, error, count } = await q;
+      if (error && error.code !== 'PGRST103') throw error;
+      if (error && error.code === 'PGRST103') {
+        return { total: count ?? 0, data: [] } as PagedResult<ClaimWithNames>;
+      }
+      const ids = (data ?? []).map((r: any) => r.id);
+      const { data: links } = ids.length
+        ? await supabase
+            .from(LINK_TABLE)
+            .select('parent_id, child_id')
+            .in('child_id', ids)
+        : { data: [] };
+      const linkMap = new Map<number, number>();
+      (links ?? []).forEach((l: any) => linkMap.set(l.child_id, l.parent_id));
+      return {
+        total: count ?? 0,
+        data: (data ?? []).map((r: any) =>
+          mapClaim({
+            ...r,
+            parent_id: linkMap.get(r.id) ?? null,
+            unit_ids: (r.claim_units ?? []).map((u: any) => u.unit_id),
+            defect_ids: (r.claim_defects ?? []).map((d: any) => d.defect_id),
+            attachments: (r.claim_attachments ?? []).map((a: any) => a.attachments),
+          }),
+        ),
+      } as PagedResult<ClaimWithNames>;
     },
     staleTime: 5 * 60_000,
   });

--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -13,8 +13,8 @@ import {
 import ExportClaimsButton from '@/features/claim/ExportClaimsButton';
 import { useSnackbar } from 'notistack';
 import {
-  useClaims,
-  useClaimsAll,
+  useClaimsPage,
+  useClaimsPageAll,
   useDeleteClaim,
   useLinkClaims,
   useUnlinkClaim,
@@ -45,19 +45,32 @@ export default function ClaimsPage() {
   const { enqueueSnackbar } = useSnackbar();
   const role = useAuthStore((s) => s.profile?.role as RoleName | undefined);
   const { data: perm } = useRolePermission(role);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(25);
   const {
-    data: claimsAssigned = [],
+    data: assignedPage,
     isLoading: loadingAssigned,
     error: errorAssigned,
-  } = useClaims();
+  } = useClaimsPage(page, pageSize);
   const {
-    data: claimsAll = [],
+    data: allPage,
     isLoading: loadingAll,
     error: errorAll,
-  } = useClaimsAll();
-  const claims = perm?.only_assigned_project ? claimsAssigned : claimsAll;
+  } = useClaimsPageAll(page, pageSize);
+  const claims = perm?.only_assigned_project ? assignedPage?.data ?? [] : allPage?.data ?? [];
+  const total = perm?.only_assigned_project ? assignedPage?.total ?? 0 : allPage?.total ?? 0;
   const isLoading = perm?.only_assigned_project ? loadingAssigned : loadingAll;
   const error = errorAssigned || errorAll;
+
+  // корректировка номера страницы, если после смены размера выборки
+  // текущая страница стала выходить за пределы доступных данных
+  React.useEffect(() => {
+    const last = Math.max(1, Math.ceil(total / pageSize) || 1);
+    if (page > last) setPage(last);
+  }, [total, pageSize]);
+  React.useEffect(() => {
+    setPage(1);
+  }, [pageSize]);
   const deleteClaimMutation = useDeleteClaim();
   const { data: users = [] } = useUsers();
   const unitIds = useMemo(
@@ -333,6 +346,19 @@ export default function ClaimsPage() {
               filters={filters}
               loading={isLoading}
               columns={columns}
+              page={page}
+              pageSize={pageSize}
+              total={total}
+              onPageChange={(p, size) => {
+                const newSize = size ?? pageSize;
+                if (newSize !== pageSize) {
+                  setPageSize(newSize);
+                  setPage(1);
+                } else {
+                  const last = Math.max(1, Math.ceil(total / newSize) || 1);
+                  setPage(p > last ? last : p);
+                }
+              }}
               onView={(id) => setViewId(id)}
               onAddChild={setLinkFor}
               onUnlink={(id) => unlinkClaim.mutate(id)}

--- a/src/shared/types/pagedResult.ts
+++ b/src/shared/types/pagedResult.ts
@@ -1,0 +1,13 @@
+export interface PageParams {
+  /** Количество элементов на странице */
+  limit: number;
+  /** Сдвиг от начала выборки */
+  offset: number;
+}
+
+export interface PagedResult<T> {
+  /** Всего строк в выборке */
+  total: number;
+  /** Данные текущей страницы */
+  data: T[];
+}

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import dayjs from 'dayjs';
 import { Table, Tooltip, Space, Button, Popconfirm, message } from 'antd';
-import type { ColumnsType } from 'antd/es/table';
+import type { ColumnsType, TablePaginationConfig } from 'antd/es/table';
 import {
   EyeOutlined,
   DeleteOutlined,
@@ -24,6 +24,14 @@ interface Props {
   filters: ClaimFilters;
   loading?: boolean;
   columns?: ColumnsType<any>;
+  /** Текущий номер страницы */
+  page?: number;
+  /** Количество элементов на странице */
+  pageSize?: number;
+  /** Общее число строк */
+  total?: number;
+  /** Событие смены страницы */
+  onPageChange?: (page: number, size: number) => void;
   onView?: (id: number) => void;
   onAddChild?: (parent: ClaimWithNames) => void;
   onUnlink?: (id: number) => void;
@@ -34,6 +42,10 @@ export default function ClaimsTable({
   filters,
   loading,
   columns: columnsProp,
+  page = 1,
+  pageSize = 25,
+  total = 0,
+  onPageChange,
   onView,
   onAddChild,
   onUnlink,
@@ -157,7 +169,6 @@ export default function ClaimsTable({
   }, [filtered]);
 
   const [expandedRowKeys, setExpandedRowKeys] = React.useState<React.Key[]>([]);
-  const [pageSize, setPageSize] = React.useState(25);
 
   React.useEffect(() => {
     // По умолчанию все строки свернуты
@@ -183,10 +194,12 @@ export default function ClaimsTable({
       dataSource={treeData}
       loading={loading}
       pagination={{
+        current: page,
         pageSize,
+        total,
         showSizeChanger: true,
-        onChange: (_p, size) => size && setPageSize(size),
-      }}
+        onChange: (p, size) => onPageChange && onPageChange(p, size ?? pageSize),
+      } as TablePaginationConfig}
       size="middle"
       expandable={{
         expandRowByClick: true,


### PR DESCRIPTION
## Summary
- add generic `PagedResult` type
- implement `useClaimsPage` & `useClaimsPageAll` hooks
- support pagination props in `ClaimsTable`
- integrate pagination on `/claims` page
- ensure pagination offset fits total data
- avoid requesting non-existent pages
- reset to first page when page size changes

## Testing
- `npm test`
- `npx tsc -p tsconfig.json` *(fails: Cannot find module & other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ee9fc6048832e8883c68c2c89dc5b