### PR TITLE
Add user profile page

### DIFF
--- a/src/app/Router.tsx
+++ b/src/app/Router.tsx
@@ -16,6 +16,7 @@ import LoginPage from "@/pages/UnitsPage/LoginPage"; // ← CHANGE
 import RegisterPage from "@/pages/UnitsPage/RegisterPage"; // ← CHANGE
 import AdminPage from "@/pages/UnitsPage/AdminPage";
 import ProjectStructurePage from "@/pages/ProjectStructurePage/ProjectStructurePage";
+import ProfilePage from "@/pages/ProfilePage/ProfilePage";
 import RequirePermission from "@/shared/components/RequirePermission";
 
 /** --------------------------------------------------------------------------
@@ -125,6 +126,15 @@ export default function AppRouter() {
           </RequireAuth>
         }
         data-oid="50g:286"
+      />
+
+      <Route
+        path="/profile"
+        element={
+          <RequireAuth>
+            <ProfilePage />
+          </RequireAuth>
+        }
       />
 
 

--- a/src/entities/user.ts
+++ b/src/entities/user.ts
@@ -128,3 +128,33 @@ export const useUpdateUserProjects = () => {
     });
 };
 
+
+/** Обновить имя пользователя. */
+export const useUpdateUserName = () => {
+    const qc = useQueryClient();
+    return useMutation<User, Error, { id: string; name: string | null }>({
+        mutationFn: async ({ id, name }) => {
+            const { data, error } = await supabase
+                .from('profiles')
+                .update({ name })
+                .eq('id', id)
+                .select(FIELDS)
+                .single();
+            if (error) throw error;
+            return {
+                ...data,
+                project_ids: data?.profiles_projects?.map((p: any) => p.project_id) ?? [],
+            } as User;
+        },
+        onSuccess: () => qc.invalidateQueries({ queryKey: ['users', 'all'] }),
+    });
+};
+
+/** Сменить пароль текущего пользователя. */
+export const useChangePassword = () =>
+    useMutation<void, Error, string>({
+        mutationFn: async (password: string) => {
+            const { error } = await supabase.auth.updateUser({ password });
+            if (error) throw error;
+        },
+    });

--- a/src/features/user/ChangeNameForm.tsx
+++ b/src/features/user/ChangeNameForm.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Form, Input, Button } from 'antd';
+import { useUpdateUserName } from '@/entities/user';
+import { useAuthStore } from '@/shared/store/authStore';
+import { useNotify } from '@/shared/hooks/useNotify';
+
+/** Форма изменения имени пользователя. */
+export default function ChangeNameForm() {
+  const profile = useAuthStore((s) => s.profile)!;
+  const setProfile = useAuthStore((s) => s.setProfile);
+  const update = useUpdateUserName();
+  const notify = useNotify();
+  const [form] = Form.useForm<{ name: string | null }>();
+
+  React.useEffect(() => {
+    form.setFieldsValue({ name: profile.name });
+  }, [profile, form]);
+
+  const onSave = () => {
+    const name = form.getFieldValue('name');
+    update.mutate(
+      { id: profile.id, name },
+      {
+        onSuccess: (data) => {
+          setProfile({ ...profile, name: data.name });
+          notify.success('Имя обновлено');
+        },
+        onError: (e) => notify.error(e.message),
+      },
+    );
+  };
+
+  return (
+    <Form form={form} layout="vertical">
+      <Form.Item label="ФИО" name="name">
+        <Input />
+      </Form.Item>
+      <Form.Item>
+        <Button type="primary" onClick={onSave} loading={update.isPending}>
+          Сохранить
+        </Button>
+      </Form.Item>
+    </Form>
+  );
+}

--- a/src/features/user/ChangePasswordForm.tsx
+++ b/src/features/user/ChangePasswordForm.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Form, Input, Button, Typography } from 'antd';
+import { useChangePassword } from '@/entities/user';
+import { useNotify } from '@/shared/hooks/useNotify';
+
+/** Форма смены пароля пользователя. */
+export default function ChangePasswordForm() {
+  const [form] = Form.useForm<{ password: string }>();
+  const changePass = useChangePassword();
+  const notify = useNotify();
+
+  const onSave = () => {
+    const password = form.getFieldValue('password');
+    changePass.mutate(password, {
+      onSuccess: () => {
+        notify.success('Пароль изменён');
+        form.resetFields();
+      },
+      onError: (e) => notify.error(e.message),
+    });
+  };
+
+  return (
+    <Form form={form} layout="vertical">
+      <Form.Item
+        label="Новый пароль"
+        name="password"
+        rules={[{ required: true, min: 6, message: 'Минимум 6 символов' }]}
+      >
+        <Input.Password />
+      </Form.Item>
+      <Typography.Paragraph type="secondary">
+        Просмотр текущего пароля невозможен
+      </Typography.Paragraph>
+      <Form.Item>
+        <Button type="primary" onClick={onSave} loading={changePass.isPending}>
+          Изменить пароль
+        </Button>
+      </Form.Item>
+    </Form>
+  );
+}

--- a/src/features/user/UserProjectsEditor.tsx
+++ b/src/features/user/UserProjectsEditor.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Select, Tag, Skeleton } from 'antd';
+import { useUpdateUserProjects } from '@/entities/user';
+import { useAuthStore } from '@/shared/store/authStore';
+import type { Project } from '@/shared/types/project';
+
+/** Редактор проектов в личном кабинете. */
+export default function UserProjectsEditor({
+  projects,
+  loading = false,
+}: {
+  projects: Project[];
+  loading?: boolean;
+}) {
+  const profile = useAuthStore((s) => s.profile)!;
+  const setProjectIds = useAuthStore((s) => s.setProjectIds);
+  const update = useUpdateUserProjects();
+  const [editing, setEditing] = React.useState(false);
+
+  const options = React.useMemo(
+    () => projects.map((p) => ({ label: p.name, value: p.id })),
+    [projects],
+  );
+
+  const handleChange = (vals: number[]) => {
+    update.mutate(
+      { id: profile.id, projectIds: vals },
+      {
+        onSuccess: () => setProjectIds(vals),
+      },
+    );
+    setEditing(false);
+  };
+
+  const tags = profile.project_ids
+    .map((id) => projects.find((p) => p.id === id)?.name)
+    .filter(Boolean) as string[];
+
+  if (loading) return <Skeleton.Button active size="small" style={{ width: 160 }} />;
+
+  if (!editing) {
+    return (
+      <div onClick={() => setEditing(true)} style={{ cursor: 'pointer' }}>
+        {tags.length ? tags.map((t) => <Tag key={t}>{t}</Tag>) : <Tag>—</Tag>}
+      </div>
+    );
+  }
+
+  return (
+    <Select
+      mode="multiple"
+      size="small"
+      autoFocus
+      open
+      style={{ width: '100%' }}
+      defaultValue={profile.project_ids}
+      onBlur={() => setEditing(false)}
+      onChange={handleChange}
+      options={options}
+      loading={update.isPending}
+    />
+  );
+}

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Card, Space, Typography, Skeleton } from 'antd';
+import ChangeNameForm from '@/features/user/ChangeNameForm';
+import ChangePasswordForm from '@/features/user/ChangePasswordForm';
+import UserProjectsEditor from '@/features/user/UserProjectsEditor';
+import { useVisibleProjects } from '@/entities/project';
+import { useAuthStore } from '@/shared/store/authStore';
+
+/** Страница личного кабинета пользователя. */
+export default function ProfilePage() {
+  const profile = useAuthStore((s) => s.profile);
+  const { data: projects = [], isPending } = useVisibleProjects();
+
+  if (!profile) return <Skeleton active />;
+
+  return (
+    <Space direction="vertical" size="large" style={{ width: '100%' }}>
+      <Card title="ФИО">
+        <ChangeNameForm />
+      </Card>
+
+      <Card title="Пароль">
+        <ChangePasswordForm />
+      </Card>
+
+      <Card title="Проекты">
+        {isPending ? (
+          <Skeleton active />
+        ) : (
+          <UserProjectsEditor projects={projects} />
+        )}
+      </Card>
+
+      <Card title="Ваша роль">
+        <Typography.Text>{profile.role}</Typography.Text>
+      </Card>
+    </Space>
+  );
+}

--- a/src/shared/types/profileForm.ts
+++ b/src/shared/types/profileForm.ts
@@ -1,0 +1,12 @@
+/**
+ * Значения формы личного кабинета пользователя.
+ */
+export interface ProfileFormValues {
+  /** Полное имя пользователя */
+  name: string | null;
+  /** Новый пароль (необязательно) */
+  password?: string;
+  /** Проекты пользователя */
+  project_ids: number[];
+}
+

--- a/src/widgets/NavBar.tsx
+++ b/src/widgets/NavBar.tsx
@@ -78,17 +78,18 @@ const NavBar: React.FC = () => {
                 }}
             >
               <Space direction="vertical" size={0} align="end" style={{ flex: 1, minWidth: 0 }}>
-                <Typography.Text
-                    style={{
-                      color: '#fff',
-                      whiteSpace: 'nowrap',
-                      textOverflow: 'ellipsis',
-                      overflow: 'hidden',
-                      display: 'block',
-                    }}
-                >
-                  {profile.name ? `${profile.name} (${profile.email})` : profile.email}
-                </Typography.Text>
+                <RouterLink to="/profile" style={{ color: '#fff' }}>
+                  <Typography.Text
+                      style={{
+                        whiteSpace: 'nowrap',
+                        textOverflow: 'ellipsis',
+                        overflow: 'hidden',
+                        display: 'block',
+                      }}
+                  >
+                    {profile.name ? `${profile.name} (${profile.email})` : profile.email}
+                  </Typography.Text>
+                </RouterLink>
 
                 {perm?.only_assigned_project && (
                     isPending ? (


### PR DESCRIPTION
## Summary
- profile page to edit name, password and projects
- helper forms for profile editing
- hooks for updating profile name and password
- link username to profile

## Testing
- `npx eslint src --max-warnings=0`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f6fbd334c832e9d24fcbfe56a8daa