### PR TITLE
Add claim author info

### DIFF
--- a/src/entities/claim.ts
+++ b/src/entities/claim.ts
@@ -65,6 +65,8 @@ function mapClaim(r: any): ClaimWithNames {
     pre_trial_claim: r.pre_trial_claim ?? false,
     defect_ids: r.defect_ids ?? [],
     description: r.description ?? '',
+    created_by: r.created_by ?? null,
+    createdAt: toDayjs(r.created_at),
     projectName: r.projects?.name ?? '—',
     statusName: r.statuses?.name ?? '—',
     statusColor: r.statuses?.color ?? null,
@@ -136,7 +138,7 @@ export function useClaims() {
         .select(
           `id, project_id, claim_status_id, claim_no, claimed_on,
           accepted_on, registered_on, resolved_on,
-          engineer_id, owner, case_uid_id, pre_trial_claim, description, created_at,
+          engineer_id, owner, case_uid_id, pre_trial_claim, description, created_at, created_by,
           projects (id, name),
           case_uids(id, uid),
           statuses (id, name, color),
@@ -186,7 +188,7 @@ export function useClaim(id?: number | string) {
         .select(
           `id, project_id, claim_status_id, claim_no, claimed_on,
           accepted_on, registered_on, resolved_on,
-          engineer_id, owner, case_uid_id, pre_trial_claim, description, created_at,
+          engineer_id, owner, case_uid_id, pre_trial_claim, description, created_at, created_by,
           projects (id, name),
           case_uids(id, uid),
           statuses (id, name, color),
@@ -231,7 +233,7 @@ export function useClaimAll(id?: number | string) {
         .select(
           `id, project_id, claim_status_id, claim_no, claimed_on,
           accepted_on, registered_on, resolved_on,
-          engineer_id, owner, case_uid_id, pre_trial_claim, description, created_at,
+          engineer_id, owner, case_uid_id, pre_trial_claim, description, created_at, created_by,
           projects (id, name),
           case_uids(id, uid),
           statuses (id, name, color),
@@ -272,7 +274,7 @@ export function useClaimsAll() {
         .select(
           `id, project_id, claim_status_id, claim_no, claimed_on,
           accepted_on, registered_on, resolved_on,
-          engineer_id, owner, case_uid_id, pre_trial_claim, description, created_at,
+          engineer_id, owner, case_uid_id, pre_trial_claim, description, created_at, created_by,
           projects (id, name),
           statuses (id, name, color),
           claim_units(unit_id),

--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -105,7 +105,11 @@ export default function ClaimsPage() {
   const [showColumnsDrawer, setShowColumnsDrawer] = useState(false);
   const [columnsState, setColumnsState] = useState<TableColumnSetting[]>(() => {
     const base = getBaseColumns();
-    const defaults = Object.keys(base).map((key) => ({ key, title: base[key].title as string, visible: true }));
+    const defaults = Object.keys(base).map((key) => ({
+      key,
+      title: base[key].title as string,
+      visible: !['createdAt', 'createdByName'].includes(key),
+    }));
     return defaults;
   });
 
@@ -117,7 +121,7 @@ export default function ClaimsPage() {
     const defaults = Object.keys(base).map((key) => ({
       key,
       title: base[key].title as string,
-      visible: true,
+      visible: !['createdAt', 'createdByName'].includes(key),
     }));
     setColumnsState(defaults);
   };
@@ -162,6 +166,7 @@ export default function ClaimsPage() {
         unitNumbers: c.unit_ids.map((id) => unitNumberMap[id]).filter(Boolean).join(', '),
         buildings: Array.from(new Set(c.unit_ids.map((id) => buildingMap[id]).filter(Boolean))).join(', '),
         responsibleEngineerName: userMap[c.engineer_id] ?? null,
+        createdByName: userMap[c.created_by as string] ?? null,
       })),
     [claims, unitMap, unitNumberMap, buildingMap, userMap, checkingDefectMap],
   );
@@ -231,6 +236,8 @@ export default function ClaimsPage() {
       registeredOn: { title: 'Дата регистрации претензии', dataIndex: 'registeredOn', width: 120, sorter: (a: any, b: any) => (a.registeredOn ? a.registeredOn.valueOf() : 0) - (b.registeredOn ? b.registeredOn.valueOf() : 0), render: (v: any) => fmt(v) },
       resolvedOn: { title: 'Дата устранения', dataIndex: 'resolvedOn', width: 120, sorter: (a: any, b: any) => (a.resolvedOn ? a.resolvedOn.valueOf() : 0) - (b.resolvedOn ? b.resolvedOn.valueOf() : 0), render: (v: any) => fmt(v) },
       responsibleEngineerName: { title: 'Закрепленный инженер', dataIndex: 'responsibleEngineerName', width: 180, sorter: (a: any, b: any) => (a.responsibleEngineerName || '').localeCompare(b.responsibleEngineerName || '') },
+      createdAt: { title: 'Добавлено', dataIndex: 'createdAt', width: 120, sorter: (a: any, b: any) => (a.createdAt ? a.createdAt.valueOf() : 0) - (b.createdAt ? b.createdAt.valueOf() : 0), render: (v: any) => fmt(v) },
+      createdByName: { title: 'Автор', dataIndex: 'createdByName', width: 160, sorter: (a: any, b: any) => (a.createdByName || '').localeCompare(b.createdByName || '') },
       actions: {
         title: 'Действия',
         key: 'actions',

--- a/src/shared/types/claimWithNames.ts
+++ b/src/shared/types/claimWithNames.ts
@@ -30,4 +30,8 @@ export interface ClaimWithNames extends Claim {
   attachments?: import('./claimFile').RemoteClaimFile[];
   /** Есть связанные дефекты со статусом "На проверке" */
   hasCheckingDefect?: boolean;
+  /** Дата создания претензии */
+  createdAt: Dayjs | null;
+  /** Имя автора создания */
+  createdByName?: string | null;
 }

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -71,6 +71,8 @@ export default function ClaimsTable({
       { title: 'Дата регистрации претензии', dataIndex: 'registeredOn', width: 120, sorter: (a, b) => (a.registeredOn ? a.registeredOn.valueOf() : 0) - (b.registeredOn ? b.registeredOn.valueOf() : 0), render: (v) => fmt(v) },
       { title: 'Дата устранения', dataIndex: 'resolvedOn', width: 120, sorter: (a, b) => (a.resolvedOn ? a.resolvedOn.valueOf() : 0) - (b.resolvedOn ? b.resolvedOn.valueOf() : 0), render: (v) => fmt(v) },
       { title: 'Закрепленный инженер', dataIndex: 'responsibleEngineerName', width: 180, sorter: (a, b) => (a.responsibleEngineerName || '').localeCompare(b.responsibleEngineerName || '') },
+      { title: 'Добавлено', dataIndex: 'createdAt', width: 120, sorter: (a, b) => (a.createdAt ? a.createdAt.valueOf() : 0) - (b.createdAt ? b.createdAt.valueOf() : 0), render: (v) => fmt(v) },
+      { title: 'Автор', dataIndex: 'createdByName', width: 160, sorter: (a, b) => (a.createdByName || '').localeCompare(b.createdByName || '') },
       {
         title: 'Действия',
         key: 'actions',


### PR DESCRIPTION
## Summary
- show who and when a claim was added
- expose created fields in claim types
- hide author columns by default

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f6eed266c832eb1c54ba8ff56b18f