### PR TITLE
Add created columns on court cases

### DIFF
--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -205,6 +205,8 @@ export default function CourtCasesPage() {
     daysSinceFixStart: c.fix_start_date ? dayjs(c.fix_end_date ?? dayjs()).diff(dayjs(c.fix_start_date), 'day') : null,
     statusName: stages.find((s) => s.id === c.status)?.name ?? null,
     statusColor: stages.find((s) => s.id === c.status)?.color ?? null,
+    createdAt: c.created_at ?? null,
+    createdByName: users.find((u) => u.id === (c as any).created_by)?.name ?? null,
   }));
 
   const idOptions = React.useMemo(
@@ -367,6 +369,19 @@ export default function CourtCasesPage() {
       render: (v: string | null) => (v ? dayjs(v).format('DD.MM.YYYY') : ''),
       sorter: (a, b) => dayjs(a.fix_end_date || 0).valueOf() - dayjs(b.fix_end_date || 0).valueOf(),
     },
+    createdAt: {
+      title: 'Добавлено',
+      dataIndex: 'createdAt',
+      width: 160,
+      sorter: (a, b) => dayjs(a.createdAt || 0).valueOf() - dayjs(b.createdAt || 0).valueOf(),
+      render: (v: string | null) => (v ? dayjs(v).format('DD.MM.YYYY HH:mm') : ''),
+    },
+    createdByName: {
+      title: 'Автор',
+      dataIndex: 'createdByName',
+      width: 160,
+      sorter: (a, b) => (a.createdByName || '').localeCompare(b.createdByName || ''),
+    },
     responsibleLawyer: {
       title: 'Юрист',
       dataIndex: 'responsibleLawyer',
@@ -416,7 +431,7 @@ export default function CourtCasesPage() {
     const defaults = Object.keys(baseColumns).map((key) => ({
       key,
       title: baseColumns[key].title as string,
-      visible: true,
+      visible: !['createdAt', 'createdByName'].includes(key) ? true : false,
     }));
     try {
       const saved = localStorage.getItem(LS_COLUMNS_KEY);
@@ -435,7 +450,7 @@ export default function CourtCasesPage() {
     const defaults = Object.keys(baseColumns).map((key) => ({
       key,
       title: baseColumns[key].title as string,
-      visible: true,
+      visible: !['createdAt', 'createdByName'].includes(key) ? true : false,
     }));
     setColumnsState(defaults);
   };

--- a/src/shared/types/courtCase.ts
+++ b/src/shared/types/courtCase.ts
@@ -42,6 +42,10 @@ export interface CourtCase {
   /** Ссылки на загруженные файлы */
   attachment_ids?: number[];
   defects: Defect[];
+  /** Дата создания записи */
+  created_at?: string | null;
+  /** Автор создания */
+  created_by?: string | null;
 }
 
 /** Связь дел: parent_id - родительское дело, child_id - дочернее */


### PR DESCRIPTION
## Summary
- add `created_at` and `created_by` fields to court case type
- display optional columns "Добавлено" and "Автор" on court cases table
- hide these columns by default and allow enabling via gear icon

## Testing
- `npm run lint` *(fails: Parsing errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f7b09a550832e94da0421edb546bd