### PR TITLE
Add created info columns to court cases

### DIFF
--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -202,6 +202,8 @@ export default function CourtCasesPage() {
       personsList.find((p) => p.id === c.defendant_person_id)?.full_name ||
       c.defendant,
     responsibleLawyer: users.find((u) => u.id === c.responsible_lawyer_id)?.name ?? c.responsibleLawyer,
+    createdAt: c.created_at ? dayjs(c.created_at) : null,
+    createdByName: users.find((u) => u.id === c.created_by)?.name ?? null,
     daysSinceFixStart: c.fix_start_date ? dayjs(c.fix_end_date ?? dayjs()).diff(dayjs(c.fix_start_date), 'day') : null,
     statusName: stages.find((s) => s.id === c.status)?.name ?? null,
     statusColor: stages.find((s) => s.id === c.status)?.color ?? null,
@@ -373,6 +375,20 @@ export default function CourtCasesPage() {
       width: 180,
       sorter: (a, b) => (a.responsibleLawyer || '').localeCompare(b.responsibleLawyer || ''),
     },
+    createdAt: {
+      title: 'Добавлено',
+      dataIndex: 'createdAt',
+      width: 160,
+      sorter: (a, b) =>
+        (a.createdAt ? a.createdAt.valueOf() : 0) - (b.createdAt ? b.createdAt.valueOf() : 0),
+      render: (v: dayjs.Dayjs | null) => (v ? v.format('DD.MM.YYYY HH:mm') : ''),
+    },
+    createdByName: {
+      title: 'Автор',
+      dataIndex: 'createdByName',
+      width: 160,
+      sorter: (a, b) => (a.createdByName || '').localeCompare(b.createdByName || ''),
+    },
     actions: {
       title: 'Действия',
       key: 'actions',
@@ -416,7 +432,7 @@ export default function CourtCasesPage() {
     const defaults = Object.keys(baseColumns).map((key) => ({
       key,
       title: baseColumns[key].title as string,
-      visible: true,
+      visible: !['createdAt', 'createdByName'].includes(key),
     }));
     try {
       const saved = localStorage.getItem(LS_COLUMNS_KEY);
@@ -435,7 +451,7 @@ export default function CourtCasesPage() {
     const defaults = Object.keys(baseColumns).map((key) => ({
       key,
       title: baseColumns[key].title as string,
-      visible: true,
+      visible: !['createdAt', 'createdByName'].includes(key),
     }));
     setColumnsState(defaults);
   };

--- a/src/shared/types/courtCase.ts
+++ b/src/shared/types/courtCase.ts
@@ -36,6 +36,14 @@ export interface CourtCase {
   defendant_contractor_id: number | null;
   responsible_lawyer_id: string | null;
   status: number;
+  /** Автор создания записи */
+  created_by?: string | null;
+  /** Дата создания записи */
+  created_at?: string;
+  /** Автор последнего изменения */
+  updated_by?: string | null;
+  /** Дата последнего изменения */
+  updated_at?: string;
   fix_start_date?: string | null;
   fix_end_date?: string | null;
   description: string;


### PR DESCRIPTION
## Summary
- extend `CourtCase` type with creation/update metadata
- display creator and creation time columns in court cases table
- hide these columns by default and allow toggling via settings drawer

## Testing
- `npm run lint` *(fails: parsing errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f7b09a550832e94da0421edb546bd