### PR TITLE
Add SQL and docs for letters created_by

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -939,6 +939,13 @@
   },
   {
     "table_name": "letters",
+    "column_name": "created_by",
+    "data_type": "uuid",
+    "is_nullable": "YES",
+    "column_default": null
+  },
+  {
+    "table_name": "letters",
     "column_name": "responsible_user_id",
     "data_type": "uuid",
     "is_nullable": "YES",

--- a/sql/letters_add_created_by.sql
+++ b/sql/letters_add_created_by.sql
@@ -1,0 +1,2 @@
+ALTER TABLE letters
+  ADD COLUMN IF NOT EXISTS created_by uuid REFERENCES profiles(id);

--- a/src/entities/correspondence/index.ts
+++ b/src/entities/correspondence/index.ts
@@ -57,7 +57,7 @@ export function useLetters() {
       let query = supabase
         .from(LETTERS_TABLE)
         .select(
-          `id, project_id, number, letter_type_id, direction, status_id, letter_date, subject, content, sender_person_id, sender_contractor_id, receiver_person_id, receiver_contractor_id, responsible_user_id, created_at`
+          `id, project_id, number, letter_type_id, direction, status_id, letter_date, subject, content, sender_person_id, sender_contractor_id, receiver_person_id, receiver_contractor_id, responsible_user_id, created_at, created_by`
         );
       if (onlyAssigned) {
         query = query.in('project_id', projectIds.length ? projectIds : [-1]);
@@ -182,6 +182,8 @@ export function useLetters() {
           receiver,
           subject: row.subject ?? '',
           content: row.content ?? '',
+          created_by: row.created_by ?? null,
+          created_at: row.created_at ?? null,
 
           attachments,
         } as CorrespondenceLetter;
@@ -224,6 +226,7 @@ export function useAddLetter() {
           receiver_contractor_id: receiverIds.contractorId,
           // null в случае отсутствия выбранного сотрудника
           responsible_user_id: data.responsible_user_id ?? null,
+          created_by: data.created_by ?? null,
         };
       const { data: inserted, error } = await supabase
         .from(LETTERS_TABLE)
@@ -295,6 +298,8 @@ export function useAddLetter() {
         receiver: data.receiver,
         subject: data.subject,
         content: data.content,
+        created_by: inserted.created_by ?? null,
+        created_at: inserted.created_at ?? null,
 
         attachments: files,
       } as CorrespondenceLetter;
@@ -426,7 +431,7 @@ export function useLetter(letterId: number | string | undefined) {
       const { data, error } = await supabase
         .from(LETTERS_TABLE)
         .select(
-          `id, project_id, number, letter_type_id, direction, status_id, letter_date, subject, content, sender_person_id, sender_contractor_id, receiver_person_id, receiver_contractor_id, responsible_user_id`
+          `id, project_id, number, letter_type_id, direction, status_id, letter_date, subject, content, sender_person_id, sender_contractor_id, receiver_person_id, receiver_contractor_id, responsible_user_id, created_at, created_by`
         )
         .eq('id', id)
         .single();
@@ -523,6 +528,8 @@ export function useLetter(letterId: number | string | undefined) {
         receiver,
         subject: data?.subject ?? '',
         content: data?.content ?? '',
+        created_by: data?.created_by ?? null,
+        created_at: data?.created_at ?? null,
         attachments,
       } as CorrespondenceLetter & { attachments: any[] };
     },

--- a/src/shared/types/correspondence.ts
+++ b/src/shared/types/correspondence.ts
@@ -42,6 +42,11 @@ export interface CorrespondenceLetter {
   /** Содержание письма */
   content: string;
 
+  /** Пользователь, создавший письмо (ссылка на `profiles.id`) */
+  created_by?: string | null;
+  /** Дата создания письма */
+  created_at?: string | null;
+
   /** Загруженные файлы */
   attachments: CorrespondenceAttachment[];
 }

--- a/src/widgets/CorrespondenceTable.tsx
+++ b/src/widgets/CorrespondenceTable.tsx
@@ -74,6 +74,7 @@ export default function CorrespondenceTable({
         responsibleName: l.responsible_user_id
             ? maps.user[l.responsible_user_id]
             : null,
+        createdByName: l.created_by ? maps.user[l.created_by] : null,
         statusName: l.status_id ? maps.status[l.status_id] : null,
         children: [],
       };
@@ -228,6 +229,21 @@ export default function CorrespondenceTable({
       sorter: (a, b) =>
           (a.responsibleName || '').localeCompare(b.responsibleName || ''),
       render: (name: string) => name || '—',
+    },
+    {
+      title: 'Добавлено',
+      dataIndex: 'created_at',
+      width: 160,
+      sorter: (a, b) =>
+        (a.created_at ? dayjs(a.created_at).valueOf() : 0) -
+        (b.created_at ? dayjs(b.created_at).valueOf() : 0),
+      render: (v: string | null) => (v ? dayjs(v).format('DD.MM.YYYY HH:mm') : '—'),
+    },
+    {
+      title: 'Автор',
+      dataIndex: 'createdByName',
+      width: 160,
+      sorter: (a, b) => (a.createdByName || '').localeCompare(b.createdByName || ''),
     },
     {
       title: 'Действия',


### PR DESCRIPTION
## Summary
- document that `created_by` references `profiles.id`
- provide SQL to add the foreign key on letters

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f88216d4c832e8a3aff07393320ce