### PR TITLE
Add debounce for building filter

### DIFF
--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -17,6 +17,7 @@ import ClaimAttachmentsBlock from './ClaimAttachmentsBlock';
 import dayjs from 'dayjs';
 import { useVisibleProjects } from '@/entities/project';
 import { useUnitsByProject } from '@/entities/unit';
+import { useDebounce } from '@/shared/hooks/useDebounce';
 import { useUsers } from '@/entities/user';
 import { useClaimStatuses } from '@/entities/claimStatus';
 import { useCreateClaim } from '@/entities/claim';
@@ -80,7 +81,11 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
   const { data: projects = [] } = useVisibleProjects();
   const { buildings = [] } = useProjectBuildings(projectId);
   const buildingWatch = Form.useWatch('building', form) ?? null;
-  const { data: units = [] } = useUnitsByProject(projectId, buildingWatch ?? undefined);
+  const buildingDebounced = useDebounce(buildingWatch);
+  const { data: units = [] } = useUnitsByProject(
+    projectId,
+    buildingDebounced ?? undefined,
+  );
   const { data: users = [] } = useUsers();
   const { data: statuses = [] } = useClaimStatuses();
   const create = useCreateClaim();

--- a/src/shared/hooks/useDebounce.ts
+++ b/src/shared/hooks/useDebounce.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Возвращает значение, обновлённое с задержкой.
+ * Используется для редкого вызова эффектов и запросов.
+ *
+ * @param value Значение для дебаунса
+ * @param delay Задержка в миллисекундах
+ */
+export function useDebounce<T>(value: T, delay = 300): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(id);
+  }, [value, delay]);
+
+  return debounced;
+}


### PR DESCRIPTION
## Summary
- implement `useDebounce` hook
- use debounce for building selector in `ClaimFormAntd`

## Testing
- `npm run lint` *(fails: eslint config issues)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f8e9e3ab4832eaa317baaa04d2cb9