### PR TITLE
Reduce realtime subscriptions

### DIFF
--- a/src/features/user/ActiveProjectSelect.tsx
+++ b/src/features/user/ActiveProjectSelect.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Select, Skeleton } from 'antd';
+import { useAuthStore } from '@/shared/store/authStore';
+import { useVisibleProjects } from '@/entities/project';
+
+/**
+ * Выпадающий список для выбора активного проекта пользователя.
+ */
+export default function ActiveProjectSelect() {
+  const projectId = useAuthStore((s) => s.projectId);
+  const setProjectId = useAuthStore((s) => s.setProjectId);
+  const { data: projects = [], isPending } = useVisibleProjects();
+
+  const options = React.useMemo(
+    () => projects.map((p) => ({ value: p.id, label: p.name })),
+    [projects],
+  );
+
+  if (isPending) {
+    return <Skeleton.Button active size="small" style={{ width: 160 }} />;
+  }
+
+  return (
+    <Select
+      size="small"
+      value={projectId ?? undefined}
+      onChange={(val) => setProjectId(val)}
+      options={options}
+      placeholder="Выберите проект"
+      style={{ width: '100%' }}
+    />
+  );
+}

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -12,6 +12,7 @@ import dayjs from 'dayjs';
 import ChangeNameForm from '@/features/user/ChangeNameForm';
 import ChangePasswordForm from '@/features/user/ChangePasswordForm';
 import UserProjectsEditor from '@/features/user/UserProjectsEditor';
+import ActiveProjectSelect from '@/features/user/ActiveProjectSelect';
 import { useVisibleProjects } from '@/entities/project';
 import { useAuthStore } from '@/shared/store/authStore';
 /**
@@ -75,6 +76,9 @@ export default function ProfilePage() {
             label: 'Настройки',
             children: (
               <Space direction="vertical" size="large" style={{ width: '100%' }}>
+                <Card title="Активный проект">
+                  <ActiveProjectSelect />
+                </Card>
                 <Card title="ФИО">
                   <ChangeNameForm />
                 </Card>

--- a/src/shared/hooks/useDashboardStats.ts
+++ b/src/shared/hooks/useDashboardStats.ts
@@ -2,6 +2,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { supabase } from '@/shared/api/supabaseClient';
 import { useVisibleProjects } from '@/entities/project';
+import { useProjectId } from '@/shared/hooks/useProjectId';
 import { useClaimStatuses } from '@/entities/claimStatus';
 import { useDefectStatuses } from '@/entities/defectStatus';
 import type { DashboardStats, ProjectStats } from '@/shared/types/dashboardStats';
@@ -12,56 +13,56 @@ import type { DashboardStats, ProjectStats } from '@/shared/types/dashboardStats
 export function useDashboardStats() {
   const qc = useQueryClient();
   const { data: projects = [] } = useVisibleProjects();
+  const projectId = useProjectId();
   const { data: claimStatuses = [] } = useClaimStatuses();
   const { data: defectStatuses = [] } = useDefectStatuses();
 
   const closedClaimId = claimStatuses.find((s) => /закры/i.test(s.name))?.id ?? null;
   const closedDefectId = defectStatuses.find((s) => /закры/i.test(s.name))?.id ?? null;
-  const projectIds = projects.map((p) => p.id);
 
   const statsQuery = useQuery<DashboardStats>({
-    queryKey: ['dashboard-stats', projectIds.join(','), closedClaimId, closedDefectId],
-    enabled: projectIds.length > 0,
+    queryKey: ['dashboard-stats', projectId, closedClaimId, closedDefectId],
+    enabled: !!projectId,
     queryFn: async () => {
-      const projectStats: ProjectStats[] = [];
-      for (const p of projects) {
-        const [{ count: unitCount }, { count: defectTotal }, { count: letterCount }] = await Promise.all([
-          supabase.from('units').select('id', { count: 'exact', head: true }).eq('project_id', p.id),
-          supabase.from('defects').select('id', { count: 'exact', head: true }).eq('project_id', p.id),
-          supabase.from('letters').select('id', { count: 'exact', head: true }).eq('project_id', p.id),
-        ]);
-        projectStats.push({
-          projectId: p.id,
-          projectName: p.name,
-          unitCount: unitCount ?? 0,
-          defectTotal: defectTotal ?? 0,
-          letterCount: letterCount ?? 0,
-        });
-      }
+      const project = projects.find((p) => p.id === projectId);
+      if (!project) throw new Error('no project');
+
+      const [{ count: unitCount }, { count: defectTotal }, { count: letterCount }] = await Promise.all([
+        supabase.from('units').select('id', { count: 'exact', head: true }).eq('project_id', project.id),
+        supabase.from('defects').select('id', { count: 'exact', head: true }).eq('project_id', project.id),
+        supabase.from('letters').select('id', { count: 'exact', head: true }).eq('project_id', project.id),
+      ]);
 
       const claimsQuery = supabase
         .from('claims')
         .select('id, engineer_id')
-        .in('project_id', projectIds);
+        .eq('project_id', project.id);
 
-      const [{ count: claimsTotal }, { count: claimsClosed }, { count: defectsTotal }, { count: defectsClosed }, { count: courtCases }, { data: claimsRows }] = await Promise.all([
-        supabase.from('claims').select('id', { count: 'exact', head: true }).in('project_id', projectIds),
+      const [
+        { count: claimsTotal },
+        { count: claimsClosed },
+        { count: defectsTotal },
+        { count: defectsClosed },
+        { count: courtCases },
+        { data: claimsRows },
+      ] = await Promise.all([
+        supabase.from('claims').select('id', { count: 'exact', head: true }).eq('project_id', project.id),
         closedClaimId
           ? supabase
               .from('claims')
               .select('id', { count: 'exact', head: true })
-              .in('project_id', projectIds)
+              .eq('project_id', project.id)
               .eq('claim_status_id', closedClaimId)
           : Promise.resolve({ count: 0 }),
-        supabase.from('defects').select('id', { count: 'exact', head: true }).in('project_id', projectIds),
+        supabase.from('defects').select('id', { count: 'exact', head: true }).eq('project_id', project.id),
         closedDefectId
           ? supabase
               .from('defects')
               .select('id', { count: 'exact', head: true })
-              .in('project_id', projectIds)
+              .eq('project_id', project.id)
               .eq('status_id', closedDefectId)
           : Promise.resolve({ count: 0 }),
-        supabase.from('court_cases').select('id', { count: 'exact', head: true }).in('project_id', projectIds),
+        supabase.from('court_cases').select('id', { count: 'exact', head: true }).eq('project_id', project.id),
         claimsQuery,
       ]);
 
@@ -73,26 +74,17 @@ export function useDashboardStats() {
           engineerMap[row.engineer_id] = (engineerMap[row.engineer_id] || 0) + 1;
         }
       });
-
       const { data: engineerNames } = Object.keys(engineerMap).length
-        ? await supabase
-            .from('profiles')
-            .select('id, name')
-            .in('id', Object.keys(engineerMap))
+        ? await supabase.from('profiles').select('id, name').in('id', Object.keys(engineerMap))
         : { data: [] };
-      const engineerNameMap = new Map(
-        (engineerNames ?? []).map((u: any) => [u.id, u.name]),
-      );
+      const engineerNameMap = new Map((engineerNames ?? []).map((u: any) => [u.id, u.name]));
       const claimsByEngineer = Object.entries(engineerMap).map(([id, count]) => ({
         engineerName: engineerNameMap.get(id) ?? '—',
         count,
       }));
 
       const { data: claimUnitRows } = claimIds.length
-        ? await supabase
-            .from('claim_units')
-            .select('unit_id')
-            .in('claim_id', claimIds)
+        ? await supabase.from('claim_units').select('unit_id').in('claim_id', claimIds)
         : { data: [] };
       const unitCountMap: Record<number, number> = {};
       (claimUnitRows ?? []).forEach((row: any) => {
@@ -100,10 +92,7 @@ export function useDashboardStats() {
       });
       const unitIds = Object.keys(unitCountMap).map((v) => Number(v));
       const { data: unitNames } = unitIds.length
-        ? await supabase
-            .from('units')
-            .select('id, name')
-            .in('id', unitIds)
+        ? await supabase.from('units').select('id, name').in('id', unitIds)
         : { data: [] };
       const unitNameMap = new Map((unitNames ?? []).map((u: any) => [u.id, u.name]));
       const claimsByUnit = unitIds.map((id) => ({
@@ -114,7 +103,7 @@ export function useDashboardStats() {
       const { data: defectRows } = await supabase
         .from('defects')
         .select('fixed_by')
-        .in('project_id', projectIds);
+        .eq('project_id', project.id);
       const defectEngineerMap: Record<string, number> = {};
       (defectRows ?? []).forEach((row: any) => {
         if (row.fixed_by) {
@@ -122,20 +111,23 @@ export function useDashboardStats() {
         }
       });
       const { data: defectEngineerNames } = Object.keys(defectEngineerMap).length
-        ? await supabase
-            .from('profiles')
-            .select('id, name')
-            .in('id', Object.keys(defectEngineerMap))
+        ? await supabase.from('profiles').select('id, name').in('id', Object.keys(defectEngineerMap))
         : { data: [] };
-      const defectEngineerNameMap = new Map(
-        (defectEngineerNames ?? []).map((u: any) => [u.id, u.name]),
-      );
-      const defectsByEngineer = Object.entries(defectEngineerMap).map(
-        ([id, count]) => ({
-          engineerName: defectEngineerNameMap.get(id) ?? '—',
-          count,
-        }),
-      );
+      const defectEngineerNameMap = new Map((defectEngineerNames ?? []).map((u: any) => [u.id, u.name]));
+      const defectsByEngineer = Object.entries(defectEngineerMap).map(([id, count]) => ({
+        engineerName: defectEngineerNameMap.get(id) ?? '—',
+        count,
+      }));
+
+      const projectStats: ProjectStats[] = [
+        {
+          projectId: project.id,
+          projectName: project.name,
+          unitCount: unitCount ?? 0,
+          defectTotal: defectTotal ?? 0,
+          letterCount: letterCount ?? 0,
+        },
+      ];
 
       return {
         projects: projectStats,
@@ -144,32 +136,30 @@ export function useDashboardStats() {
         defectsOpen: (defectsTotal ?? 0) - (defectsClosed ?? 0),
         defectsClosed: defectsClosed ?? 0,
         courtCases: courtCases ?? 0,
-        claimsByUnit: claimsByUnit ?? [],
-        claimsByEngineer: claimsByEngineer ?? [],
-        defectsByEngineer: defectsByEngineer ?? [],
+        claimsByUnit,
+        claimsByEngineer,
+        defectsByEngineer,
       } as DashboardStats;
     },
     staleTime: 60_000,
   });
 
   useEffect(() => {
-    if (projectIds.length === 0) return;
-    const channel = supabase.channel('dashboard-stats');
+    if (!projectId) return;
+    const channel = supabase.channel(`dashboard-stats-${projectId}`);
     const tables = ['units', 'claims', 'defects', 'court_cases', 'letters'];
     tables.forEach((table) => {
-      projectIds.forEach((pid) => {
-        channel.on(
-          'postgres_changes',
-          { event: '*', schema: 'public', table, filter: `project_id=eq.${pid}` },
-          () => qc.invalidateQueries({ queryKey: ['dashboard-stats'] }),
-        );
-      });
+      channel.on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table, filter: `project_id=eq.${projectId}` },
+        () => qc.invalidateQueries({ queryKey: ['dashboard-stats'] }),
+      );
     });
     channel.subscribe();
     return () => {
       channel.unsubscribe();
     };
-  }, [projectIds.join(','), qc]);
+  }, [projectId, qc]);
 
   return statsQuery;
 }

--- a/src/shared/hooks/useRealtimeUpdates.ts
+++ b/src/shared/hooks/useRealtimeUpdates.ts
@@ -2,9 +2,6 @@ import { useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/shared/api/supabaseClient';
 import { useProjectId } from '@/shared/hooks/useProjectId';
-import { useAuthStore } from '@/shared/store/authStore';
-import { useRolePermission } from '@/entities/rolePermission';
-import type { RoleName } from '@/shared/types/rolePermission';
 
 /**
  * Подписка на создание записей в ключевых таблицах.
@@ -15,72 +12,42 @@ import type { RoleName } from '@/shared/types/rolePermission';
 export function useRealtimeUpdates() {
   const qc = useQueryClient();
   const projectId = useProjectId();
-  const projectIds = useAuthStore((s) => s.profile?.project_ids) ?? [];
-  const role = useAuthStore((s) => s.profile?.role as RoleName | undefined);
-  const { data: perm } = useRolePermission(role);
 
   useEffect(() => {
-    const ids = perm?.only_assigned_project
-      ? projectIds
-      : projectId
-        ? [projectId]
-        : [];
-    const subscribeAllLetters = !perm?.only_assigned_project && !projectId;
-    if (ids.length === 0 && !subscribeAllLetters) return;
+    if (!projectId) return;
 
-    const channel = supabase.channel('realtime-updates');
-    ids.forEach((pid) => {
-      channel
-        .on(
-          'postgres_changes',
-          { event: '*', schema: 'public', table: 'court_cases', filter: `project_id=eq.${pid}` },
-          () => qc.invalidateQueries({ queryKey: ['court_cases', pid] }),
-        )
-        .on(
-          'postgres_changes',
-          { event: '*', schema: 'public', table: 'letters', filter: `project_id=eq.${pid}` },
-          () => qc.invalidateQueries({ queryKey: ['letters'] }),
-        )
-        .on(
-          'postgres_changes',
-          { event: '*', schema: 'public', table: 'claims', filter: `project_id=eq.${pid}` },
-          () => qc.invalidateQueries({ queryKey: ['claims'] }),
-        )
-        .on(
-          'postgres_changes',
-          { event: '*', schema: 'public', table: 'units', filter: `project_id=eq.${pid}` },
-          () => qc.invalidateQueries({ queryKey: ['units'] }),
-        );
-    });
-
+    const channel = supabase.channel(`realtime-updates-${projectId}`);
     channel
       .on(
         'postgres_changes',
-        { event: '*', schema: 'public', table: 'defects' },
+        { event: '*', schema: 'public', table: 'court_cases', filter: `project_id=eq.${projectId}` },
+        () => qc.invalidateQueries({ queryKey: ['court_cases', projectId] }),
+      )
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'letters', filter: `project_id=eq.${projectId}` },
+        () => qc.invalidateQueries({ queryKey: ['letters'] }),
+      )
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'claims', filter: `project_id=eq.${projectId}` },
+        () => qc.invalidateQueries({ queryKey: ['claims'] }),
+      )
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'units', filter: `project_id=eq.${projectId}` },
+        () => qc.invalidateQueries({ queryKey: ['units'] }),
+      )
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'defects', filter: `project_id=eq.${projectId}` },
         () => qc.invalidateQueries({ queryKey: ['defects'] }),
       );
-    if (subscribeAllLetters) {
-      channel
-        .on(
-          'postgres_changes',
-          { event: '*', schema: 'public', table: 'letters' },
-          () => qc.invalidateQueries({ queryKey: ['letters'] }),
-        )
-        .on(
-          'postgres_changes',
-          { event: '*', schema: 'public', table: 'claims' },
-          () => qc.invalidateQueries({ queryKey: ['claims'] }),
-        )
-        .on(
-          'postgres_changes',
-          { event: '*', schema: 'public', table: 'units' },
-          () => qc.invalidateQueries({ queryKey: ['units'] }),
-        );
-    }
+
     channel.subscribe();
 
     return () => {
       channel.unsubscribe();
     };
-  }, [projectId, projectIds.join(','), perm?.only_assigned_project, qc]);
+  }, [projectId, qc]);
 }


### PR DESCRIPTION
## Summary
- subscribe to realtime updates only for active project
- limit dashboard statistics realtime channel to current project
- allow choosing active project in profile settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fa60f9e34832ebc479a2005e262e5