### PR TITLE
Implement dashboard RPC usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,6 @@ VITE_ATTACH_BUCKET=<название корзины для вложений>
 Индексы: [db_indexes_summary.md](db_indexes_summary.md).
 
 
+
+## RPC функции
+- `dashboard_stats` — агрегирует все данные для дашборда. Структура ответа описана в [src/shared/types/dashboardStats.ts](src/shared/types/dashboardStats.ts).

--- a/src/shared/api/dashboardRpc.ts
+++ b/src/shared/api/dashboardRpc.ts
@@ -1,0 +1,20 @@
+import { supabase } from './supabaseClient';
+import type { DashboardStats } from '@/shared/types/dashboardStats';
+import type { DashboardRpcParams } from '@/shared/types/dashboardRpc';
+
+/**
+ * Запрашивает агрегированную статистику дашборда через RPC-функцию `dashboard_stats`.
+ */
+export async function fetchDashboardStats({
+  projectIds,
+  closedClaimStatusId,
+  closedDefectStatusId,
+}: DashboardRpcParams): Promise<DashboardStats> {
+  const { data, error } = await supabase.rpc('dashboard_stats', {
+    project_ids: projectIds,
+    closed_claim_status_id: closedClaimStatusId,
+    closed_defect_status_id: closedDefectStatusId,
+  });
+  if (error) throw error;
+  return data as DashboardStats;
+}

--- a/src/shared/hooks/useDashboardStats.ts
+++ b/src/shared/hooks/useDashboardStats.ts
@@ -1,10 +1,11 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { supabase } from '@/shared/api/supabaseClient';
+import { fetchDashboardStats } from '@/shared/api/dashboardRpc';
 import { useVisibleProjects } from '@/entities/project';
 import { useClaimStatuses } from '@/entities/claimStatus';
 import { useDefectStatuses } from '@/entities/defectStatus';
-import type { DashboardStats, ProjectStats } from '@/shared/types/dashboardStats';
+import type { DashboardStats } from '@/shared/types/dashboardStats';
 
 /**
  * Загружает статистику для дашборда и подписывается на обновления.
@@ -22,133 +23,12 @@ export function useDashboardStats() {
   const statsQuery = useQuery<DashboardStats>({
     queryKey: ['dashboard-stats', projectIds.join(','), closedClaimId, closedDefectId],
     enabled: projectIds.length > 0,
-    queryFn: async () => {
-      const projectStats: ProjectStats[] = [];
-      for (const p of projects) {
-        const [{ count: unitCount }, { count: defectTotal }, { count: letterCount }] = await Promise.all([
-          supabase.from('units').select('id', { count: 'exact', head: true }).eq('project_id', p.id),
-          supabase.from('defects').select('id', { count: 'exact', head: true }).eq('project_id', p.id),
-          supabase.from('letters').select('id', { count: 'exact', head: true }).eq('project_id', p.id),
-        ]);
-        projectStats.push({
-          projectId: p.id,
-          projectName: p.name,
-          unitCount: unitCount ?? 0,
-          defectTotal: defectTotal ?? 0,
-          letterCount: letterCount ?? 0,
-        });
-      }
-
-      const claimsQuery = supabase
-        .from('claims')
-        .select('id, engineer_id')
-        .in('project_id', projectIds);
-
-      const [{ count: claimsTotal }, { count: claimsClosed }, { count: defectsTotal }, { count: defectsClosed }, { count: courtCases }, { data: claimsRows }] = await Promise.all([
-        supabase.from('claims').select('id', { count: 'exact', head: true }).in('project_id', projectIds),
-        closedClaimId
-          ? supabase
-              .from('claims')
-              .select('id', { count: 'exact', head: true })
-              .in('project_id', projectIds)
-              .eq('claim_status_id', closedClaimId)
-          : Promise.resolve({ count: 0 }),
-        supabase.from('defects').select('id', { count: 'exact', head: true }).in('project_id', projectIds),
-        closedDefectId
-          ? supabase
-              .from('defects')
-              .select('id', { count: 'exact', head: true })
-              .in('project_id', projectIds)
-              .eq('status_id', closedDefectId)
-          : Promise.resolve({ count: 0 }),
-        supabase.from('court_cases').select('id', { count: 'exact', head: true }).in('project_id', projectIds),
-        claimsQuery,
-      ]);
-
-      const claimIds = (claimsRows ?? []).map((r: any) => r.id);
-
-      const engineerMap: Record<string, number> = {};
-      (claimsRows ?? []).forEach((row: any) => {
-        if (row.engineer_id) {
-          engineerMap[row.engineer_id] = (engineerMap[row.engineer_id] || 0) + 1;
-        }
-      });
-
-      const { data: engineerNames } = Object.keys(engineerMap).length
-        ? await supabase
-            .from('profiles')
-            .select('id, name')
-            .in('id', Object.keys(engineerMap))
-        : { data: [] };
-      const engineerNameMap = new Map(
-        (engineerNames ?? []).map((u: any) => [u.id, u.name]),
-      );
-      const claimsByEngineer = Object.entries(engineerMap).map(([id, count]) => ({
-        engineerName: engineerNameMap.get(id) ?? '—',
-        count,
-      }));
-
-      const { data: claimUnitRows } = claimIds.length
-        ? await supabase
-            .from('claim_units')
-            .select('unit_id')
-            .in('claim_id', claimIds)
-        : { data: [] };
-      const unitCountMap: Record<number, number> = {};
-      (claimUnitRows ?? []).forEach((row: any) => {
-        unitCountMap[row.unit_id] = (unitCountMap[row.unit_id] || 0) + 1;
-      });
-      const unitIds = Object.keys(unitCountMap).map((v) => Number(v));
-      const { data: unitNames } = unitIds.length
-        ? await supabase
-            .from('units')
-            .select('id, name')
-            .in('id', unitIds)
-        : { data: [] };
-      const unitNameMap = new Map((unitNames ?? []).map((u: any) => [u.id, u.name]));
-      const claimsByUnit = unitIds.map((id) => ({
-        unitName: unitNameMap.get(id) ?? `#${id}`,
-        count: unitCountMap[id],
-      }));
-
-      const { data: defectRows } = await supabase
-        .from('defects')
-        .select('fixed_by')
-        .in('project_id', projectIds);
-      const defectEngineerMap: Record<string, number> = {};
-      (defectRows ?? []).forEach((row: any) => {
-        if (row.fixed_by) {
-          defectEngineerMap[row.fixed_by] = (defectEngineerMap[row.fixed_by] || 0) + 1;
-        }
-      });
-      const { data: defectEngineerNames } = Object.keys(defectEngineerMap).length
-        ? await supabase
-            .from('profiles')
-            .select('id, name')
-            .in('id', Object.keys(defectEngineerMap))
-        : { data: [] };
-      const defectEngineerNameMap = new Map(
-        (defectEngineerNames ?? []).map((u: any) => [u.id, u.name]),
-      );
-      const defectsByEngineer = Object.entries(defectEngineerMap).map(
-        ([id, count]) => ({
-          engineerName: defectEngineerNameMap.get(id) ?? '—',
-          count,
-        }),
-      );
-
-      return {
-        projects: projectStats,
-        claimsOpen: (claimsTotal ?? 0) - (claimsClosed ?? 0),
-        claimsClosed: claimsClosed ?? 0,
-        defectsOpen: (defectsTotal ?? 0) - (defectsClosed ?? 0),
-        defectsClosed: defectsClosed ?? 0,
-        courtCases: courtCases ?? 0,
-        claimsByUnit: claimsByUnit ?? [],
-        claimsByEngineer: claimsByEngineer ?? [],
-        defectsByEngineer: defectsByEngineer ?? [],
-      } as DashboardStats;
-    },
+    queryFn: async () =>
+      fetchDashboardStats({
+        projectIds,
+        closedClaimStatusId: closedClaimId,
+        closedDefectStatusId: closedDefectId,
+      }),
     staleTime: 60_000,
   });
 

--- a/src/shared/types/dashboardRpc.ts
+++ b/src/shared/types/dashboardRpc.ts
@@ -1,0 +1,9 @@
+export interface DashboardRpcParams {
+  /** Идентификаторы проектов */
+  projectIds: number[];
+  /** Статус закрытой претензии */
+  closedClaimStatusId: number | null;
+  /** Статус закрытого дефекта */
+  closedDefectStatusId: number | null;
+}
+


### PR DESCRIPTION
## Summary
- call aggregated RPC function for dashboard stats
- document new `dashboard_stats` RPC

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fa79b20a0832e9529deffa362eea4