### PR TITLE
Implement dashboard stats RPC call

### DIFF
--- a/src/shared/hooks/useDashboardStats.ts
+++ b/src/shared/hooks/useDashboardStats.ts
@@ -5,7 +5,7 @@ import { useVisibleProjects } from '@/entities/project';
 import { useProjectId } from '@/shared/hooks/useProjectId';
 import { useClaimStatuses } from '@/entities/claimStatus';
 import { useDefectStatuses } from '@/entities/defectStatus';
-import type { DashboardStats, ProjectStats } from '@/shared/types/dashboardStats';
+import type { DashboardStats } from '@/shared/types/dashboardStats';
 
 /**
  * Загружает статистику для дашборда и подписывается на обновления.
@@ -27,119 +27,13 @@ export function useDashboardStats() {
       const project = projects.find((p) => p.id === projectId);
       if (!project) throw new Error('no project');
 
-      const [{ count: unitCount }, { count: defectTotal }, { count: letterCount }] = await Promise.all([
-        supabase.from('units').select('id', { count: 'exact', head: true }).eq('project_id', project.id),
-        supabase.from('defects').select('id', { count: 'exact', head: true }).eq('project_id', project.id),
-        supabase.from('letters').select('id', { count: 'exact', head: true }).eq('project_id', project.id),
-      ]);
-
-      const claimsQuery = supabase
-        .from('claims')
-        .select('id, engineer_id')
-        .eq('project_id', project.id);
-
-      const [
-        { count: claimsTotal },
-        { count: claimsClosed },
-        { count: defectsTotal },
-        { count: defectsClosed },
-        { count: courtCases },
-        { data: claimsRows },
-      ] = await Promise.all([
-        supabase.from('claims').select('id', { count: 'exact', head: true }).eq('project_id', project.id),
-        closedClaimId
-          ? supabase
-              .from('claims')
-              .select('id', { count: 'exact', head: true })
-              .eq('project_id', project.id)
-              .eq('claim_status_id', closedClaimId)
-          : Promise.resolve({ count: 0 }),
-        supabase.from('defects').select('id', { count: 'exact', head: true }).eq('project_id', project.id),
-        closedDefectId
-          ? supabase
-              .from('defects')
-              .select('id', { count: 'exact', head: true })
-              .eq('project_id', project.id)
-              .eq('status_id', closedDefectId)
-          : Promise.resolve({ count: 0 }),
-        supabase.from('court_cases').select('id', { count: 'exact', head: true }).eq('project_id', project.id),
-        claimsQuery,
-      ]);
-
-      const claimIds = (claimsRows ?? []).map((r: any) => r.id);
-
-      const engineerMap: Record<string, number> = {};
-      (claimsRows ?? []).forEach((row: any) => {
-        if (row.engineer_id) {
-          engineerMap[row.engineer_id] = (engineerMap[row.engineer_id] || 0) + 1;
-        }
+      const { data, error } = await supabase.rpc('dashboard_stats', {
+        pid: project.id,
+        closed_claim_id: closedClaimId,
+        closed_defect_id: closedDefectId,
       });
-      const { data: engineerNames } = Object.keys(engineerMap).length
-        ? await supabase.from('profiles').select('id, name').in('id', Object.keys(engineerMap))
-        : { data: [] };
-      const engineerNameMap = new Map((engineerNames ?? []).map((u: any) => [u.id, u.name]));
-      const claimsByEngineer = Object.entries(engineerMap).map(([id, count]) => ({
-        engineerName: engineerNameMap.get(id) ?? '—',
-        count,
-      }));
-
-      const { data: claimUnitRows } = claimIds.length
-        ? await supabase.from('claim_units').select('unit_id').in('claim_id', claimIds)
-        : { data: [] };
-      const unitCountMap: Record<number, number> = {};
-      (claimUnitRows ?? []).forEach((row: any) => {
-        unitCountMap[row.unit_id] = (unitCountMap[row.unit_id] || 0) + 1;
-      });
-      const unitIds = Object.keys(unitCountMap).map((v) => Number(v));
-      const { data: unitNames } = unitIds.length
-        ? await supabase.from('units').select('id, name').in('id', unitIds)
-        : { data: [] };
-      const unitNameMap = new Map((unitNames ?? []).map((u: any) => [u.id, u.name]));
-      const claimsByUnit = unitIds.map((id) => ({
-        unitName: unitNameMap.get(id) ?? `#${id}`,
-        count: unitCountMap[id],
-      }));
-
-      const { data: defectRows } = await supabase
-        .from('defects')
-        .select('fixed_by')
-        .eq('project_id', project.id);
-      const defectEngineerMap: Record<string, number> = {};
-      (defectRows ?? []).forEach((row: any) => {
-        if (row.fixed_by) {
-          defectEngineerMap[row.fixed_by] = (defectEngineerMap[row.fixed_by] || 0) + 1;
-        }
-      });
-      const { data: defectEngineerNames } = Object.keys(defectEngineerMap).length
-        ? await supabase.from('profiles').select('id, name').in('id', Object.keys(defectEngineerMap))
-        : { data: [] };
-      const defectEngineerNameMap = new Map((defectEngineerNames ?? []).map((u: any) => [u.id, u.name]));
-      const defectsByEngineer = Object.entries(defectEngineerMap).map(([id, count]) => ({
-        engineerName: defectEngineerNameMap.get(id) ?? '—',
-        count,
-      }));
-
-      const projectStats: ProjectStats[] = [
-        {
-          projectId: project.id,
-          projectName: project.name,
-          unitCount: unitCount ?? 0,
-          defectTotal: defectTotal ?? 0,
-          letterCount: letterCount ?? 0,
-        },
-      ];
-
-      return {
-        projects: projectStats,
-        claimsOpen: (claimsTotal ?? 0) - (claimsClosed ?? 0),
-        claimsClosed: claimsClosed ?? 0,
-        defectsOpen: (defectsTotal ?? 0) - (defectsClosed ?? 0),
-        defectsClosed: defectsClosed ?? 0,
-        courtCases: courtCases ?? 0,
-        claimsByUnit,
-        claimsByEngineer,
-        defectsByEngineer,
-      } as DashboardStats;
+      if (error) throw error;
+      return data as DashboardStats;
     },
     staleTime: 60_000,
   });


### PR DESCRIPTION
## Summary
- replace numerous queries in `useDashboardStats` with single `dashboard_stats` RPC call

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fb0909384832e9af3dc8c6942ecb2