### PR TITLE
Optimize bulk DB operations

### DIFF
--- a/src/entities/defect.ts
+++ b/src/entities/defect.ts
@@ -354,6 +354,7 @@ export function useFixDefect() {
         const claimCheckingId = claimStatusRow?.id ?? null;
 
         if (claimCheckingId) {
+          const updateIds: number[] = [];
           for (const cId of claimIds) {
             const { data: defRows } = await supabase
               .from('claim_defects')
@@ -373,12 +374,13 @@ export function useFixDefect() {
               return /\u043F\u0440\u043E\u0432\u0435\u0440|\u0437\u0430\u043A\u0440\u044B/.test(name);
             });
 
-            if (allFixed) {
-              await supabase
-                .from('claims')
-                .update({ claim_status_id: claimCheckingId })
-                .eq('id', cId);
-            }
+            if (allFixed) updateIds.push(cId);
+          }
+          if (updateIds.length) {
+            await supabase
+              .from('claims')
+              .update({ claim_status_id: claimCheckingId })
+              .in('id', updateIds);
           }
         }
       }
@@ -444,6 +446,7 @@ export function useCancelDefectFix() {
         const claimInWorkId = clSt?.id ?? null;
 
         if (claimInWorkId) {
+          const updateIds: number[] = [];
           for (const cId of claimIds) {
             const { data: defRows } = await supabase
               .from('claim_defects')
@@ -463,12 +466,13 @@ export function useCancelDefectFix() {
               return /\u043F\u0440\u043E\u0432\u0435\u0440|\u0437\u0430\u043A\u0440\u044B/.test(name);
             });
 
-            if (!allFixed) {
-              await supabase
-                .from('claims')
-                .update({ claim_status_id: claimInWorkId })
-                .eq('id', cId);
-            }
+            if (!allFixed) updateIds.push(cId);
+          }
+          if (updateIds.length) {
+            await supabase
+              .from('claims')
+              .update({ claim_status_id: claimInWorkId })
+              .in('id', updateIds);
           }
         }
       }

--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -19,7 +19,7 @@ import {
   useClaimAll,
   useUpdateClaim,
   useAddClaimAttachments,
-  useRemoveClaimAttachment,
+  removeClaimAttachmentsBulk,
   signedUrl,
   markClaimDefectsPreTrial,
 } from '@/entities/claim';
@@ -105,7 +105,6 @@ const ClaimFormAntdEdit = React.forwardRef<
   const { data: caseUids = [] } = useCaseUids();
   const update = useUpdateClaim();
   const addAtt = useAddClaimAttachments();
-  const removeAtt = useRemoveClaimAttachment();
   const notify = useNotify();
   const userId = useAuthStore((s) => s.profile?.id) ?? null;
   const attachments =
@@ -173,11 +172,11 @@ const ClaimFormAntdEdit = React.forwardRef<
         await markClaimDefectsPreTrial(claim.id);
       }
 
-      for (const id of attachments.removedIds) {
-        await removeAtt.mutateAsync({
-          claimId: claim.id,
-          attachmentId: Number(id),
-        });
+      if (attachments.removedIds.length) {
+        await removeClaimAttachmentsBulk(
+          claim.id,
+          attachments.removedIds.map(Number),
+        );
       }
       let uploaded: RemoteClaimFile[] = [];
       if (attachments.newFiles.length) {


### PR DESCRIPTION
## Summary
- optimize claim status recalculation using bulk updates
- support batch removal of claim attachments
- use new bulk removal in ClaimFormAntdEdit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fb08649c8832eb982f5ea60500153