### PR TITLE
Improve defects section

### DIFF
--- a/src/features/claim/ClaimViewModal.tsx
+++ b/src/features/claim/ClaimViewModal.tsx
@@ -3,7 +3,7 @@ import { Modal, Skeleton, Typography, Button } from 'antd';
 import { useClaim, useClaimAll, signedUrl, closeDefectsForClaim } from '@/entities/claim';
 import ClaimFormAntdEdit from './ClaimFormAntdEdit';
 import ClaimAttachmentsBlock from './ClaimAttachmentsBlock';
-import TicketDefectsEditorTable from '@/widgets/TicketDefectsEditorTable';
+import ClaimDefectsTable from '@/widgets/ClaimDefectsTable';
 import DefectAddModal from '@/features/defect/DefectAddModal';
 import DefectViewModal from '@/features/defect/DefectViewModal';
 import dayjs from 'dayjs';
@@ -86,7 +86,7 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
     }
   }, [open]);
 
-  const { data: loadedDefs = [] } = useDefectsWithNames(defectIds);
+  const { data: loadedDefs = [], isPending: loadingDefs } = useDefectsWithNames(defectIds);
 
   const defectTypeMap = React.useMemo(() => {
     const map: Record<number, string> = {};
@@ -263,25 +263,22 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
             attachmentsState={attachments}
           />
           <div style={{ marginTop: 16 }}>
-            {displayDefs.length ? (
-              <TicketDefectsEditorTable
-                items={displayDefs}
-                defectTypes={defectTypes}
-                statuses={defectStatuses}
-                brigades={brigades}
-                contractors={contractors}
-                onChange={handleChangeDef}
-                onRemove={handleRemove}
-                onView={setViewDefId}
-              />
-            ) : (
-              <Typography.Text>Дефекты не указаны</Typography.Text>
-            )}
-            <div style={{ textAlign: 'right', marginTop: 8 }}>
+            <div style={{ textAlign: 'right', marginBottom: 8 }}>
               <Button size="small" type="primary" onClick={() => setShowAdd(true)}>
                 Добавить дефекты
               </Button>
             </div>
+            {displayDefs.length ? (
+              <ClaimDefectsTable
+                items={displayDefs}
+                loading={loadingDefs}
+                onView={setViewDefId}
+                onRemove={handleRemove}
+                onWarrantyChange={(id, v) => handleChangeDef(id, 'is_warranty', v)}
+              />
+            ) : (
+              <Typography.Text>Дефекты не указаны</Typography.Text>
+            )}
           </div>
           <ClaimAttachmentsBlock
             remoteFiles={attachments.remoteFiles}

--- a/src/widgets/ClaimDefectsTable.tsx
+++ b/src/widgets/ClaimDefectsTable.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import {
+  Table,
+  Switch,
+  Tooltip,
+  Skeleton,
+  Button,
+  Space,
+  Popconfirm,
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { EyeOutlined, DeleteOutlined } from '@ant-design/icons';
+import type { DefectWithNames } from '@/shared/types/defectWithNames';
+import DefectStatusSelect from '@/features/defect/DefectStatusSelect';
+import DefectFilesRow from './DefectFilesRow';
+
+export interface ClaimDefectsTableProps {
+  items: DefectWithNames[];
+  loading?: boolean;
+  onView?: (id: number) => void;
+  onRemove?: (id: number) => void;
+  onWarrantyChange?: (id: number, val: boolean) => void;
+}
+
+export default function ClaimDefectsTable({
+  items,
+  loading,
+  onView,
+  onRemove,
+  onWarrantyChange,
+}: ClaimDefectsTableProps) {
+  const [expanded, setExpanded] = React.useState<number[]>([]);
+
+  const columns: ColumnsType<DefectWithNames> = [
+    {
+      title: 'ID',
+      dataIndex: 'id',
+      width: 80,
+      sorter: (a, b) => a.id - b.id,
+      defaultSortOrder: 'ascend',
+    },
+    {
+      title: 'Описание',
+      dataIndex: 'description',
+      ellipsis: true,
+      render: (v: string) => (
+        <Tooltip title={v} placement="topLeft">
+          {v}
+        </Tooltip>
+      ),
+    },
+    {
+      title: 'Тип',
+      dataIndex: 'defectTypeName',
+      width: 120,
+      render: (v: string | null) => v ?? '—',
+    },
+    {
+      title: 'Статус',
+      dataIndex: 'status_id',
+      width: 160,
+      render: (_: any, row) => (
+        <DefectStatusSelect
+          defectId={row.id}
+          statusId={row.status_id}
+          statusName={row.defectStatusName}
+          statusColor={row.defectStatusColor}
+        />
+      ),
+    },
+    {
+      title: 'Гарантия',
+      dataIndex: 'is_warranty',
+      width: 100,
+      render: (v: boolean, row) => (
+        <Switch
+          size="small"
+          checked={v}
+          onChange={(val) => onWarrantyChange?.(row.id, val)}
+        />
+      ),
+    },
+    {
+      title: 'Дата получения',
+      dataIndex: 'received_at',
+      width: 120,
+      render: (v: string | null) =>
+        v ? dayjs(v).format('DD.MM.YYYY') : '—',
+    },
+    {
+      title: 'Дата устранения',
+      dataIndex: 'fixed_at',
+      width: 120,
+      render: (v: string | null) =>
+        v ? dayjs(v).format('DD.MM.YYYY') : '—',
+    },
+    {
+      title: 'Исполнитель',
+      dataIndex: 'contractor_id',
+      width: 120,
+      render: (_: any, row) => (
+        <Switch
+          size="small"
+          checkedChildren="подряд"
+          unCheckedChildren="собст"
+          checked={row.contractor_id !== null}
+          disabled
+        />
+      ),
+    },
+    {
+      title: 'Действия',
+      key: 'actions',
+      width: 100,
+      render: (_: any, row) => (
+        <Space size="middle">
+          <Tooltip title="Просмотр">
+            <Button
+              size="small"
+              type="text"
+              icon={<EyeOutlined />}
+              onClick={() => onView?.(row.id)}
+            />
+          </Tooltip>
+          <Popconfirm
+            title="Удалить дефект?"
+            okText="Да"
+            cancelText="Нет"
+            onConfirm={() => {
+              onRemove?.(row.id);
+            }}
+          >
+            <Button size="small" type="text" danger icon={<DeleteOutlined />} />
+          </Popconfirm>
+        </Space>
+      ),
+    },
+  ];
+
+  if (loading) return <Skeleton active paragraph={{ rows: 4 }} />;
+
+  return (
+    <Table
+      rowKey="id"
+      size="small"
+      columns={columns}
+      dataSource={items}
+      pagination={false}
+      expandable={{
+        expandedRowRender: (rec) => (
+          <DefectFilesRow defectId={rec.id} expanded={expanded.includes(rec.id)} />
+        ),
+        onExpand: (ex, rec) => {
+          setExpanded((p) =>
+            ex ? [...p, rec.id] : p.filter((id) => id !== rec.id),
+          );
+        },
+      }}
+    />
+  );
+}

--- a/src/widgets/DefectFilesRow.tsx
+++ b/src/widgets/DefectFilesRow.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Table, Button, Tooltip } from 'antd';
+import { FileOutlined, DownloadOutlined, DeleteOutlined } from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import { useDefectFiles, signedUrl, useRemoveDefectAttachment } from '@/entities/defect';
+import type { RemoteDefectFile } from '@/shared/types/defectFile';
+
+interface Props {
+  defectId: number;
+  expanded: boolean;
+}
+
+export default function DefectFilesRow({ defectId, expanded }: Props) {
+  const { data = [], isLoading } = useDefectFiles(defectId, { enabled: expanded });
+  const remove = useRemoveDefectAttachment();
+
+  const rows = data.map((f) => ({
+    key: String(f.id),
+    id: String(f.id),
+    name: f.original_name ?? f.name,
+    path: f.path,
+    mime: f.mime_type,
+  }));
+
+  const handleRemove = async (id: string) => {
+    await remove.mutateAsync({ defectId, attachmentId: Number(id) });
+  };
+
+  const columns: ColumnsType<typeof rows[0]> = [
+    { dataIndex: 'icon', width: 32, render: () => <FileOutlined /> },
+    { title: 'Имя', dataIndex: 'name', width: 200, ellipsis: true },
+    {
+      title: 'Действия',
+      dataIndex: 'actions',
+      width: 100,
+      render: (_: any, row) => (
+        <div style={{ display: 'flex', gap: 4 }}>
+          <Tooltip title="Скачать">
+            <Button
+              type="text"
+              size="small"
+              icon={<DownloadOutlined />}
+              onClick={async () => {
+                const url = await signedUrl(row.path, row.name);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = row.name;
+                document.body.appendChild(a);
+                a.click();
+                a.remove();
+              }}
+            />
+          </Tooltip>
+          <Tooltip title="Удалить">
+            <Button
+              type="text"
+              size="small"
+              danger
+              icon={<DeleteOutlined />}
+              onClick={() => handleRemove(row.id)}
+            />
+          </Tooltip>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <Table
+      rowKey="key"
+      columns={columns}
+      dataSource={rows}
+      size="small"
+      pagination={false}
+      loading={isLoading}
+      showHeader={false}
+      style={{ width: 'fit-content' }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add new ClaimDefectsTable widget with expandable file rows
- fetch defect files lazily using new hook
- refactor ClaimViewModal to use new table and move add button

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686027cf63d4832ea58d5802104f264b