### PR TITLE
Add expandable defect files in claims view

### DIFF
--- a/src/entities/defect.ts
+++ b/src/entities/defect.ts
@@ -560,3 +560,21 @@ export function useRemoveDefectAttachment() {
     onError: (e) => notify.error(`Ошибка удаления файла: ${e.message}`),
   });
 }
+
+/** Получить вложения дефекта по его идентификатору */
+export function useDefectAttachments(id?: number) {
+  return useQuery({
+    queryKey: ['defect-attachments', id],
+    enabled: !!id,
+    queryFn: async () => {
+      const { data } = await supabase
+        .from('defect_attachments')
+        .select(
+          'attachments(id, storage_path, file_url:path, file_type:mime_type, original_name)'
+        )
+        .eq('defect_id', id as number);
+      return (data ?? []).map((r: any) => r.attachments);
+    },
+    staleTime: 5 * 60_000,
+  });
+}

--- a/src/widgets/DefectFilesLoader.tsx
+++ b/src/widgets/DefectFilesLoader.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Skeleton } from 'antd';
+import { useDefectAttachments } from '@/entities/defect';
+import DefectFilesTable from './DefectFilesTable';
+import type { RemoteDefectFile } from '@/shared/types/defectFile';
+
+export default function DefectFilesLoader({ defectId }: { defectId: number }) {
+  const { data = [], isLoading } = useDefectAttachments(defectId);
+  const files: RemoteDefectFile[] = (data ?? []).map((f: any) => ({
+    id: String(f.id),
+    name: f.original_name ?? f.storage_path.split('/').pop(),
+    path: f.storage_path,
+    url: f.file_url,
+    mime_type: f.file_type,
+    size: (f as any).file_size,
+  }));
+
+  if (isLoading) return <Skeleton active paragraph={{ rows: 2 }} />;
+  if (!files.length) return null;
+  return <DefectFilesTable defectId={defectId} files={files} />;
+}

--- a/src/widgets/DefectFilesTable.tsx
+++ b/src/widgets/DefectFilesTable.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { Table, Tooltip, Button, Space } from 'antd';
+import {
+  FileOutlined,
+  FilePdfOutlined,
+  FileImageOutlined,
+  FileZipOutlined,
+  FileTextOutlined,
+  DownloadOutlined,
+  DeleteOutlined,
+} from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import type { RemoteDefectFile } from '@/shared/types/defectFile';
+import { signedUrl, useRemoveDefectAttachment } from '@/entities/defect';
+
+interface Props {
+  defectId: number;
+  files: RemoteDefectFile[];
+}
+
+const formatSize = (size?: number) => {
+  if (!size) return '—';
+  if (size < 1024) return size + ' B';
+  if (size < 1024 * 1024) return (size / 1024).toFixed(1) + ' KB';
+  return (size / 1024 / 1024).toFixed(1) + ' MB';
+};
+
+const iconByMime = (mime?: string) => {
+  if (!mime) return <FileOutlined />;
+  if (mime.includes('pdf')) return <FilePdfOutlined />;
+  if (mime.startsWith('image/')) return <FileImageOutlined />;
+  if (mime.includes('zip') || mime.includes('rar')) return <FileZipOutlined />;
+  if (mime.includes('text')) return <FileTextOutlined />;
+  return <FileOutlined />;
+};
+
+export default function DefectFilesTable({ defectId, files }: Props) {
+  const remove = useRemoveDefectAttachment();
+
+  const columns: ColumnsType<RemoteDefectFile> = [
+    {
+      dataIndex: 'icon',
+      width: 32,
+      render: (_: unknown, row) => iconByMime(row.mime_type),
+    },
+    { title: 'Имя', dataIndex: 'name', ellipsis: true },
+    { title: 'Размер', dataIndex: 'size', width: 100, render: formatSize },
+    {
+      title: 'Действия',
+      dataIndex: 'actions',
+      width: 100,
+      render: (_: unknown, row) => (
+        <Space>
+          <Tooltip title="Скачать">
+            <Button
+              size="small"
+              type="text"
+              icon={<DownloadOutlined />}
+              onClick={async () => {
+                const url = await signedUrl(row.path, row.name);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = row.name;
+                document.body.appendChild(a);
+                a.click();
+                a.remove();
+              }}
+            />
+          </Tooltip>
+          <Tooltip title="Удалить">
+            <Button
+              size="small"
+              type="text"
+              danger
+              icon={<DeleteOutlined />}
+              onClick={() =>
+                remove.mutate({ defectId, attachmentId: Number(row.id) })
+              }
+            />
+          </Tooltip>
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <Table
+      rowKey="id"
+      size="small"
+      pagination={false}
+      columns={columns}
+      dataSource={files}
+      style={{ marginLeft: 40 }}
+      showHeader={false}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- implement `useDefectAttachments` hook for lazy defect file loading
- add tables to display defect files
- enhance defect editor table with sorting, tooltips, expandable file rows and skeleton
- show Snackbar messages on defect add/update/delete
- move "Add defects" button above table and pass loading state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686027cf63d4832ea58d5802104f264b