### PR TITLE
Add unit archive page

### DIFF
--- a/src/app/Router.tsx
+++ b/src/app/Router.tsx
@@ -16,6 +16,7 @@ import LoginPage from "@/pages/UnitsPage/LoginPage"; // ← CHANGE
 import RegisterPage from "@/pages/UnitsPage/RegisterPage"; // ← CHANGE
 import AdminPage from "@/pages/UnitsPage/AdminPage";
 import ProjectStructurePage from "@/pages/ProjectStructurePage/ProjectStructurePage";
+import ObjectArchivePage from "@/pages/ObjectArchivePage/ObjectArchivePage";
 import ProfilePage from "@/pages/ProfilePage/ProfilePage";
 import RequirePermission from "@/shared/components/RequirePermission";
 
@@ -126,6 +127,17 @@ export default function AppRouter() {
           </RequireAuth>
         }
         data-oid="50g:286"
+      />
+
+      <Route
+        path="/unit-archive"
+        element={
+          <RequireAuth>
+            <RequirePermission page="structure">
+              <ObjectArchivePage />
+            </RequirePermission>
+          </RequireAuth>
+        }
       />
 
       <Route

--- a/src/entities/unitArchive.ts
+++ b/src/entities/unitArchive.ts
@@ -1,0 +1,115 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/shared/api/supabaseClient';
+
+export interface ArchiveFile {
+  id: string;
+  name: string;
+  path: string;
+  mime: string;
+}
+
+export interface UnitArchive {
+  officialDocs: ArchiveFile[];
+  defectDocs: ArchiveFile[];
+  courtDocs: ArchiveFile[];
+  drawings: ArchiveFile[];
+}
+
+function mapFile(a: any): ArchiveFile {
+  if (!a) return { id: '', name: '', path: '', mime: '' };
+  let name = a.original_name;
+  if (!name) {
+    try {
+      name = decodeURIComponent(
+        a.storage_path.split('/').pop()?.replace(/^\d+_/, '') || a.storage_path,
+      );
+    } catch {
+      name = a.storage_path;
+    }
+  }
+  return {
+    id: String(a.id),
+    name,
+    path: a.file_url,
+    mime: a.file_type,
+  };
+}
+
+export function useUnitArchive(unitId?: number) {
+  return useQuery<UnitArchive>({
+    queryKey: ['unit-archive', unitId],
+    enabled: !!unitId,
+    queryFn: async () => {
+      const result: UnitArchive = {
+        officialDocs: [],
+        defectDocs: [],
+        courtDocs: [],
+        drawings: [],
+      };
+      if (!unitId) return result;
+
+      const { data: claimRows } = await supabase
+        .from('claim_units')
+        .select('claim_id')
+        .eq('unit_id', unitId);
+      const claimIds = (claimRows ?? []).map((r: any) => r.claim_id);
+      if (claimIds.length) {
+        const { data } = await supabase
+          .from('claim_attachments')
+          .select(
+            'attachments(id, storage_path, file_url:path, file_type:mime_type, original_name)',
+          )
+          .in('claim_id', claimIds);
+        result.officialDocs = (data ?? []).map((r: any) => mapFile(r.attachments));
+      }
+
+      const { data: defectRows } = await supabase
+        .from('defects')
+        .select('id')
+        .eq('unit_id', unitId);
+      const defectIds = (defectRows ?? []).map((r: any) => r.id);
+      if (defectIds.length) {
+        const { data } = await supabase
+          .from('defect_attachments')
+          .select(
+            'attachments(id, storage_path, file_url:path, file_type:mime_type, original_name)',
+          )
+          .in('defect_id', defectIds);
+        result.defectDocs = (data ?? []).map((r: any) => mapFile(r.attachments));
+      }
+
+      const { data: caseRows } = await supabase
+        .from('court_case_units')
+        .select('court_case_id')
+        .eq('unit_id', unitId);
+      const caseIds = (caseRows ?? []).map((r: any) => r.court_case_id);
+      if (caseIds.length) {
+        const { data } = await supabase
+          .from('court_case_attachments')
+          .select(
+            'attachments(id, storage_path, file_url:path, file_type:mime_type, original_name)',
+          )
+          .in('court_case_id', caseIds);
+        result.courtDocs = (data ?? []).map((r: any) => mapFile(r.attachments));
+      }
+
+      const { data: letterRows } = await supabase
+        .from('letter_units')
+        .select('letter_id')
+        .eq('unit_id', unitId);
+      const letterIds = (letterRows ?? []).map((r: any) => r.letter_id);
+      if (letterIds.length) {
+        const { data } = await supabase
+          .from('letter_attachments')
+          .select(
+            'attachments(id, storage_path, file_url:path, file_type:mime_type, original_name)',
+          )
+          .in('letter_id', letterIds);
+        result.drawings = (data ?? []).map((r: any) => mapFile(r.attachments));
+      }
+
+      return result;
+    },
+    staleTime: 5 * 60_000,
+  });
+}

--- a/src/pages/ObjectArchivePage/ObjectArchivePage.tsx
+++ b/src/pages/ObjectArchivePage/ObjectArchivePage.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { ConfigProvider, Typography, Divider, Skeleton } from 'antd';
+import ruRU from 'antd/locale/ru_RU';
+import { useSearchParams } from 'react-router-dom';
+import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
+import { useUnitArchive } from '@/entities/unitArchive';
+
+export default function ObjectArchivePage() {
+  const [params] = useSearchParams();
+  const unitId = Number(params.get('unit_id'));
+  const { data, isLoading } = useUnitArchive(Number.isNaN(unitId) ? undefined : unitId);
+
+  return (
+    <ConfigProvider locale={ruRU}>
+      <Typography.Title level={3}>Архив документации</Typography.Title>
+      {isLoading && <Skeleton active />} 
+      {!isLoading && (
+        <>
+          <Typography.Title level={4}>Документы по объекту</Typography.Title>
+          <AttachmentEditorTable remoteFiles={data?.officialDocs} showMime={false} />
+          <Divider />
+          <Typography.Title level={4}>Документы по дефектам</Typography.Title>
+          <AttachmentEditorTable remoteFiles={data?.defectDocs} showMime={false} />
+          <Divider />
+          <Typography.Title level={4}>Судебные материалы</Typography.Title>
+          <AttachmentEditorTable remoteFiles={data?.courtDocs} showMime={false} />
+          <Divider />
+          <Typography.Title level={4}>Чертежи и исполнительная документация</Typography.Title>
+          <AttachmentEditorTable remoteFiles={data?.drawings} showMime={false} />
+        </>
+      )}
+    </ConfigProvider>
+  );
+}

--- a/src/widgets/UnitsMatrix/UnitsMatrix.tsx
+++ b/src/widgets/UnitsMatrix/UnitsMatrix.tsx
@@ -417,6 +417,18 @@ export default function UnitsMatrix({
               >
                 Добавить письмо
               </AntButton>
+              <AntButton
+                onClick={() => {
+                  const id = actionDialog.unit?.id;
+                  const search = createSearchParams({
+                    unit_id: String(id ?? ''),
+                  }).toString();
+                  navigate(`/unit-archive?${search}`);
+                  setActionDialog({ open: false, unit: null, action: '' });
+                }}
+              >
+                Посмотреть архив
+              </AntButton>
             </div>
           )}
         </Modal>


### PR DESCRIPTION
## Summary
- fetch unit archive data from Supabase
- show archive sections with attachments
- link archive page from structure cell menu
- register new route for unit archive

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686035cc53b0832eaf40e1177903f9c8