### PR TITLE
Add defect attachments in claims

### DIFF
--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -21,10 +21,13 @@ import { useDebounce } from '@/shared/hooks/useDebounce';
 import { useUsers } from '@/entities/user';
 import { useClaimStatuses } from '@/entities/claimStatus';
 import { useCreateClaim } from '@/entities/claim';
+import { addDefectAttachments } from '@/entities/attachment';
+import { supabase } from '@/shared/api/supabaseClient';
 import { useProjectId } from '@/shared/hooks/useProjectId';
 import { useNotify } from '@/shared/hooks/useNotify';
 import DefectEditableTable from '@/widgets/DefectEditableTable';
 import { useCreateDefects, type NewDefect } from '@/entities/defect';
+import type { NewDefectFile } from '@/shared/types/defectFile';
 import { useAuthStore } from '@/shared/store/authStore';
 import type { RoleName } from '@/shared/types/rolePermission';
 import { useRolePermission } from '@/entities/rolePermission';
@@ -74,6 +77,7 @@ export interface ClaimFormValues {
 export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefectsForm = true, showAttachments = true }: ClaimFormAntdProps) {
   const [form] = Form.useForm<ClaimFormValues>();
   const [files, setFiles] = useState<File[]>([]);
+  const [defectFiles, setDefectFiles] = useState<Record<number, NewDefectFile[]>>({});
   const globalProjectId = useProjectId();
   const projectIdWatch = Form.useWatch('project_id', form) ?? globalProjectId;
   const projectId = projectIdWatch != null ? Number(projectIdWatch) : null;
@@ -103,6 +107,9 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
     setFiles((p) => [...p, ...dropped]);
   };
   const removeFile = (idx: number) => setFiles((p) => p.filter((_, i) => i !== idx));
+  const changeDefectFiles = (idx: number, fs: NewDefectFile[]) => {
+    setDefectFiles((p) => ({ ...p, [idx]: fs }));
+  };
 
   useEffect(() => {
     if (initialValues.project_id != null) {
@@ -175,6 +182,17 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
     }
   }, [defectsWatch, form]);
 
+  useEffect(() => {
+    if (!Array.isArray(defectsWatch)) return;
+    setDefectFiles((prev) => {
+      const res: Record<number, NewDefectFile[]> = {};
+      defectsWatch.forEach((_, i) => {
+        if (prev[i]) res[i] = prev[i];
+      });
+      return res;
+    });
+  }, [defectsWatch]);
+
 
   const onFinish = async (values: ClaimFormValues) => {
     if (!showDefectsForm) return;
@@ -201,6 +219,25 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
       case_uid_id: values.case_uid_id ?? null,
     }));
     const defectIds = await createDefects.mutateAsync(newDefs);
+
+    for (let i = 0; i < defectIds.length; i += 1) {
+      const filesFor = defectFiles[i] ?? [];
+      if (filesFor.length) {
+        const uploaded = await addDefectAttachments(
+          filesFor.map((f) => ({ file: f.file, type_id: null })),
+          defectIds[i],
+        );
+        if (uploaded.length) {
+          await supabase.from('defect_attachments').insert(
+            uploaded.map((u: any) => ({
+              defect_id: defectIds[i],
+              attachment_id: u.id,
+            })),
+          );
+        }
+      }
+    }
+
     await create.mutateAsync({
       ...rest,
       attachments: files,
@@ -215,6 +252,7 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
     } as any);
     form.resetFields();
     setFiles([]);
+    setDefectFiles({});
     onCreated?.();
   };
 
@@ -333,6 +371,8 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
               remove={remove}
               projectId={projectId}
               showFiles={false}
+              fileMap={defectFiles}
+              onFilesChange={changeDefectFiles}
               defaultReceivedAt={acceptedOnWatch}
             />
           )}

--- a/src/features/claim/ClaimViewModal.tsx
+++ b/src/features/claim/ClaimViewModal.tsx
@@ -20,6 +20,7 @@ import { useBrigades } from '@/entities/brigade';
 import { useContractors } from '@/entities/contractor';
 import { useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/shared/api/supabaseClient';
+import { addDefectAttachments } from '@/entities/attachment';
 import { useClaimAttachments } from './model/useClaimAttachments';
 import type { ClaimFormAntdEditRef } from '@/shared/types/claimFormAntdEditRef';
 import { useAuthStore } from '@/shared/store/authStore';
@@ -27,6 +28,7 @@ import { useRolePermission } from '@/entities/rolePermission';
 import type { RoleName } from '@/shared/types/rolePermission';
 import FilePreviewModal from '@/shared/ui/FilePreviewModal';
 import type { PreviewFile } from '@/shared/types/previewFile';
+import type { NewDefectFile } from '@/shared/types/defectFile';
 
 interface Props {
   open: boolean;
@@ -57,6 +59,7 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
   const [showAdd, setShowAdd] = React.useState(false);
   const [viewDefId, setViewDefId] = React.useState<number | null>(null);
   const [previewFile, setPreviewFile] = React.useState<PreviewFile | null>(null);
+  const [defectFiles, setDefectFiles] = React.useState<Record<number, NewDefectFile[]>>({});
   const tmpIdRef = React.useRef(-1);
 
   const lastClaimIdRef = React.useRef<number | null>(null);
@@ -83,6 +86,7 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
       setNewDefs([]);
       setRemovedIds([]);
       attachments.reset();
+      setDefectFiles({});
     }
   }, [open]);
 
@@ -147,6 +151,10 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
   const handleRemove = (id: number) => {
     if (id < 0) {
       setNewDefs((p) => p.filter((d) => d.tmpId !== id));
+      setDefectFiles((p) => {
+        const { [id]: _omit, ...rest } = p;
+        return rest;
+      });
     } else {
       setDefectIds((p) => p.filter((d) => d !== id));
       setRemovedIds((p) => [...p, id]);
@@ -166,6 +174,10 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
       })),
     ]);
     setShowAdd(false);
+  };
+
+  const changeDefFiles = (id: number, files: NewDefectFile[]) => {
+    setDefectFiles((p) => ({ ...p, [id]: files }));
   };
 
   const handleChangeDef = (
@@ -202,6 +214,23 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
           })),
         );
         await closeDefectsForClaim(claim.id, claim.claim_status_id ?? null);
+        for (let i = 0; i < createdIds.length; i += 1) {
+          const filesFor = defectFiles[newDefs[i].tmpId] ?? [];
+          if (filesFor.length) {
+            const uploaded = await addDefectAttachments(
+              filesFor.map((f) => ({ file: f.file, type_id: null })),
+              createdIds[i],
+            );
+            if (uploaded.length) {
+              await supabase.from('defect_attachments').insert(
+                uploaded.map((u: any) => ({
+                  defect_id: createdIds[i],
+                  attachment_id: u.id,
+                })),
+              );
+            }
+          }
+        }
       }
       if (removedIds.length) {
         await supabase
@@ -231,6 +260,7 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
       setEditedDefs({});
       setNewDefs([]);
       setRemovedIds([]);
+      setDefectFiles({});
       onClose();
     } catch (e) {
       console.error(e);
@@ -273,6 +303,8 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
                 onChange={handleChangeDef}
                 onRemove={handleRemove}
                 onView={setViewDefId}
+                fileMap={defectFiles}
+                onFilesChange={changeDefFiles}
               />
             ) : (
               <Typography.Text>Дефекты не указаны</Typography.Text>

--- a/src/features/defect/DefectFilesModal.tsx
+++ b/src/features/defect/DefectFilesModal.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Modal } from 'antd';
+import FileDropZone from '@/shared/ui/FileDropZone';
+import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
+import type { NewDefectFile } from '@/shared/types/defectFile';
+
+/**
+ * Модальное окно выбора файлов для нового дефекта.
+ */
+export interface DefectFilesModalProps {
+  /** Открыто ли окно */
+  open: boolean;
+  /** Текущие файлы */
+  files: NewDefectFile[];
+  /** Изменение файлов */
+  onChange: (files: NewDefectFile[]) => void;
+  /** Закрытие окна */
+  onClose: () => void;
+}
+
+export default function DefectFilesModal({
+  open,
+  files,
+  onChange,
+  onClose,
+}: DefectFilesModalProps) {
+  const handleFiles = (f: File[]) => {
+    onChange([...files, ...f.map((file) => ({ file }))]);
+  };
+  const removeFile = (idx: number) => {
+    onChange(files.filter((_, i) => i !== idx));
+  };
+  return (
+    <Modal open={open} onCancel={onClose} onOk={onClose} title="Файлы дефекта">
+      <FileDropZone onFiles={handleFiles} />
+      <AttachmentEditorTable
+        newFiles={files.map((f) => ({ file: f.file, mime: f.file.type }))}
+        showMime={false}
+        onRemoveNew={removeFile}
+      />
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary
- add DefectFilesModal for selecting files
- extend DefectEditableTable with attachments support
- allow attaching files to defects when creating a claim
- show and edit defect attachments in claim view
- update TicketDefectsEditorTable to manage files per defect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68603c4f0edc832e880788d0af1efa51