### PR TITLE
Add project selection panel to dashboard

### DIFF
--- a/src/features/project/ProjectsMultiSelect.tsx
+++ b/src/features/project/ProjectsMultiSelect.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Select, Skeleton } from 'antd';
+import { useVisibleProjects } from '@/entities/project';
+
+/**
+ * Множественный выбор проектов для дашборда.
+ */
+export default function ProjectsMultiSelect({
+  value,
+  onChange,
+}: {
+  value: number[];
+  onChange: (v: number[]) => void;
+}) {
+  const { data: projects = [], isPending } = useVisibleProjects();
+
+  const options = React.useMemo(
+    () => projects.map((p) => ({ value: p.id, label: p.name })),
+    [projects],
+  );
+
+  if (isPending) {
+    return <Skeleton.Input active style={{ width: 260 }} />;
+  }
+
+  return (
+    <Select
+      mode="multiple"
+      allowClear
+      placeholder="Выберите проекты"
+      value={value}
+      onChange={onChange}
+      options={options}
+      style={{ minWidth: 260 }}
+    />
+  );
+}

--- a/src/pages/DashboardPage/DashboardPage.tsx
+++ b/src/pages/DashboardPage/DashboardPage.tsx
@@ -5,12 +5,15 @@ import { useSnackbar } from 'notistack';
 import { useVisibleProjects } from '@/entities/project';
 import { useAuthStore } from '@/shared/store/authStore';
 import DashboardInfographics from '@/widgets/DashboardInfographics';
+import ProjectsMultiSelect from '@/features/project/ProjectsMultiSelect';
+import ProjectStatsCard from '@/widgets/ProjectStatsCard';
 
 /** Главная страница с инфографикой. */
 export default function DashboardPage() {
   const { enqueueSnackbar } = useSnackbar();
   const { data: projects = [], isPending, error } = useVisibleProjects();
   const profile = useAuthStore((s) => s.profile);
+  const [selected, setSelected] = React.useState<number[]>([]);
 
   useEffect(() => {
     if (error) enqueueSnackbar('Ошибка загрузки проектов.', { variant: 'error' });
@@ -26,6 +29,14 @@ export default function DashboardPage() {
         </Typography.Title>
         <Typography.Paragraph>Всего проектов: {projects.length}</Typography.Paragraph>
       </Card>
+
+      <Card title="Выбор проектов">
+        <ProjectsMultiSelect value={selected} onChange={setSelected} />
+      </Card>
+
+      {selected.map((id) => (
+        <ProjectStatsCard key={id} projectId={id} />
+      ))}
 
       <DashboardInfographics />
 

--- a/src/shared/hooks/useDashboardStats.ts
+++ b/src/shared/hooks/useDashboardStats.ts
@@ -9,11 +9,14 @@ import type { DashboardStats } from '@/shared/types/dashboardStats';
 
 /**
  * Загружает статистику для дашборда и подписывается на обновления.
+ *
+ * @param pid Опциональный идентификатор проекта. Если не указан,
+ *            используется выбранный в приложении проект.
  */
-export function useDashboardStats() {
+export function useDashboardStats(pid?: number | null) {
   const qc = useQueryClient();
   const { data: projects = [] } = useVisibleProjects();
-  const projectId = useProjectId();
+  const projectId = pid ?? useProjectId();
   const { data: claimStatuses = [] } = useClaimStatuses();
   const { data: defectStatuses = [] } = useDefectStatuses();
 

--- a/src/widgets/ProjectStatsCard.tsx
+++ b/src/widgets/ProjectStatsCard.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Card, Row, Col, Statistic, Skeleton } from 'antd';
+import { useDashboardStats } from '@/shared/hooks/useDashboardStats';
+import { useVisibleProjects } from '@/entities/project';
+
+interface Props {
+  projectId: number;
+}
+
+/**
+ * Карточка статистики выбранного проекта.
+ */
+export default function ProjectStatsCard({ projectId }: Props) {
+  const { data, isPending } = useDashboardStats(projectId);
+  const { data: projects = [] } = useVisibleProjects();
+  const name = projects.find((p) => p.id === projectId)?.name || 'Проект';
+
+  if (isPending || !data) {
+    return (
+      <Card title={name} style={{ width: '100%' }}>
+        <Skeleton active paragraph={{ rows: 2 }} />
+      </Card>
+    );
+  }
+
+  const prj = data.projects[0];
+
+  return (
+    <Card title={name} style={{ width: '100%' }}>
+      <Row gutter={16}>
+        <Col span={6}>
+          <Statistic title="Объекты" value={prj?.unitCount ?? 0} />
+        </Col>
+        <Col span={6}>
+          <Statistic title="Откр. претензий" value={data.claimsOpen} />
+        </Col>
+        <Col span={6}>
+          <Statistic title="Закр. претензий" value={data.claimsClosed} />
+        </Col>
+        <Col span={6}>
+          <Statistic title="Откр. дефектов" value={data.defectsOpen} />
+        </Col>
+      </Row>
+      <Row gutter={16} style={{ marginTop: 16 }}>
+        <Col span={6}>
+          <Statistic title="Закр. дефектов" value={data.defectsClosed} />
+        </Col>
+        <Col span={6}>
+          <Statistic title="Писем" value={prj?.letterCount ?? 0} />
+        </Col>
+        <Col span={6}>
+          <Statistic title="Судебных дел" value={data.courtCases} />
+        </Col>
+      </Row>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- add multi-project select feature
- show stats for chosen projects
- allow `useDashboardStats` to take a project ID
- update dashboard page to include project selection and stats

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68603d4648d0832eb80be1a378645747