### PR TITLE
Update archive view

### DIFF
--- a/src/pages/ObjectArchivePage/ObjectArchivePage.tsx
+++ b/src/pages/ObjectArchivePage/ObjectArchivePage.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { ConfigProvider, Typography, Divider, Skeleton } from 'antd';
+import { ConfigProvider, Typography, Divider, Skeleton, Upload, Input } from 'antd';
 import ruRU from 'antd/locale/ru_RU';
 import { useSearchParams } from 'react-router-dom';
+import { UploadOutlined } from '@ant-design/icons';
 import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
 import { useUnitArchive } from '@/entities/unitArchive';
 
@@ -9,6 +10,7 @@ export default function ObjectArchivePage() {
   const [params] = useSearchParams();
   const unitId = Number(params.get('unit_id'));
   const { data, isLoading } = useUnitArchive(Number.isNaN(unitId) ? undefined : unitId);
+  const [newObjectFiles, setNewObjectFiles] = React.useState<File[]>([]);
 
   return (
     <ConfigProvider locale={ruRU}>
@@ -16,17 +18,45 @@ export default function ObjectArchivePage() {
       {isLoading && <Skeleton active />} 
       {!isLoading && (
         <>
-          <Typography.Title level={4}>Документы по объекту</Typography.Title>
-          <AttachmentEditorTable remoteFiles={data?.officialDocs} showMime={false} />
+          <Typography.Title level={4}>
+            Документы по объекту{' '}
+            <Upload
+              beforeUpload={(file) => {
+                setNewObjectFiles((p) => [...p, file]);
+                return false;
+              }}
+              showUploadList={false}
+            >
+              <UploadOutlined />
+            </Upload>
+          </Typography.Title>
+          <AttachmentEditorTable
+            remoteFiles={data?.objectDocs}
+            newFiles={newObjectFiles.map((f) => ({ file: f }))}
+            showMime={false}
+            showDetails
+          />
+          <Divider />
+          <Typography.Title level={4}>Документы по замечаниям</Typography.Title>
+          <AttachmentEditorTable
+            remoteFiles={data?.remarkDocs}
+            showMime={false}
+            getLink={(f) => `/claims?id=${f.entityId}`}
+          />
           <Divider />
           <Typography.Title level={4}>Документы по дефектам</Typography.Title>
-          <AttachmentEditorTable remoteFiles={data?.defectDocs} showMime={false} />
+          <AttachmentEditorTable
+            remoteFiles={data?.defectDocs}
+            showMime={false}
+            getLink={(f) => `/defects?id=${f.entityId}`}
+          />
           <Divider />
-          <Typography.Title level={4}>Судебные материалы</Typography.Title>
-          <AttachmentEditorTable remoteFiles={data?.courtDocs} showMime={false} />
-          <Divider />
-          <Typography.Title level={4}>Чертежи и исполнительная документация</Typography.Title>
-          <AttachmentEditorTable remoteFiles={data?.drawings} showMime={false} />
+          <Typography.Title level={4}>Документы по судебным делам</Typography.Title>
+          <AttachmentEditorTable
+            remoteFiles={data?.courtDocs}
+            showMime={false}
+            getLink={(f) => `/court-cases?id=${f.entityId}`}
+          />
         </>
       )}
     </ConfigProvider>

--- a/src/shared/types/archiveFile.ts
+++ b/src/shared/types/archiveFile.ts
@@ -1,0 +1,15 @@
+/**
+ * Представление файла в архиве объекта.
+ */
+export interface ArchiveFile {
+  /** Идентификатор файла */
+  id: string;
+  /** Имя файла */
+  name: string;
+  /** Путь в хранилище */
+  path: string;
+  /** MIME-тип */
+  mime: string;
+  /** Идентификатор связанной сущности */
+  entityId?: number;
+}

--- a/src/shared/types/unitArchive.ts
+++ b/src/shared/types/unitArchive.ts
@@ -1,0 +1,15 @@
+import type { ArchiveFile } from './archiveFile';
+
+/**
+ * Набор документов, связанных с объектом.
+ */
+export interface UnitArchive {
+  /** Документы по объекту */
+  objectDocs: ArchiveFile[];
+  /** Документы по замечаниям */
+  remarkDocs: ArchiveFile[];
+  /** Документы по дефектам */
+  defectDocs: ArchiveFile[];
+  /** Документы по судебным делам */
+  courtDocs: ArchiveFile[];
+}

--- a/src/shared/ui/AttachmentEditorTable.tsx
+++ b/src/shared/ui/AttachmentEditorTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Table, Button, Space, Tooltip, Select } from 'antd';
+import { Table, Button, Space, Tooltip, Select, Input } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import {
   FileOutlined,
@@ -28,6 +28,10 @@ interface Props {
   getSignedUrl?: (path: string, name: string) => Promise<string>;
   /** Показывать колонку MIME */
   showMime?: boolean;
+  /** Показывать поле подробностей */
+  showDetails?: boolean;
+  /** Получить ссылку для просмотра сущности */
+  getLink?: (file: RemoteFile) => string | undefined;
 }
 
 /**
@@ -42,6 +46,8 @@ export default function AttachmentEditorTable({
                                                 onRemoveNew,
                                                 getSignedUrl,
                                                 showMime = true,
+                                                showDetails = false,
+                                                getLink,
                                               }: Props) {
   const [cache, setCache] = React.useState<Record<string, string>>({});
 
@@ -110,6 +116,27 @@ export default function AttachmentEditorTable({
     },
     ...(showMime
       ? [{ title: 'MIME', dataIndex: 'mime', width: 200 } as ColumnsType<Row>[number]]
+      : []),
+    ...(showDetails
+      ? [{
+          title: 'Подробности',
+          dataIndex: 'details',
+          width: 200,
+          render: () => <Input placeholder="Подробности" size="small" />,
+        } as ColumnsType<Row>[number]]
+      : []),
+    ...(getLink
+      ? [{
+          title: 'Ссылка',
+          dataIndex: 'link',
+          width: 120,
+          render: (_: unknown, row) =>
+            row.isRemote && row.id ? (
+              <a href={getLink({ id: row.id, name: row.name, path: row.path ?? '', mime: row.mime })}>
+                Открыть
+              </a>
+            ) : null,
+        } as ColumnsType<Row>[number]]
       : []),
     {
       title: 'Действия',


### PR DESCRIPTION
## Summary
- enhance AttachmentEditorTable with details field and optional links
- refactor unitArchive hooks for new object, remark, defect and court case docs
- add archive file types
- update ObjectArchivePage layout and upload icon

## Testing
- `npm test --silent`
- `npm run lint --silent` *(fails: parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68603fd9ced8832e8824f8860789a460