### PR TITLE
Update dashboard stats blocks

### DIFF
--- a/src/pages/DashboardPage/DashboardPage.tsx
+++ b/src/pages/DashboardPage/DashboardPage.tsx
@@ -1,10 +1,8 @@
 import React, { useEffect } from 'react';
-import { Link as RouterLink } from 'react-router-dom';
-import { Card, Typography, List, Skeleton, Space } from 'antd';
+import { Card, Typography, Skeleton, Space } from 'antd';
 import { useSnackbar } from 'notistack';
 import { useVisibleProjects } from '@/entities/project';
 import { useAuthStore } from '@/shared/store/authStore';
-import DashboardInfographics from '@/widgets/DashboardInfographics';
 import ProjectsMultiSelect from '@/features/project/ProjectsMultiSelect';
 import ProjectStatsCard from '@/widgets/ProjectStatsCard';
 
@@ -37,23 +35,6 @@ export default function DashboardPage() {
       {selected.map((id) => (
         <ProjectStatsCard key={id} projectId={id} />
       ))}
-
-      <DashboardInfographics />
-
-      <Card title="Список проектов">
-        {projects.length === 0 ? (
-          <Typography>Проектов пока нет.</Typography>
-        ) : (
-          <List
-            dataSource={projects}
-            renderItem={(p) => (
-              <List.Item>
-                <RouterLink to={`/units?project=${p.id}`}>{p.name}</RouterLink>
-              </List.Item>
-            )}
-          />
-        )}
-      </Card>
     </Space>
   );
 }

--- a/src/shared/types/dashboardStats.ts
+++ b/src/shared/types/dashboardStats.ts
@@ -9,6 +9,8 @@ export interface ProjectStats {
   defectTotal: number;
   /** Количество писем */
   letterCount: number;
+  /** Количество корпусов в проекте */
+  buildingCount: number;
 }
 
 export interface DashboardStats {
@@ -22,8 +24,10 @@ export interface DashboardStats {
   defectsOpen: number;
   /** Количество закрытых дефектов */
   defectsClosed: number;
-  /** Количество судебных дел */
-  courtCases: number;
+  /** Количество открытых судебных дел */
+  courtCasesOpen: number;
+  /** Количество закрытых судебных дел */
+  courtCasesClosed: number;
   /** Претензии по объектам */
   claimsByUnit: Array<{ unitName: string; count: number }>;
   /** Претензии по закрепленным инженерам */

--- a/src/widgets/DashboardInfographics.tsx
+++ b/src/widgets/DashboardInfographics.tsx
@@ -93,9 +93,14 @@ export default function DashboardInfographics() {
           <Bar data={sortedDefectEng} xField="count" yField="name" height={200} />
         </Card>
       </Col>
-      <Col span={24}>
+      <Col span={12}>
         <Card>
-          <Statistic title="Судебных дел" value={data.courtCases} />
+          <Statistic title="Откр. судебных дел" value={data.courtCasesOpen} />
+        </Card>
+      </Col>
+      <Col span={12}>
+        <Card>
+          <Statistic title="Закр. судебных дел" value={data.courtCasesClosed} />
         </Card>
       </Col>
     </Row>

--- a/src/widgets/ProjectStatsCard.tsx
+++ b/src/widgets/ProjectStatsCard.tsx
@@ -28,28 +28,36 @@ export default function ProjectStatsCard({ projectId }: Props) {
   return (
     <Card title={name} style={{ width: '100%' }}>
       <Row gutter={16}>
-        <Col span={6}>
+        <Col span={8}>
           <Statistic title="Объекты" value={prj?.unitCount ?? 0} />
         </Col>
-        <Col span={6}>
+        <Col span={8}>
+          <Statistic title="Корпусов" value={prj?.buildingCount ?? 0} />
+        </Col>
+        <Col span={8}>
           <Statistic title="Откр. претензий" value={data.claimsOpen} />
-        </Col>
-        <Col span={6}>
-          <Statistic title="Закр. претензий" value={data.claimsClosed} />
-        </Col>
-        <Col span={6}>
-          <Statistic title="Откр. дефектов" value={data.defectsOpen} />
         </Col>
       </Row>
       <Row gutter={16} style={{ marginTop: 16 }}>
-        <Col span={6}>
+        <Col span={8}>
+          <Statistic title="Откр. дефектов" value={data.defectsOpen} />
+        </Col>
+        <Col span={8}>
+          <Statistic title="Закр. претензий" value={data.claimsClosed} />
+        </Col>
+        <Col span={8}>
           <Statistic title="Закр. дефектов" value={data.defectsClosed} />
         </Col>
-        <Col span={6}>
+      </Row>
+      <Row gutter={16} style={{ marginTop: 16 }}>
+        <Col span={8}>
           <Statistic title="Писем" value={prj?.letterCount ?? 0} />
         </Col>
-        <Col span={6}>
-          <Statistic title="Судебных дел" value={data.courtCases} />
+        <Col span={8}>
+          <Statistic title="Откр. судебных дел" value={data.courtCasesOpen} />
+        </Col>
+        <Col span={8}>
+          <Statistic title="Закр. судебных дел" value={data.courtCasesClosed} />
         </Col>
       </Row>
     </Card>


### PR DESCRIPTION
## Summary
- extend dashboard stats to include building count and open/closed court cases
- display new metrics in project stats card and infographics
- trim dashboard page to only show welcome, project selector and stats

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686041a366f8832e9cf6306c166a1a43