### PR TITLE
Add description field to attachments

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -29,6 +29,13 @@
   },
   {
     "table_name": "attachments",
+    "column_name": "description",
+    "data_type": "text",
+    "is_nullable": "YES",
+    "column_default": null
+  },
+  {
+    "table_name": "attachments",
     "column_name": "storage_path",
     "data_type": "text",
     "is_nullable": "NO",

--- a/src/entities/attachment.js
+++ b/src/entities/attachment.js
@@ -123,12 +123,13 @@ export async function addCaseAttachments(files, caseId) {
         mime_type: u.type,
         original_name: files[idx].file.name,
         storage_path: u.path,
+        description: files[idx].description ?? null,
     }));
 
     const { data, error } = await supabase
         .from('attachments')
         .insert(rows)
-        .select('id, storage_path, file_url:path, file_type:mime_type, original_name');
+        .select('id, storage_path, file_url:path, file_type:mime_type, original_name, description');
 
     if (error) throw error;
     return data ?? [];
@@ -149,12 +150,13 @@ export async function addLetterAttachments(files, letterId) {
         mime_type: u.type,
         original_name: files[idx].file.name,
         storage_path: u.path,
+        description: files[idx].description ?? null,
     }));
 
     const { data, error } = await supabase
         .from('attachments')
         .insert(rows)
-        .select('id, storage_path, file_url:path, file_type:mime_type, original_name');
+        .select('id, storage_path, file_url:path, file_type:mime_type, original_name, description');
 
     if (error) throw error;
     return data ?? [];
@@ -177,12 +179,13 @@ export async function addTicketAttachments(files, projectId, ticketId) {
         mime_type: u.type,
         original_name: files[idx].file.name,
         storage_path: u.path,
+        description: files[idx].description ?? null,
     }));
 
     const { data, error } = await supabase
         .from('attachments')
         .insert(rows)
-        .select('id, storage_path, file_url:path, file_type:mime_type, original_name');
+        .select('id, storage_path, file_url:path, file_type:mime_type, original_name, description');
 
     if (error) throw error;
     return data ?? [];
@@ -204,12 +207,13 @@ export async function addClaimAttachments(files, claimId) {
         mime_type: u.type,
         original_name: files[idx].file.name,
         storage_path: u.path,
+        description: files[idx].description ?? null,
     }));
 
     const { data, error } = await supabase
         .from('attachments')
         .insert(rows)
-        .select('id, storage_path, file_url:path, file_type:mime_type, original_name');
+        .select('id, storage_path, file_url:path, file_type:mime_type, original_name, description');
 
     if (error) throw error;
     return data ?? [];
@@ -231,12 +235,13 @@ export async function addDefectAttachments(files, defectId) {
         mime_type: u.type,
         original_name: files[idx].file.name,
         storage_path: u.path,
+        description: files[idx].description ?? null,
     }));
 
     const { data, error } = await supabase
         .from('attachments')
         .insert(rows)
-        .select('id, storage_path, file_url:path, file_type:mime_type, original_name');
+        .select('id, storage_path, file_url:path, file_type:mime_type, original_name, description');
 
     if (error) throw error;
     return data ?? [];
@@ -250,7 +255,7 @@ export async function getAttachmentsByIds(ids) {
     if (!ids.length) return [];
     const { data, error } = await supabase
         .from('attachments')
-        .select('id, storage_path, file_url:path, file_type:mime_type, original_name')
+        .select('id, storage_path, file_url:path, file_type:mime_type, original_name, description')
         .in('id', ids);
 
     if (error) throw error;

--- a/src/entities/claim.ts
+++ b/src/entities/claim.ts
@@ -144,7 +144,7 @@ export function useClaims() {
           statuses (id, name, color),
           claim_units(unit_id),
           claim_defects(defect_id),
-          claim_attachments(attachments(id, storage_path, file_url:path, file_type:mime_type, original_name))`,
+          claim_attachments(attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description))`,
         );
       q = filterByProjects(q, projectId, projectIds, onlyAssigned);
       q = q.order('created_at', { ascending: false });
@@ -194,7 +194,7 @@ export function useClaim(id?: number | string) {
           statuses (id, name, color),
           claim_units(unit_id),
           claim_defects(defect_id),
-          claim_attachments(attachments(id, storage_path, file_url:path, file_type:mime_type, original_name))`,
+          claim_attachments(attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description))`,
         )
         .eq('id', claimId);
       q = filterByProjects(q, projectId, projectIds, onlyAssigned);
@@ -239,7 +239,7 @@ export function useClaimAll(id?: number | string) {
           statuses (id, name, color),
           claim_units(unit_id),
           claim_defects(defect_id),
-          claim_attachments(attachments(id, storage_path, file_url:path, file_type:mime_type, original_name))`,
+          claim_attachments(attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description))`,
         )
         .eq('id', claimId)
         .maybeSingle();
@@ -279,7 +279,7 @@ export function useClaimsAll() {
           statuses (id, name, color),
           claim_units(unit_id),
           claim_defects(defect_id),
-          claim_attachments(attachments(id, storage_path, file_url:path, file_type:mime_type, original_name))`,
+          claim_attachments(attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description))`,
         )
         .order('created_at', { ascending: false });
       if (error) throw error;
@@ -463,7 +463,9 @@ export function useCreateClaim() {
       if (attachments.length) {
         const uploaded = await addClaimAttachments(
           attachments.map((f: any) =>
-            'file' in f ? { file: f.file, type_id: f.type_id ?? null } : { file: f, type_id: null },
+            'file' in f
+              ? { file: f.file, type_id: f.type_id ?? null, description: f.description }
+              : { file: f, type_id: null, description: undefined },
           ),
           created.id,
         );
@@ -627,7 +629,7 @@ export function useClaimAttachments(id?: number) {
     queryFn: async () => {
       const { data } = await supabase
         .from('claim_attachments')
-        .select('attachments(id, storage_path, file_url:path, file_type:mime_type, original_name)')
+        .select('attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description)')
         .eq('claim_id', id as number);
       return (data ?? []).map((r: any) => r.attachments);
     },
@@ -696,7 +698,7 @@ export function useAddClaimAttachments() {
   return useMutation({
     mutationFn: async ({ claimId, files }: { claimId: number; files: File[] }) => {
       const uploaded = await addClaimAttachments(
-        files.map((f) => ({ file: f, type_id: null })),
+        files.map((f) => ({ file: f, type_id: null, description: undefined })),
         claimId,
       );
       if (uploaded.length) {

--- a/src/entities/courtCase/index.ts
+++ b/src/entities/courtCase/index.ts
@@ -468,7 +468,11 @@ export function useUpdateCourtCaseFull() {
       let uploaded: any[] = [];
       if (newAttachments.length) {
         uploaded = await addCaseAttachments(
-          newAttachments.map((f) => ({ file: f.file, type_id: null })),
+          newAttachments.map((f) => ({
+            file: f.file,
+            type_id: null,
+            description: (f as any).description,
+          })),
           id,
         );
         ids = ids.concat(uploaded.map((u) => u.id));

--- a/src/entities/defect.ts
+++ b/src/entities/defect.ts
@@ -73,7 +73,7 @@ export function useDefect(id?: number) {
       const { data: attachRows, error: attachErr } = await supabase
         .from('defect_attachments')
         .select(
-          'attachments(id, storage_path, file_url:path, file_type:mime_type, original_name)'
+          'attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description)'
         )
         .eq('defect_id', id as number);
       if (attachErr) throw attachErr;
@@ -305,7 +305,14 @@ export function useFixDefect() {
       }
       let uploaded: any[] = [];
       if (attachments.length) {
-        uploaded = await addDefectAttachments(attachments, id);
+        uploaded = await addDefectAttachments(
+          attachments.map((a: any) => ({
+            file: a.file,
+            type_id: a.type_id ?? null,
+            description: a.description,
+          })),
+          id,
+        );
         const rows = uploaded.map((u) => ({
           defect_id: id,
           attachment_id: u.id,
@@ -505,7 +512,7 @@ export function useAddDefectAttachments() {
   return useMutation({
     mutationFn: async ({ defectId, files }: { defectId: number; files: File[] }) => {
       const uploaded = await addDefectAttachments(
-        files.map((f) => ({ file: f, type_id: null })),
+        files.map((f) => ({ file: f, type_id: null, description: undefined })),
         defectId,
       );
       if (uploaded.length) {

--- a/src/entities/unitArchive.ts
+++ b/src/entities/unitArchive.ts
@@ -19,6 +19,7 @@ function mapFile(a: any, entityId?: number): ArchiveFile {
     name,
     path: a.file_url,
     mime: a.file_type,
+    description: a.description ?? null,
     entityId,
   };
 }
@@ -45,7 +46,7 @@ export function useUnitArchive(unitId?: number) {
         const { data } = await supabase
           .from('letter_attachments')
           .select(
-            'letter_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name)',
+            'letter_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description)',
           )
           .in('letter_id', letterIds);
         result.objectDocs = (data ?? []).map((r: any) =>
@@ -62,7 +63,7 @@ export function useUnitArchive(unitId?: number) {
         const { data } = await supabase
           .from('claim_attachments')
           .select(
-            'claim_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name)',
+            'claim_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description)',
           )
           .in('claim_id', claimIds);
         result.remarkDocs = (data ?? []).map((r: any) =>
@@ -79,7 +80,7 @@ export function useUnitArchive(unitId?: number) {
         const { data } = await supabase
           .from('defect_attachments')
           .select(
-            'defect_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name)',
+            'defect_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description)',
           )
           .in('defect_id', defectIds);
         result.defectDocs = (data ?? []).map((r: any) =>
@@ -96,7 +97,7 @@ export function useUnitArchive(unitId?: number) {
         const { data } = await supabase
           .from('court_case_attachments')
           .select(
-            'court_case_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name)',
+            'court_case_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description)',
           )
           .in('court_case_id', caseIds);
         result.courtDocs = (data ?? []).map((r: any) =>

--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -224,7 +224,7 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
       const filesFor = defectFiles[i] ?? [];
       if (filesFor.length) {
         const uploaded = await addDefectAttachments(
-          filesFor.map((f) => ({ file: f.file, type_id: null })),
+          filesFor.map((f) => ({ file: f.file, type_id: null, description: f.description })),
           defectIds[i],
         );
         if (uploaded.length) {

--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -356,7 +356,10 @@ const ClaimFormAntdEdit = React.forwardRef<
             newFiles={attachments.newFiles.map((f) => ({
               file: f.file,
               mime: f.file.type,
+              description: f.description,
             }))}
+            showDetails
+            onDescNew={(idx, d) => attachments.setDescription(idx, d)}
             onRemoveRemote={(id) => attachments.removeRemote(id)}
             onRemoveNew={(idx) => attachments.removeNew(idx)}
             getSignedUrl={(path, name) => signedUrl(path, name)}

--- a/src/features/claim/ClaimViewModal.tsx
+++ b/src/features/claim/ClaimViewModal.tsx
@@ -218,7 +218,7 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
           const filesFor = defectFiles[newDefs[i].tmpId] ?? [];
           if (filesFor.length) {
             const uploaded = await addDefectAttachments(
-              filesFor.map((f) => ({ file: f.file, type_id: null })),
+              filesFor.map((f) => ({ file: f.file, type_id: null, description: f.description })),
               createdIds[i],
             );
             if (uploaded.length) {

--- a/src/features/claim/model/useClaimAttachments.ts
+++ b/src/features/claim/model/useClaimAttachments.ts
@@ -41,6 +41,7 @@ export function useClaimAttachments(options: { claim?: (Claim & { attachments?: 
         path: storagePath ?? '',
         url: fileUrl,
         mime_type: fileType,
+        description: (file as any).description ?? null,
       } as RemoteClaimFile;
     });
     setRemoteFiles(attachments);
@@ -49,11 +50,14 @@ export function useClaimAttachments(options: { claim?: (Claim & { attachments?: 
   }, [claim]);
 
   const addFiles = useCallback((files: File[]) => {
-    setNewFiles((p) => [...p, ...files.map((f) => ({ file: f }))]);
+    setNewFiles((p) => [...p, ...files.map((f) => ({ file: f, description: '' }))]);
   }, []);
 
   const removeNew = useCallback((idx: number) => {
     setNewFiles((p) => p.filter((_, i) => i !== idx));
+  }, []);
+  const setDescription = useCallback((idx: number, val: string) => {
+    setNewFiles((p) => p.map((f, i) => (i === idx ? { ...f, description: val } : f)));
   }, []);
 
   const removeRemote = useCallback((id: string) => {
@@ -85,6 +89,7 @@ export function useClaimAttachments(options: { claim?: (Claim & { attachments?: 
     addFiles,
     removeNew,
     removeRemote,
+    setDescription,
     appendRemote,
     markPersisted,
     attachmentsChanged,

--- a/src/features/correspondence/AddLetterForm.tsx
+++ b/src/features/correspondence/AddLetterForm.tsx
@@ -41,7 +41,7 @@ export interface AddLetterFormData {
   unit_ids: number[];
   /** Статус письма */
   status_id: number | null;
-  attachments: { file: File }[];
+  attachments: { file: File; description?: string }[];
   parent_id: string | null;
 }
 
@@ -59,7 +59,7 @@ export default function AddLetterForm({ onSubmit, parentId = null, initialValues
   const senderValue = Form.useWatch('sender', form);
   const receiverValue = Form.useWatch('receiver', form);
 
-  const { files, addFiles, removeFile, reset: resetFiles } = useLetterFiles();
+  const { files, addFiles, setDescription, removeFile, reset: resetFiles } = useLetterFiles();
   const [senderType, setSenderType] = React.useState<'person' | 'contractor'>('contractor');
   const [receiverType, setReceiverType] = React.useState<'person' | 'contractor'>('contractor');
   const [personModal, setPersonModal] = React.useState<{ target: 'sender' | 'receiver'; data?: any } | null>(null);
@@ -125,7 +125,7 @@ export default function AddLetterForm({ onSubmit, parentId = null, initialValues
       ...values,
       date: values.date ?? dayjs(),
       status_id: statuses[0]?.id ?? null,
-      attachments: files,
+      attachments: files.map((f) => ({ file: f.file, description: f.description })),
       parent_id: parentId,
     });
     form.resetFields();
@@ -357,8 +357,15 @@ export default function AddLetterForm({ onSubmit, parentId = null, initialValues
         <Form.Item label="Вложения">
           <input type="file" multiple onChange={handleFiles} />
           {files.map((f, i) => (
-              <div key={i} style={{ display: 'flex', alignItems: 'center', marginTop: 4 }}>
+              <div key={i} style={{ display: 'flex', alignItems: 'center', marginTop: 4, gap: 8 }}>
                 <span style={{ marginRight: 8 }}>{f.file.name}</span>
+                <Input
+                  placeholder="Описание"
+                  size="small"
+                  value={f.description}
+                  onChange={(e) => setDescription(i, e.target.value)}
+                  style={{ width: 160 }}
+                />
                 <Button type="text" danger onClick={() => removeFile(i)}>
                   Удалить
                 </Button>

--- a/src/features/correspondence/LetterFormAntdEdit.tsx
+++ b/src/features/correspondence/LetterFormAntdEdit.tsx
@@ -400,10 +400,17 @@ export default function LetterFormAntdEdit({ letterId, onCancel, onSaved, embedd
             name: f.original_name ?? f.name,
             path: f.path,
             mime: f.mime_type,
+            description: f.description,
           }))}
-          newFiles={attachments.newFiles.map((f) => ({ file: f.file, mime: f.file.type }))}
+          newFiles={attachments.newFiles.map((f) => ({
+            file: f.file,
+            mime: f.file.type,
+            description: f.description,
+          }))}
           onRemoveRemote={attachments.removeRemote}
           onRemoveNew={attachments.removeNew}
+          onDescNew={(idx, d) => attachments.setDescription(idx, d)}
+          showDetails
           getSignedUrl={(path, name) => signedUrl(path, name)}
         />
       </Form.Item>

--- a/src/features/correspondence/model/useLetterFiles.ts
+++ b/src/features/correspondence/model/useLetterFiles.ts
@@ -1,17 +1,19 @@
 import { useState } from 'react';
 
-export interface LetterFile { file: File }
+export interface LetterFile { file: File; description?: string }
 
 /** Хук управления файлами письма */
 export function useLetterFiles() {
   const [files, setFiles] = useState<LetterFile[]>([]);
 
   const addFiles = (fs: File[]) =>
-    setFiles((p) => [...p, ...fs.map((f) => ({ file: f }))]);
+    setFiles((p) => [...p, ...fs.map((f) => ({ file: f, description: '' }))]);
   const setType = (_idx: number, _val: number | null) => {};
+  const setDescription = (idx: number, val: string) =>
+    setFiles((p) => p.map((f, i) => (i === idx ? { ...f, description: val } : f)));
   const removeFile = (idx: number) =>
     setFiles((p) => p.filter((_, i) => i !== idx));
   const reset = () => setFiles([]);
 
-  return { files, addFiles, setType, removeFile, reset };
+  return { files, addFiles, setType, setDescription, removeFile, reset };
 }

--- a/src/features/courtCase/AddCourtCaseFormAntd.tsx
+++ b/src/features/courtCase/AddCourtCaseFormAntd.tsx
@@ -131,7 +131,7 @@ export default function AddCourtCaseFormAntd({
   const [defendantType, setDefendantType] = useState<'person' | 'contractor'>('contractor');
   const [partyRole, setPartyRole] = useState<'plaintiff' | 'defendant' | null>(null);
   const [showClaims, setShowClaims] = useState(false);
-  const { caseFiles, addFiles: addCaseFiles, setType: setCaseFileType, removeFile: removeCaseFile, reset: resetCaseFiles } = useCaseFiles();
+  const { caseFiles, addFiles: addCaseFiles, setType: setCaseFileType, setDescription: setCaseFileDescription, removeFile: removeCaseFile, reset: resetCaseFiles } = useCaseFiles();
 
   useEffect(() => {
     if (showClaims && !(form.getFieldValue('claims')?.length)) {
@@ -184,7 +184,14 @@ export default function AddCourtCaseFormAntd({
 
       let newAtts: { id: number }[] = [];
       if (caseFiles.length) {
-        newAtts = await addCaseAttachments(caseFiles, newCase.id);
+        newAtts = await addCaseAttachments(
+          caseFiles.map((f) => ({
+            file: f.file,
+            type_id: f.type_id,
+            description: f.description,
+          })),
+          newCase.id,
+        );
         await updateCaseMutation.mutateAsync({
           id: newCase.id,
           updates: { attachment_ids: newAtts.map((a) => a.id) },
@@ -448,7 +455,14 @@ export default function AddCourtCaseFormAntd({
                 <Col flex="auto">
                   <span>{f.file.name}</span>
                 </Col>
-                <Col flex="220px" />
+                <Col flex="220px">
+                  <Input
+                    placeholder="Описание"
+                    size="small"
+                    value={f.description}
+                    onChange={(e) => setCaseFileDescription(i, e.target.value)}
+                  />
+                </Col>
                 <Col>
                   <Button type="text" danger onClick={() => removeCaseFile(i)}>
                     Удалить

--- a/src/features/courtCase/CourtCaseFormAntdEdit.tsx
+++ b/src/features/courtCase/CourtCaseFormAntdEdit.tsx
@@ -347,10 +347,17 @@ export default function CourtCaseFormAntdEdit({
             name: f.name,
             path: f.path,
             mime: f.mime_type,
+            description: f.description,
           }))}
-          newFiles={attachments.newFiles.map((f) => ({ file: f.file, mime: f.file.type }))}
+          newFiles={attachments.newFiles.map((f) => ({
+            file: f.file,
+            mime: f.file.type,
+            description: f.description,
+          }))}
           onRemoveRemote={(id) => attachments.removeRemote(id)}
           onRemoveNew={(idx) => attachments.removeNew(idx)}
+          onDescNew={(idx, d) => attachments.setDescription(idx, d)}
+          showDetails
           getSignedUrl={(path, name) => signedUrl(path, name)}
         />
       </Form.Item>

--- a/src/features/courtCase/model/useCaseAttachments.ts
+++ b/src/features/courtCase/model/useCaseAttachments.ts
@@ -32,6 +32,7 @@ export function useCaseAttachments(options: {
         path: storagePath ?? '',
         url: fileUrl,
         mime_type: fileType,
+        description: (file as any).description ?? null,
       } as RemoteCaseFile;
     }).filter(Boolean) as RemoteCaseFile[];
     setRemoteFiles(attachmentsWithType);
@@ -39,7 +40,7 @@ export function useCaseAttachments(options: {
 
   const addFiles = useCallback(
     (files: File[]) => {
-      setNewFiles((p) => [...p, ...files.map((f) => ({ file: f }))]);
+      setNewFiles((p) => [...p, ...files.map((f) => ({ file: f, description: '' }))]);
     },
     [],
   );
@@ -55,6 +56,9 @@ export function useCaseAttachments(options: {
   }, []);
   const changeRemoteType = (_id: string, _type: number | null) => {};
   const changeNewType = (_idx: number, _type: number | null) => {};
+  const setDescription = useCallback((idx: number, val: string) => {
+    setNewFiles((p) => p.map((f, i) => (i === idx ? { ...f, description: val } : f)));
+  }, []);
   const appendRemote = useCallback((files: RemoteCaseFile[]) => {
     setRemoteFiles((p) => [...p, ...files]);
   }, []);
@@ -77,6 +81,7 @@ export function useCaseAttachments(options: {
     removeRemote,
     changeRemoteType: (_id: string, _t: number | null) => {},
     changeNewType: (_idx: number, _t: number | null) => {},
+    setDescription,
     appendRemote,
     markPersisted,
     attachmentsChanged,

--- a/src/features/courtCase/model/useCaseFiles.ts
+++ b/src/features/courtCase/model/useCaseFiles.ts
@@ -1,18 +1,20 @@
 import { useState } from 'react';
 
-export interface CaseFile { file: File; type_id: number | null; }
+export interface CaseFile { file: File; type_id: number | null; description?: string; }
 
 /** Хук для управления файлами судебного дела */
 export function useCaseFiles() {
   const [caseFiles, setCaseFiles] = useState<CaseFile[]>([]);
 
   const addFiles = (files: File[]) =>
-    setCaseFiles((p) => [...p, ...files.map((f) => ({ file: f, type_id: null }))]);
+    setCaseFiles((p) => [...p, ...files.map((f) => ({ file: f, type_id: null, description: '' }))]);
   const setType = (idx: number, val: number | null) =>
     setCaseFiles((p) => p.map((f, i) => (i === idx ? { ...f, type_id: val } : f)));
+  const setDescription = (idx: number, val: string) =>
+    setCaseFiles((p) => p.map((f, i) => (i === idx ? { ...f, description: val } : f)));
   const removeFile = (idx: number) =>
     setCaseFiles((p) => p.filter((_, i) => i !== idx));
   const reset = () => setCaseFiles([]);
 
-  return { caseFiles, addFiles, setType, removeFile, reset };
+  return { caseFiles, addFiles, setType, setDescription, removeFile, reset };
 }

--- a/src/features/defect/DefectFilesModal.tsx
+++ b/src/features/defect/DefectFilesModal.tsx
@@ -25,18 +25,23 @@ export default function DefectFilesModal({
   onClose,
 }: DefectFilesModalProps) {
   const handleFiles = (f: File[]) => {
-    onChange([...files, ...f.map((file) => ({ file }))]);
+    onChange([...files, ...f.map((file) => ({ file, description: '' }))]);
   };
   const removeFile = (idx: number) => {
     onChange(files.filter((_, i) => i !== idx));
+  };
+  const changeDesc = (idx: number, d: string) => {
+    onChange(files.map((f, i) => (i === idx ? { ...f, description: d } : f)));
   };
   return (
     <Modal open={open} onCancel={onClose} onOk={onClose} title="Файлы дефекта">
       <FileDropZone onFiles={handleFiles} />
       <AttachmentEditorTable
-        newFiles={files.map((f) => ({ file: f.file, mime: f.file.type }))}
+        newFiles={files.map((f) => ({ file: f.file, mime: f.file.type, description: f.description }))}
         showMime={false}
+        showDetails
         onRemoveNew={removeFile}
+        onDescNew={changeDesc}
       />
     </Modal>
   );

--- a/src/features/defect/DefectFixModal.tsx
+++ b/src/features/defect/DefectFixModal.tsx
@@ -159,10 +159,13 @@ export default function DefectFixModal({ defectId, open, onClose }: Props) {
               name: f.name,
               path: f.path,
               mime: f.mime_type,
+              description: f.description,
             }))}
-            newFiles={files.map((f) => ({ file: f.file, mime: f.file.type }))}
+            newFiles={files.map((f) => ({ file: f.file, mime: f.file.type, description: f.description }))}
             onRemoveRemote={removeRemote}
             onRemoveNew={removeFile}
+            onDescNew={(idx, d) => setFiles(files.map((ff, i) => (i === idx ? { ...ff, description: d } : ff)))}
+            showDetails
             getSignedUrl={(p, n) => signedUrl(p, n)}
           />
         </Form.Item>

--- a/src/pages/ObjectArchivePage/ObjectArchivePage.tsx
+++ b/src/pages/ObjectArchivePage/ObjectArchivePage.tsx
@@ -10,7 +10,7 @@ export default function ObjectArchivePage() {
   const [params] = useSearchParams();
   const unitId = Number(params.get('unit_id'));
   const { data, isLoading } = useUnitArchive(Number.isNaN(unitId) ? undefined : unitId);
-  const [newObjectFiles, setNewObjectFiles] = React.useState<File[]>([]);
+  const [newObjectFiles, setNewObjectFiles] = React.useState<{ file: File; description: string }[]>([]);
 
   return (
     <ConfigProvider locale={ruRU}>
@@ -22,7 +22,7 @@ export default function ObjectArchivePage() {
             Документы по объекту{' '}
             <Upload
               beforeUpload={(file) => {
-                setNewObjectFiles((p) => [...p, file]);
+                setNewObjectFiles((p) => [...p, { file, description: '' }]);
                 return false;
               }}
               showUploadList={false}
@@ -32,7 +32,10 @@ export default function ObjectArchivePage() {
           </Typography.Title>
           <AttachmentEditorTable
             remoteFiles={data?.objectDocs}
-            newFiles={newObjectFiles.map((f) => ({ file: f }))}
+            newFiles={newObjectFiles.map((f) => ({ file: f.file, description: f.description }))}
+            onDescNew={(idx, d) =>
+              setNewObjectFiles((p) => p.map((f, i) => (i === idx ? { ...f, description: d } : f)))
+            }
             showMime={false}
             showDetails
           />

--- a/src/shared/types/archiveFile.ts
+++ b/src/shared/types/archiveFile.ts
@@ -10,6 +10,8 @@ export interface ArchiveFile {
   path: string;
   /** MIME-тип */
   mime: string;
+  /** Описание файла */
+  description?: string | null;
   /** Идентификатор связанной сущности */
   entityId?: number;
 }

--- a/src/shared/types/attachment.ts
+++ b/src/shared/types/attachment.ts
@@ -8,6 +8,8 @@ export interface Attachment {
   mime_type: string;
   /** Исходное имя файла */
   original_name: string | null;
+  /** Описание файла */
+  description: string | null;
   /** Кто загрузил файл */
   uploaded_by: string | null;
   /** Когда обновлён */

--- a/src/shared/types/caseFile.ts
+++ b/src/shared/types/caseFile.ts
@@ -6,9 +6,12 @@ export interface RemoteCaseFile {
   path: string;
   url: string;
   mime_type: string;
+  /** Описание файла */
+  description?: string | null;
 }
 
 /** Новый файл для вложения судебного дела */
 export interface NewCaseFile {
   file: File;
+  description?: string;
 }

--- a/src/shared/types/claimFile.ts
+++ b/src/shared/types/claimFile.ts
@@ -8,9 +8,12 @@ export interface RemoteClaimFile {
   mime_type: string;
   /** Размер файла в байтах */
   size?: number;
+  /** Описание файла */
+  description?: string | null;
 }
 
 /** Новый файл для вложения претензии */
 export interface NewClaimFile {
   file: File;
+  description?: string;
 }

--- a/src/shared/types/defectFile.ts
+++ b/src/shared/types/defectFile.ts
@@ -6,9 +6,12 @@ export interface RemoteDefectFile {
   path: string;
   url: string;
   mime_type: string;
+  /** Описание файла */
+  description?: string | null;
 }
 
 /** Новый файл для вложения дефекта */
 export interface NewDefectFile {
   file: File;
+  description?: string;
 }

--- a/src/shared/types/letterFile.ts
+++ b/src/shared/types/letterFile.ts
@@ -6,9 +6,12 @@ export interface RemoteLetterFile {
   path: string;
   url: string;
   mime_type: string;
+  /** Описание файла */
+  description?: string | null;
 }
 
 /** Новый файл для вложения письма */
 export interface NewLetterFile {
   file: File;
+  description?: string;
 }

--- a/src/shared/ui/AttachmentEditorTable.tsx
+++ b/src/shared/ui/AttachmentEditorTable.tsx
@@ -13,11 +13,13 @@ interface RemoteFile {
   path: string;
   /** MIME-тип файла */
   mime?: string;
+  description?: string;
 }
 
 interface NewFile {
   file: File;
   mime?: string;
+  description?: string;
 }
 
 interface Props {
@@ -25,6 +27,8 @@ interface Props {
   newFiles?: NewFile[];
   onRemoveRemote?: (id: string) => void;
   onRemoveNew?: (idx: number) => void;
+  onDescRemote?: (id: string, d: string) => void;
+  onDescNew?: (idx: number, d: string) => void;
   getSignedUrl?: (path: string, name: string) => Promise<string>;
   /** Показывать колонку MIME */
   showMime?: boolean;
@@ -44,6 +48,8 @@ export default function AttachmentEditorTable({
                                                 newFiles = [],
                                                 onRemoveRemote,
                                                 onRemoveNew,
+                                                onDescRemote,
+                                                onDescNew,
                                                 getSignedUrl,
                                                 showMime = true,
                                                 showDetails = false,
@@ -81,6 +87,7 @@ export default function AttachmentEditorTable({
     mime?: string;
     file?: File;
     path?: string;
+    description?: string;
     isRemote: boolean;
   }
 
@@ -91,6 +98,7 @@ export default function AttachmentEditorTable({
       name: f.name,
       mime: f.mime,
       path: f.path,
+      description: f.description,
       isRemote: true,
     })),
     ...newFiles.map<Row>((f, i) => ({
@@ -98,6 +106,7 @@ export default function AttachmentEditorTable({
       name: f.file.name,
       mime: f.mime,
       file: f.file,
+      description: f.description,
       isRemote: false,
     })),
   ];
@@ -122,7 +131,18 @@ export default function AttachmentEditorTable({
           title: 'Подробности',
           dataIndex: 'details',
           width: 200,
-          render: () => <Input placeholder="Подробности" size="small" />,
+          render: (_: unknown, row) => (
+            <Input
+              placeholder="Описание"
+              size="small"
+              value={row.description}
+              onChange={(e) => {
+                const val = e.target.value;
+                if (row.isRemote && row.id) onDescRemote?.(row.id, val);
+                else if (!row.isRemote) onDescNew?.(Number(row.key.split('-')[1]), val);
+              }}
+            />
+          ),
         } as ColumnsType<Row>[number]]
       : []),
     ...(getLink

--- a/src/widgets/DefectEditableTable.tsx
+++ b/src/widgets/DefectEditableTable.tsx
@@ -458,12 +458,17 @@ export default function DefectEditableTable({ fields, add, remove, projectId, fi
             if (!files.length) return null;
             return (
               <AttachmentEditorTable
-                newFiles={files.map((f) => ({ file: f.file, mime: f.file.type }))}
+                newFiles={files.map((f) => ({ file: f.file, mime: f.file.type, description: f.description }))}
                 onRemoveNew={(idx) => {
                   const arr = files.filter((_, i) => i !== idx);
                   onFilesChange?.(record.name, arr);
                 }}
+                onDescNew={(idx, d) => {
+                  const arr = files.map((ff, i) => (i === idx ? { ...ff, description: d } : ff));
+                  onFilesChange?.(record.name, arr);
+                }}
                 showMime={false}
+                showDetails
               />
             );
           },

--- a/src/widgets/TicketDefectsEditorTable.tsx
+++ b/src/widgets/TicketDefectsEditorTable.tsx
@@ -235,12 +235,17 @@ export default function TicketDefectsEditorTable({
           if (!files.length) return null;
           return (
             <AttachmentEditorTable
-              newFiles={files.map((f) => ({ file: f.file, mime: f.file.type }))}
+              newFiles={files.map((f) => ({ file: f.file, mime: f.file.type, description: f.description }))}
               onRemoveNew={(idx) => {
                 const arr = files.filter((_, i) => i !== idx);
                 onFilesChange?.(record.id, arr);
               }}
+              onDescNew={(idx, d) => {
+                const arr = files.map((ff, i) => (i === idx ? { ...ff, description: d } : ff));
+                onFilesChange?.(record.id, arr);
+              }}
               showMime={false}
+              showDetails
             />
           );
         },


### PR DESCRIPTION
## Summary
- support optional `description` for attachments
- update upload functions and queries for description
- extend file types and editor table
- allow editing descriptions in forms and modals

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686044a5b994832ebd6736a0b9012b5b