### PR TITLE
Implement unit archive attachments

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -63,6 +63,13 @@
     "column_default": "now()"
   },
   {
+    "table_name": "attachments",
+    "column_name": "file_size",
+    "data_type": "integer",
+    "is_nullable": "YES",
+    "column_default": null
+  },
+  {
     "table_name": "brigades",
     "column_name": "id",
     "data_type": "integer",
@@ -841,6 +848,20 @@
   },
   {
     "table_name": "letter_attachments",
+    "column_name": "attachment_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": null
+  },
+  {
+    "table_name": "unit_attachments",
+    "column_name": "unit_id",
+    "data_type": "integer",
+    "is_nullable": "NO",
+    "column_default": null
+  },
+  {
+    "table_name": "unit_attachments",
     "column_name": "attachment_id",
     "data_type": "integer",
     "is_nullable": "NO",

--- a/db_indexes_summary.md
+++ b/db_indexes_summary.md
@@ -87,6 +87,10 @@
 ## letter_attachments
 - `letter_attachments_pkey` - `UNIQUE letter_id, attachment_id`
 
+## unit_attachments
+- `unit_attachments_pkey` - `UNIQUE unit_id, attachment_id`
+- `idx_unit_attachments_file` - `attachment_id`
+
 ## letter_links
 - `idx_letter_links_parent` - `parent_id`
 - `letter_links_id_key` - `UNIQUE id`

--- a/src/entities/unitArchive.ts
+++ b/src/entities/unitArchive.ts
@@ -17,9 +17,10 @@ function mapFile(a: any, entityId?: number): ArchiveFile {
   return {
     id: String(a.id),
     name,
-    path: a.file_url,
+    path: a.storage_path,
     mime: a.file_type,
     description: a.description ?? null,
+    size: a.file_size ?? null,
     entityId,
   };
 }
@@ -37,22 +38,15 @@ export function useUnitArchive(unitId?: number) {
       };
       if (!unitId) return result;
 
-      const { data: letterRows } = await supabase
-        .from('letter_units')
-        .select('letter_id')
+      const { data: unitFiles } = await supabase
+        .from('unit_attachments')
+        .select(
+          'unit_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description, file_size)',
+        )
         .eq('unit_id', unitId);
-      const letterIds = (letterRows ?? []).map((r: any) => r.letter_id);
-      if (letterIds.length) {
-        const { data } = await supabase
-          .from('letter_attachments')
-          .select(
-            'letter_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description)',
-          )
-          .in('letter_id', letterIds);
-        result.objectDocs = (data ?? []).map((r: any) =>
-          mapFile(r.attachments, r.letter_id),
-        );
-      }
+      result.objectDocs = (unitFiles ?? []).map((r: any) =>
+        mapFile(r.attachments, r.unit_id),
+      );
 
       const { data: claimRows } = await supabase
         .from('claim_units')
@@ -63,7 +57,7 @@ export function useUnitArchive(unitId?: number) {
         const { data } = await supabase
           .from('claim_attachments')
           .select(
-            'claim_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description)',
+            'claim_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description, file_size)',
           )
           .in('claim_id', claimIds);
         result.remarkDocs = (data ?? []).map((r: any) =>
@@ -80,7 +74,7 @@ export function useUnitArchive(unitId?: number) {
         const { data } = await supabase
           .from('defect_attachments')
           .select(
-            'defect_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description)',
+            'defect_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description, file_size)',
           )
           .in('defect_id', defectIds);
         result.defectDocs = (data ?? []).map((r: any) =>
@@ -97,7 +91,7 @@ export function useUnitArchive(unitId?: number) {
         const { data } = await supabase
           .from('court_case_attachments')
           .select(
-            'court_case_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description)',
+            'court_case_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description, file_size)',
           )
           .in('court_case_id', caseIds);
         result.courtDocs = (data ?? []).map((r: any) =>

--- a/src/pages/ObjectArchivePage/ObjectArchivePage.tsx
+++ b/src/pages/ObjectArchivePage/ObjectArchivePage.tsx
@@ -1,16 +1,46 @@
 import React from 'react';
-import { ConfigProvider, Typography, Divider, Skeleton, Upload, Input } from 'antd';
+import { ConfigProvider, Typography, Divider, Skeleton, Upload, Input, Button } from 'antd';
 import ruRU from 'antd/locale/ru_RU';
 import { useSearchParams } from 'react-router-dom';
 import { UploadOutlined } from '@ant-design/icons';
 import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
 import { useUnitArchive } from '@/entities/unitArchive';
+import { signedUrl, updateAttachmentDescription } from '@/entities/attachment';
+import { downloadZip } from '@/shared/utils/downloadZip';
 
 export default function ObjectArchivePage() {
   const [params] = useSearchParams();
   const unitId = Number(params.get('unit_id'));
   const { data, isLoading } = useUnitArchive(Number.isNaN(unitId) ? undefined : unitId);
   const [newObjectFiles, setNewObjectFiles] = React.useState<{ file: File; description: string }[]>([]);
+
+  const handleDescRemote = React.useCallback((id: string, d: string) => {
+    updateAttachmentDescription(Number(id), d).catch(console.error);
+  }, []);
+
+  const handleDownloadArchive = async () => {
+    const files = [
+      ...(data?.objectDocs ?? []),
+      ...(data?.remarkDocs ?? []),
+      ...(data?.defectDocs ?? []),
+      ...(data?.courtDocs ?? []),
+      ...newObjectFiles.map((f) => ({ id: '', name: f.file.name, path: '', file: f.file })),
+    ];
+    const sources = await Promise.all(
+      files.map(async (f) => ({
+        name: f.name,
+        getFile: async () => {
+          if ('file' in f && f.file) return f.file;
+          const url = await signedUrl(f.path, f.name);
+          const res = await fetch(url);
+          return res.blob();
+        },
+      })),
+    );
+    if (sources.length) {
+      await downloadZip(sources, `unit-${unitId}-docs.zip`);
+    }
+  };
 
   return (
     <ConfigProvider locale={ruRU}>
@@ -29,6 +59,9 @@ export default function ObjectArchivePage() {
             >
               <UploadOutlined />
             </Upload>
+            <Button size="small" style={{ marginLeft: 8 }} onClick={handleDownloadArchive}>
+              Скачать архив
+            </Button>
           </Typography.Title>
           <AttachmentEditorTable
             remoteFiles={data?.objectDocs}
@@ -36,28 +69,43 @@ export default function ObjectArchivePage() {
             onDescNew={(idx, d) =>
               setNewObjectFiles((p) => p.map((f, i) => (i === idx ? { ...f, description: d } : f)))
             }
+            onDescRemote={handleDescRemote}
             showMime={false}
             showDetails
+            showSize
+            getSignedUrl={(p, n) => signedUrl(p, n)}
           />
           <Divider />
           <Typography.Title level={4}>Документы по замечаниям</Typography.Title>
           <AttachmentEditorTable
             remoteFiles={data?.remarkDocs}
+            onDescRemote={handleDescRemote}
             showMime={false}
+            showDetails
+            showSize
+            getSignedUrl={(p, n) => signedUrl(p, n)}
             getLink={(f) => `/claims?id=${f.entityId}`}
           />
           <Divider />
           <Typography.Title level={4}>Документы по дефектам</Typography.Title>
           <AttachmentEditorTable
             remoteFiles={data?.defectDocs}
+            onDescRemote={handleDescRemote}
             showMime={false}
+            showDetails
+            showSize
+            getSignedUrl={(p, n) => signedUrl(p, n)}
             getLink={(f) => `/defects?id=${f.entityId}`}
           />
           <Divider />
           <Typography.Title level={4}>Документы по судебным делам</Typography.Title>
           <AttachmentEditorTable
             remoteFiles={data?.courtDocs}
+            onDescRemote={handleDescRemote}
             showMime={false}
+            showDetails
+            showSize
+            getSignedUrl={(p, n) => signedUrl(p, n)}
             getLink={(f) => `/court-cases?id=${f.entityId}`}
           />
         </>

--- a/src/shared/types/archiveFile.ts
+++ b/src/shared/types/archiveFile.ts
@@ -14,4 +14,6 @@ export interface ArchiveFile {
   description?: string | null;
   /** Идентификатор связанной сущности */
   entityId?: number;
+  /** Размер файла в байтах */
+  size?: number | null;
 }

--- a/src/shared/types/attachment.ts
+++ b/src/shared/types/attachment.ts
@@ -14,4 +14,6 @@ export interface Attachment {
   uploaded_by: string | null;
   /** Когда обновлён */
   updated_at: string | null;
+  /** Размер файла в байтах */
+  file_size: number | null;
 }

--- a/src/shared/ui/AttachmentEditorTable.tsx
+++ b/src/shared/ui/AttachmentEditorTable.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Table, Button, Space, Tooltip, Select, Input } from 'antd';
+import { formatFileSize } from '@/shared/utils/formatFileSize';
 import type { ColumnsType } from 'antd/es/table';
 import {
   FileOutlined,
@@ -14,12 +15,14 @@ interface RemoteFile {
   /** MIME-тип файла */
   mime?: string;
   description?: string;
+  size?: number | null;
 }
 
 interface NewFile {
   file: File;
   mime?: string;
   description?: string;
+  size?: number;
 }
 
 interface Props {
@@ -34,6 +37,8 @@ interface Props {
   showMime?: boolean;
   /** Показывать поле подробностей */
   showDetails?: boolean;
+  /** Показывать размер файла */
+  showSize?: boolean;
   /** Получить ссылку для просмотра сущности */
   getLink?: (file: RemoteFile) => string | undefined;
 }
@@ -53,6 +58,7 @@ export default function AttachmentEditorTable({
                                                 getSignedUrl,
                                                 showMime = true,
                                                 showDetails = false,
+                                                showSize = false,
                                                 getLink,
                                               }: Props) {
   const [cache, setCache] = React.useState<Record<string, string>>({});
@@ -88,6 +94,7 @@ export default function AttachmentEditorTable({
     file?: File;
     path?: string;
     description?: string;
+    size?: number;
     isRemote: boolean;
   }
 
@@ -99,6 +106,7 @@ export default function AttachmentEditorTable({
       mime: f.mime,
       path: f.path,
       description: f.description,
+      size: f.size ?? undefined,
       isRemote: true,
     })),
     ...newFiles.map<Row>((f, i) => ({
@@ -107,6 +115,7 @@ export default function AttachmentEditorTable({
       mime: f.mime,
       file: f.file,
       description: f.description,
+      size: f.file.size,
       isRemote: false,
     })),
   ];
@@ -123,6 +132,14 @@ export default function AttachmentEditorTable({
       width: 200,
       ellipsis: true,
     },
+    ...(showSize
+      ? [{
+          title: 'Размер',
+          dataIndex: 'size',
+          width: 100,
+          render: (v: number | undefined) => (v ? formatFileSize(v) : ''),
+        } as ColumnsType<Row>[number]]
+      : []),
     ...(showMime
       ? [{ title: 'MIME', dataIndex: 'mime', width: 200 } as ColumnsType<Row>[number]]
       : []),

--- a/src/shared/utils/formatFileSize.ts
+++ b/src/shared/utils/formatFileSize.ts
@@ -1,0 +1,11 @@
+export function formatFileSize(bytes: number | null | undefined): string {
+  if (bytes === null || bytes === undefined) return '';
+  const units = ['Б', 'КБ', 'МБ', 'ГБ'];
+  let size = bytes;
+  let i = 0;
+  while (size >= 1024 && i < units.length - 1) {
+    size /= 1024;
+    i++;
+  }
+  return `${size.toFixed(1)} ${units[i]}`;
+}


### PR DESCRIPTION
## Summary
- add `file_size` column for attachments and new `unit_attachments` table docs
- document indexes for new table
- support file sizes in types and UI
- fetch unit archive files from new table and include size
- enable editing descriptions and archive download in object archive
- provide formatFileSize utility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68612c9956f8832eb50c7dc723be6b81