### PR TITLE
Add green arrow icon for defect files expand

### DIFF
--- a/src/widgets/DefectEditableTable.tsx
+++ b/src/widgets/DefectEditableTable.tsx
@@ -19,6 +19,7 @@ import {
   PlusOutlined,
   DeleteOutlined,
   UploadOutlined,
+  DownOutlined,
   PaperClipOutlined,
 } from '@ant-design/icons';
 import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
@@ -446,9 +447,9 @@ export default function DefectEditableTable({ fields, add, remove, projectId, fi
             const has = (fileMap[record.name] ?? []).length > 0;
             if (!has) return null;
             return (
-              <PaperClipOutlined
-                style={{ cursor: 'pointer' }}
-                rotate={expanded ? 90 : 0}
+              <DownOutlined
+                style={{ cursor: 'pointer', color: '#52c41a', fontWeight: 700 }}
+                rotate={expanded ? 180 : 0}
                 onClick={(e) => onExpand(record, e)}
               />
             );

--- a/src/widgets/TicketDefectsEditorTable.tsx
+++ b/src/widgets/TicketDefectsEditorTable.tsx
@@ -11,7 +11,7 @@ import {
   Space,
 } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
-import { EyeOutlined, PaperClipOutlined } from '@ant-design/icons';
+import { EyeOutlined, PaperClipOutlined, DownOutlined } from '@ant-design/icons';
 import FixBySelector from '@/shared/ui/FixBySelector';
 import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
 import DefectFilesModal from '@/features/defect/DefectFilesModal';
@@ -223,9 +223,9 @@ export default function TicketDefectsEditorTable({
           const has = (fileMap[record.id] ?? []).length > 0;
           if (!has) return null;
           return (
-            <PaperClipOutlined
-              style={{ cursor: 'pointer' }}
-              rotate={expanded ? 90 : 0}
+            <DownOutlined
+              style={{ cursor: 'pointer', color: '#52c41a', fontWeight: 700 }}
+              rotate={expanded ? 180 : 0}
               onClick={(e) => onExpand(record, e)}
             />
           );


### PR DESCRIPTION
## Summary
- use DownOutlined for expanding defect files list
- keep paperclip icon for file management but replace expand icon with bold green arrow

## Testing
- `npm run lint` *(fails: eslint plugins missing)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861419a23b4832eb521539541b4c971