### PR TITLE
Fix ObjectArchive layout

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -125,7 +125,7 @@ body {
 /* Skeleton эффекты были выше (оставил без изменений) */
 .changed-field {
   background-color: #fffbe6;
-  padding: 4px;
+  padding: 0 4px;
   border-radius: 2px;
 }
 

--- a/src/pages/ObjectArchivePage/ObjectArchivePage.tsx
+++ b/src/pages/ObjectArchivePage/ObjectArchivePage.tsx
@@ -146,6 +146,8 @@ export default function ObjectArchivePage() {
             showMime={false}
             showDetails
             showSize
+            showHeader
+            showLink
             changedMap={changed}
             getSignedUrl={(p, n) => signedUrl(p, n)}
           />
@@ -157,6 +159,8 @@ export default function ObjectArchivePage() {
             showMime={false}
             showDetails
             showSize
+            showHeader
+            showLink
             changedMap={changed}
             getSignedUrl={(p, n) => signedUrl(p, n)}
             getLink={(f) => `/claims?id=${f.entityId}`}
@@ -169,6 +173,8 @@ export default function ObjectArchivePage() {
             showMime={false}
             showDetails
             showSize
+            showHeader
+            showLink
             changedMap={changed}
             getSignedUrl={(p, n) => signedUrl(p, n)}
             getLink={(f) => `/defects?id=${f.entityId}`}
@@ -181,6 +187,8 @@ export default function ObjectArchivePage() {
             showMime={false}
             showDetails
             showSize
+            showHeader
+            showLink
             changedMap={changed}
             getSignedUrl={(p, n) => signedUrl(p, n)}
             getLink={(f) => `/court-cases?id=${f.entityId}`}

--- a/src/shared/ui/AttachmentEditorTable.tsx
+++ b/src/shared/ui/AttachmentEditorTable.tsx
@@ -40,12 +40,16 @@ interface Props {
     showMime?: boolean;
     /** Показывать поле подробностей */
     showDetails?: boolean;
+    /** Показывать колонку ссылки */
+    showLink?: boolean;
     /** Получить ссылку для просмотра сущности */
     getLink?: (file: RemoteFile) => string | undefined;
     /** Показывать размер файла */
     showSize?: boolean;
     /** Карта изменённых описаний по id */
     changedMap?: Record<string, boolean>;
+    /** Показывать заголовок таблицы */
+    showHeader?: boolean;
 }
 
 /**
@@ -62,9 +66,11 @@ export default function AttachmentEditorTable({
   getSignedUrl,
   showMime = true,
   showDetails = false,
+  showLink = false,
   getLink,
   showSize = false,
   changedMap,
+  showHeader = false,
 }: Props) {
     const [cache, setCache] = React.useState<Record<string, string>>({});
 
@@ -197,29 +203,32 @@ export default function AttachmentEditorTable({
                 } as ColumnsType<Row>[number],
             ]
             : []),
-        ...(getLink
+        ...(showLink
             ? [
                 {
                     title: 'Ссылка',
                     dataIndex: 'link',
                     width: 120,
                     render: (_: unknown, row) =>
-                        row.isRemote && row.id ? (
-                            <a
-                                href={
-                                    getLink({
-                                        id: row.id,
-                                        name: row.name,
-                                        path: row.path ?? '',
-                                        mime: row.mime,
-                                    })
-                                }
-                                target="_blank"
-                                rel="noopener noreferrer"
-                            >
-                                Открыть
-                            </a>
-                        ) : null,
+                        row.isRemote && row.id && getLink
+                            ? (() => {
+                                  const url = getLink({
+                                      id: row.id,
+                                      name: row.name,
+                                      path: row.path ?? '',
+                                      mime: row.mime,
+                                  });
+                                  return url ? (
+                                      <a
+                                          href={url}
+                                          target="_blank"
+                                          rel="noopener noreferrer"
+                                      >
+                                          Открыть
+                                      </a>
+                                  ) : null;
+                              })()
+                            : null,
                 } as ColumnsType<Row>[number],
             ]
             : []),
@@ -284,7 +293,7 @@ export default function AttachmentEditorTable({
             columns={columns}
             dataSource={data}
             rowClassName={(row) => (!row.isRemote ? 'new-row' : '')}
-            showHeader={false}
+            showHeader={showHeader}
             tableLayout="fixed"
             style={{ width: '100%', overflowX: 'hidden' }}
         />


### PR DESCRIPTION
## Summary
- align tables in archive page by always showing header and link columns
- avoid shifting description inputs by removing vertical padding
- extend AttachmentEditorTable API for flexibility

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68614d479a50832ea57ed3a62dc835f3