### PR TITLE
Add SQL migration for attachment creation info

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -63,6 +63,20 @@
     "column_default": null
   },
   {
+    "table_name": "attachments",
+    "column_name": "created_by",
+    "data_type": "uuid",
+    "is_nullable": "YES",
+    "column_default": null
+  },
+  {
+    "table_name": "attachments",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "now()"
+  },
+  {
     "table_name": "brigades",
     "column_name": "id",
     "data_type": "integer",

--- a/sql/20250629_add_attachment_created.sql
+++ b/sql/20250629_add_attachment_created.sql
@@ -1,0 +1,14 @@
+-- Добавление информации о пользователе и времени загрузки файлов
+-- Создание новых колонок в таблице attachments
+ALTER TABLE attachments
+  ADD COLUMN IF NOT EXISTS created_by uuid,
+  ADD COLUMN IF NOT EXISTS created_at timestamp with time zone DEFAULT now();
+
+-- Для уже существующих записей сохраняем текущую дату, если поле не заполнено
+UPDATE attachments
+  SET created_at = COALESCE(created_at, uploaded_at)
+  WHERE created_at IS NULL;
+-- При желании можно заполнить created_by значением uploaded_by
+UPDATE attachments
+  SET created_by = uploaded_by
+  WHERE created_by IS NULL;

--- a/src/entities/attachment.js
+++ b/src/entities/attachment.js
@@ -1,4 +1,5 @@
 import { supabase } from '@/shared/api/supabaseClient';
+import { useAuthStore } from '@/shared/store/authStore';
 
 let ATTACH_BUCKET =
     (typeof import.meta !== 'undefined' && import.meta.env?.VITE_ATTACH_BUCKET) ||
@@ -114,6 +115,7 @@ export function uploadDefectAttachment(file, defectId) {
  * @param {number} caseId
  */
 export async function addCaseAttachments(files, caseId) {
+    const userId = useAuthStore.getState().profile?.id ?? null;
     const uploaded = await Promise.all(
         files.map(({ file }) => uploadCaseAttachment(file, caseId)),
     );
@@ -124,12 +126,13 @@ export async function addCaseAttachments(files, caseId) {
         original_name: files[idx].file.name,
         storage_path: u.path,
         description: files[idx].description ?? null,
+        created_by: userId,
     }));
 
     const { data, error } = await supabase
         .from('attachments')
         .insert(rows)
-        .select('id, storage_path, file_url:path, file_type:mime_type, original_name, description');
+        .select('id, storage_path, file_url:path, file_type:mime_type, original_name, description, created_at, created_by');
 
     if (error) throw error;
     return data ?? [];
@@ -141,6 +144,7 @@ export async function addCaseAttachments(files, caseId) {
  * @param {number} letterId
  */
 export async function addLetterAttachments(files, letterId) {
+    const userId = useAuthStore.getState().profile?.id ?? null;
     const uploaded = await Promise.all(
         files.map(({ file }) => uploadLetterAttachment(file, letterId)),
     );
@@ -151,12 +155,13 @@ export async function addLetterAttachments(files, letterId) {
         original_name: files[idx].file.name,
         storage_path: u.path,
         description: files[idx].description ?? null,
+        created_by: userId,
     }));
 
     const { data, error } = await supabase
         .from('attachments')
         .insert(rows)
-        .select('id, storage_path, file_url:path, file_type:mime_type, original_name, description');
+        .select('id, storage_path, file_url:path, file_type:mime_type, original_name, description, created_at, created_by');
 
     if (error) throw error;
     return data ?? [];
@@ -170,6 +175,7 @@ export async function addLetterAttachments(files, letterId) {
  * @param {number} ticketId
  */
 export async function addTicketAttachments(files, projectId, ticketId) {
+    const userId = useAuthStore.getState().profile?.id ?? null;
     const uploaded = await Promise.all(
         files.map(({ file }) => uploadTicketAttachment(file, projectId, ticketId)),
     );
@@ -180,12 +186,13 @@ export async function addTicketAttachments(files, projectId, ticketId) {
         original_name: files[idx].file.name,
         storage_path: u.path,
         description: files[idx].description ?? null,
+        created_by: userId,
     }));
 
     const { data, error } = await supabase
         .from('attachments')
         .insert(rows)
-        .select('id, storage_path, file_url:path, file_type:mime_type, original_name, description');
+        .select('id, storage_path, file_url:path, file_type:mime_type, original_name, description, created_at, created_by');
 
     if (error) throw error;
     return data ?? [];
@@ -198,6 +205,7 @@ export async function addTicketAttachments(files, projectId, ticketId) {
  * @param {number} claimId
  */
 export async function addClaimAttachments(files, claimId) {
+    const userId = useAuthStore.getState().profile?.id ?? null;
     const uploaded = await Promise.all(
         files.map(({ file }) => uploadClaimAttachment(file, claimId)),
     );
@@ -208,12 +216,13 @@ export async function addClaimAttachments(files, claimId) {
         original_name: files[idx].file.name,
         storage_path: u.path,
         description: files[idx].description ?? null,
+        created_by: userId,
     }));
 
     const { data, error } = await supabase
         .from('attachments')
         .insert(rows)
-        .select('id, storage_path, file_url:path, file_type:mime_type, original_name, description');
+        .select('id, storage_path, file_url:path, file_type:mime_type, original_name, description, created_at, created_by');
 
     if (error) throw error;
     return data ?? [];
@@ -226,6 +235,7 @@ export async function addClaimAttachments(files, claimId) {
  * @param {number} defectId
  */
 export async function addDefectAttachments(files, defectId) {
+    const userId = useAuthStore.getState().profile?.id ?? null;
     const uploaded = await Promise.all(
         files.map(({ file }) => uploadDefectAttachment(file, defectId)),
     );
@@ -236,12 +246,13 @@ export async function addDefectAttachments(files, defectId) {
         original_name: files[idx].file.name,
         storage_path: u.path,
         description: files[idx].description ?? null,
+        created_by: userId,
     }));
 
     const { data, error } = await supabase
         .from('attachments')
         .insert(rows)
-        .select('id, storage_path, file_url:path, file_type:mime_type, original_name, description');
+        .select('id, storage_path, file_url:path, file_type:mime_type, original_name, description, created_at, created_by');
 
     if (error) throw error;
     return data ?? [];
@@ -255,7 +266,7 @@ export async function getAttachmentsByIds(ids) {
     if (!ids.length) return [];
     const { data, error } = await supabase
         .from('attachments')
-        .select('id, storage_path, file_url:path, file_type:mime_type, original_name, description')
+        .select('id, storage_path, file_url:path, file_type:mime_type, original_name, description, created_at, created_by')
         .in('id', ids);
 
     if (error) throw error;
@@ -263,6 +274,7 @@ export async function getAttachmentsByIds(ids) {
 }
 
 export async function addUnitAttachments(files, unitId) {
+    const userId = useAuthStore.getState().profile?.id ?? null;
     const uploaded = await Promise.all(
         files.map(({ file }) => upload(file, `units/${unitId}`)),
     );
@@ -273,12 +285,13 @@ export async function addUnitAttachments(files, unitId) {
         original_name: files[idx].file.name,
         storage_path: u.path,
         description: files[idx].description ?? null,
+        created_by: userId,
     }));
 
     const { data, error } = await supabase
         .from('attachments')
         .insert(rows)
-        .select('id, storage_path, file_url:path, file_type:mime_type, original_name, description');
+        .select('id, storage_path, file_url:path, file_type:mime_type, original_name, description, created_at, created_by');
 
     if (error) throw error;
 

--- a/src/entities/claim.ts
+++ b/src/entities/claim.ts
@@ -144,7 +144,7 @@ export function useClaims() {
           statuses (id, name, color),
           claim_units(unit_id),
           claim_defects(defect_id),
-          claim_attachments(attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description))`,
+          claim_attachments(attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description, created_at, created_by))`,
         );
       q = filterByProjects(q, projectId, projectIds, onlyAssigned);
       q = q.order('created_at', { ascending: false });
@@ -194,7 +194,7 @@ export function useClaim(id?: number | string) {
           statuses (id, name, color),
           claim_units(unit_id),
           claim_defects(defect_id),
-          claim_attachments(attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description))`,
+          claim_attachments(attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description, created_at, created_by))`,
         )
         .eq('id', claimId);
       q = filterByProjects(q, projectId, projectIds, onlyAssigned);
@@ -239,7 +239,7 @@ export function useClaimAll(id?: number | string) {
           statuses (id, name, color),
           claim_units(unit_id),
           claim_defects(defect_id),
-          claim_attachments(attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description))`,
+          claim_attachments(attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description, created_at, created_by))`,
         )
         .eq('id', claimId)
         .maybeSingle();
@@ -279,7 +279,7 @@ export function useClaimsAll() {
           statuses (id, name, color),
           claim_units(unit_id),
           claim_defects(defect_id),
-          claim_attachments(attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description))`,
+          claim_attachments(attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description, created_at, created_by))`,
         )
         .order('created_at', { ascending: false });
       if (error) throw error;
@@ -629,7 +629,7 @@ export function useClaimAttachments(id?: number) {
     queryFn: async () => {
       const { data } = await supabase
         .from('claim_attachments')
-        .select('attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description)')
+        .select('attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description, created_at, created_by)')
         .eq('claim_id', id as number);
       return (data ?? []).map((r: any) => r.attachments);
     },

--- a/src/entities/correspondence/index.ts
+++ b/src/entities/correspondence/index.ts
@@ -89,7 +89,7 @@ export function useLetters() {
         ? await supabase
             .from(LETTER_ATTACH_TABLE)
             .select(
-              'letter_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description)'
+              'letter_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description, created_at, created_by)'
             )
             .in('letter_id', letterIds)
         : { data: [], error: null };
@@ -497,7 +497,7 @@ export function useLetter(letterId: number | string | undefined) {
 
       const { data: attachRows } = await supabase
         .from(LETTER_ATTACH_TABLE)
-        .select('attachment_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description)')
+        .select('attachment_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description, created_at, created_by)')
         .eq('letter_id', id);
       const attachments = (attachRows ?? []).map((row: any) => {
         const f = row.attachments;

--- a/src/entities/defect.ts
+++ b/src/entities/defect.ts
@@ -73,7 +73,7 @@ export function useDefect(id?: number) {
       const { data: attachRows, error: attachErr } = await supabase
         .from('defect_attachments')
         .select(
-          'attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description)'
+          'attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description, created_at, created_by)'
         )
         .eq('defect_id', id as number);
       if (attachErr) throw attachErr;

--- a/src/entities/unitArchive.ts
+++ b/src/entities/unitArchive.ts
@@ -42,7 +42,7 @@ export function useUnitArchive(unitId?: number) {
       const { data: unitFiles } = await supabase
         .from('unit_attachments')
         .select(
-          'unit_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description)',
+          'unit_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description, created_at, created_by)',
         )
         .eq('unit_id', unitId);
       result.objectDocs = await Promise.all(
@@ -61,7 +61,7 @@ export function useUnitArchive(unitId?: number) {
         const { data } = await supabase
           .from('claim_attachments')
           .select(
-            'claim_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description)',
+            'claim_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description, created_at, created_by)',
           )
           .in('claim_id', claimIds);
         result.remarkDocs = await Promise.all(
@@ -81,7 +81,7 @@ export function useUnitArchive(unitId?: number) {
         const { data } = await supabase
           .from('defect_attachments')
           .select(
-            'defect_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description)',
+            'defect_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description, created_at, created_by)',
           )
           .in('defect_id', defectIds);
         result.defectDocs = await Promise.all(
@@ -101,7 +101,7 @@ export function useUnitArchive(unitId?: number) {
         const { data } = await supabase
           .from('court_case_attachments')
           .select(
-            'court_case_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description)',
+            'court_case_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description, created_at, created_by)',
           )
           .in('court_case_id', caseIds);
         result.courtDocs = await Promise.all(

--- a/src/shared/types/attachment.ts
+++ b/src/shared/types/attachment.ts
@@ -10,6 +10,10 @@ export interface Attachment {
   original_name: string | null;
   /** Описание файла */
   description: string | null;
+  /** Кто добавил файл */
+  created_by: string | null;
+  /** Когда добавлен */
+  created_at: string | null;
   /** Кто загрузил файл */
   uploaded_by: string | null;
   /** Когда обновлён */


### PR DESCRIPTION
## Summary
- include SQL migration script for adding created info to attachments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68614fe3fcd4832e81d51b1a858424be