### PR TITLE
Add letter docs in archive and fix open links

### DIFF
--- a/src/entities/unitArchive.ts
+++ b/src/entities/unitArchive.ts
@@ -36,6 +36,7 @@ export function useUnitArchive(unitId?: number) {
         remarkDocs: [],
         defectDocs: [],
         courtDocs: [],
+        letterDocs: [],
       };
       if (!unitId) return result;
 
@@ -109,6 +110,26 @@ export function useUnitArchive(unitId?: number) {
             const f = mapFile(r.attachments, r.court_case_id);
             return { ...f, size: await getFileSize(f.path) };
           }),
+        );
+      }
+
+      const { data: letterRows } = await supabase
+        .from('letter_units')
+        .select('letter_id')
+        .eq('unit_id', unitId);
+      const letterIds = (letterRows ?? []).map((r: any) => r.letter_id);
+      if (letterIds.length) {
+        const { data } = await supabase
+          .from('letter_attachments')
+          .select(
+            'letter_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description)'
+          )
+          .in('letter_id', letterIds);
+        result.letterDocs = await Promise.all(
+          (data ?? []).map(async (r: any) => {
+            const f = mapFile(r.attachments, r.letter_id);
+            return { ...f, size: await getFileSize(f.path) };
+          })
         );
       }
 

--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -68,7 +68,7 @@ export default function ClaimsPage() {
   );
   const { data: units = [] } = useUnitsByIds(unitIds);
   const checkingDefectMap = useMemo(() => new Map<number, boolean>(), []);
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const initialValues = {
     project_id: searchParams.get('project_id')
       ? Number(searchParams.get('project_id')!)
@@ -94,6 +94,10 @@ export default function ClaimsPage() {
     if (searchParams.get('open_form') === '1') {
       setShowAddForm(true);
     }
+  }, [searchParams]);
+  React.useEffect(() => {
+    const cid = searchParams.get('claim_id');
+    if (cid) setViewId(Number(cid));
   }, [searchParams]);
   React.useEffect(() => {
     try {
@@ -373,7 +377,16 @@ export default function ClaimsPage() {
             />
           )}
         </div>
-        <ClaimViewModal open={viewId !== null} claimId={viewId} onClose={() => setViewId(null)} />
+        <ClaimViewModal
+          open={viewId !== null}
+          claimId={viewId}
+          onClose={() => {
+            setViewId(null);
+            const params = new URLSearchParams(searchParams);
+            params.delete('claim_id');
+            setSearchParams(params, { replace: true });
+          }}
+        />
       </>
     </ConfigProvider>
   );

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -38,6 +38,7 @@ import DefectFixModal from "@/features/defect/DefectFixModal";
 import { useCancelDefectFix } from "@/entities/defect";
 import { filterDefects } from "@/shared/utils/defectFilter";
 import { naturalCompare } from "@/shared/utils/naturalSort";
+import { useSearchParams } from 'react-router-dom';
 import formatUnitName from "@/shared/utils/formatUnitName";
 import { useUsers } from "@/entities/user";
 import type { DefectWithInfo } from "@/shared/types/defect";
@@ -65,6 +66,7 @@ export default function DefectsPage() {
   const { data: brigades = [] } = useBrigades();
   const { data: contractors = [] } = useContractors();
   const { data: users = [] } = useUsers();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const userProjectIds = useAuthStore((s) => s.profile?.project_ids) ?? [];
   const userMap = useMemo(() => {
@@ -210,6 +212,10 @@ export default function DefectsPage() {
   const [fixId, setFixId] = useState<number | null>(null);
   const { mutateAsync: removeDefect, isPending: removing } = useDeleteDefect();
   const cancelFix = useCancelDefectFix();
+  React.useEffect(() => {
+    const id = searchParams.get('defect_id');
+    if (id) setViewId(Number(id));
+  }, [searchParams]);
 
   const LS_FILTERS_VISIBLE_KEY = "defectsFiltersVisible";
   const LS_COLUMNS_KEY = "defectsColumns";
@@ -551,7 +557,12 @@ export default function DefectsPage() {
         <DefectViewModal
           open={viewId !== null}
           defectId={viewId}
-          onClose={() => setViewId(null)}
+          onClose={() => {
+            setViewId(null);
+            const params = new URLSearchParams(searchParams);
+            params.delete('defect_id');
+            setSearchParams(params, { replace: true });
+          }}
         />
         <DefectFixModal
           open={fixId !== null}

--- a/src/pages/ObjectArchivePage/ObjectArchivePage.tsx
+++ b/src/pages/ObjectArchivePage/ObjectArchivePage.tsx
@@ -24,6 +24,7 @@ export default function ObjectArchivePage() {
   const [remarkFiles, setRemarkFiles] = React.useState<ArchiveFile[]>([]);
   const [defectFiles, setDefectFiles] = React.useState<ArchiveFile[]>([]);
   const [courtFiles, setCourtFiles] = React.useState<ArchiveFile[]>([]);
+  const [letterFiles, setLetterFiles] = React.useState<ArchiveFile[]>([]);
   const descInit = React.useRef<Record<string, string | null>>({});
   const [changed, setChanged] = React.useState<Record<string, string>>({});
 
@@ -33,8 +34,9 @@ export default function ObjectArchivePage() {
     setRemarkFiles(data.remarkDocs);
     setDefectFiles(data.defectDocs);
     setCourtFiles(data.courtDocs);
+    setLetterFiles(data.letterDocs);
     const map: Record<string, string | null> = {};
-    [...data.objectDocs, ...data.remarkDocs, ...data.defectDocs, ...data.courtDocs].forEach((f) => {
+    [...data.objectDocs, ...data.remarkDocs, ...data.defectDocs, ...data.courtDocs, ...data.letterDocs].forEach((f) => {
       map[f.id] = f.description ?? '';
     });
     descInit.current = map;
@@ -70,6 +72,9 @@ export default function ObjectArchivePage() {
   const handleDescCourt = React.useCallback((id: string, d: string) => {
     setDescHelper(setCourtFiles, id, d);
   }, []);
+  const handleDescLetter = React.useCallback((id: string, d: string) => {
+    setDescHelper(setLetterFiles, id, d);
+  }, []);
 
   const handleDownloadArchive = async () => {
     const files = [
@@ -77,6 +82,7 @@ export default function ObjectArchivePage() {
       ...remarkFiles,
       ...defectFiles,
       ...courtFiles,
+      ...letterFiles,
       ...newObjectFiles.map((f) => ({ id: '', name: f.file.name, path: '', file: f.file })),
     ];
     const sources = await Promise.all(
@@ -163,7 +169,8 @@ export default function ObjectArchivePage() {
             showLink
             changedMap={changed}
             getSignedUrl={(p, n) => signedUrl(p, n)}
-            getLink={(f) => `/claims?id=${f.entityId}`}
+            getLink={(f) => `/claims?claim_id=${f.entityId}`}
+            getLinkLabel={(f) => `Замечание №${f.entityId}`}
           />
           <Divider />
           <Typography.Title level={4}>Документы по дефектам</Typography.Title>
@@ -177,7 +184,8 @@ export default function ObjectArchivePage() {
             showLink
             changedMap={changed}
             getSignedUrl={(p, n) => signedUrl(p, n)}
-            getLink={(f) => `/defects?id=${f.entityId}`}
+            getLink={(f) => `/defects?defect_id=${f.entityId}`}
+            getLinkLabel={(f) => `Дефект №${f.entityId}`}
           />
           <Divider />
           <Typography.Title level={4}>Документы по судебным делам</Typography.Title>
@@ -191,7 +199,23 @@ export default function ObjectArchivePage() {
             showLink
             changedMap={changed}
             getSignedUrl={(p, n) => signedUrl(p, n)}
-            getLink={(f) => `/court-cases?id=${f.entityId}`}
+            getLink={(f) => `/court-cases?case_id=${f.entityId}`}
+            getLinkLabel={(f) => `Судебное дело №${f.entityId}`}
+          />
+          <Divider />
+          <Typography.Title level={4}>Документы из писем</Typography.Title>
+          <AttachmentEditorTable
+            remoteFiles={letterFiles}
+            onDescRemote={handleDescLetter}
+            showMime={false}
+            showDetails
+            showSize
+            showHeader
+            showLink
+            changedMap={changed}
+            getSignedUrl={(p, n) => signedUrl(p, n)}
+            getLink={(f) => `/correspondence?letter_id=${f.entityId}`}
+            getLinkLabel={(f) => `Письмо №${f.entityId}`}
           />
           <Divider />
           <Button type="primary" disabled={!newObjectFiles.length && !Object.keys(changed).length} onClick={handleSave}>

--- a/src/shared/types/unitArchive.ts
+++ b/src/shared/types/unitArchive.ts
@@ -12,4 +12,6 @@ export interface UnitArchive {
   defectDocs: ArchiveFile[];
   /** Документы по судебным делам */
   courtDocs: ArchiveFile[];
+  /** Документы из писем */
+  letterDocs: ArchiveFile[];
 }

--- a/src/shared/ui/AttachmentEditorTable.tsx
+++ b/src/shared/ui/AttachmentEditorTable.tsx
@@ -44,6 +44,8 @@ interface Props {
     showLink?: boolean;
     /** Получить ссылку для просмотра сущности */
     getLink?: (file: RemoteFile) => string | undefined;
+    /** Получить текст ссылки для просмотра */
+    getLinkLabel?: (file: RemoteFile) => string;
     /** Показывать размер файла */
     showSize?: boolean;
     /** Карта изменённых описаний по id */
@@ -68,6 +70,7 @@ export default function AttachmentEditorTable({
   showDetails = false,
   showLink = false,
   getLink,
+  getLinkLabel,
   showSize = false,
   changedMap,
   showHeader = false,
@@ -208,7 +211,7 @@ export default function AttachmentEditorTable({
                 {
                     title: 'Ссылка',
                     dataIndex: 'link',
-                    width: 120,
+                    width: 200,
                     render: (_: unknown, row) =>
                         row.isRemote && row.id && getLink
                             ? (() => {
@@ -224,7 +227,12 @@ export default function AttachmentEditorTable({
                                           target="_blank"
                                           rel="noopener noreferrer"
                                       >
-                                          Открыть
+                                          {getLinkLabel ? getLinkLabel({
+                                              id: row.id!,
+                                              name: row.name,
+                                              path: row.path ?? '',
+                                              mime: row.mime,
+                                          }) : 'Открыть'}
                                       </a>
                                   ) : null;
                               })()


### PR DESCRIPTION
## Summary
- support letter files in unit archive
- show entity type near each file in archive
- allow opening claims and defects via query params
- enhance AttachmentEditorTable with custom link text

## Testing
- `npm test`
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6861512ceab8832eb98924eb5bfeb2b3