### PR TITLE
Add letter docs to object archive

### DIFF
--- a/src/entities/unitArchive.ts
+++ b/src/entities/unitArchive.ts
@@ -36,6 +36,7 @@ export function useUnitArchive(unitId?: number) {
         remarkDocs: [],
         defectDocs: [],
         courtDocs: [],
+        letterDocs: [],
       };
       if (!unitId) return result;
 
@@ -107,6 +108,26 @@ export function useUnitArchive(unitId?: number) {
         result.courtDocs = await Promise.all(
           (data ?? []).map(async (r: any) => {
             const f = mapFile(r.attachments, r.court_case_id);
+            return { ...f, size: await getFileSize(f.path) };
+          }),
+        );
+      }
+
+      const { data: letterRows } = await supabase
+        .from('letter_units')
+        .select('letter_id')
+        .eq('unit_id', unitId);
+      const letterIds = (letterRows ?? []).map((r: any) => r.letter_id);
+      if (letterIds.length) {
+        const { data } = await supabase
+          .from('letter_attachments')
+          .select(
+            'letter_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description)',
+          )
+          .in('letter_id', letterIds);
+        result.letterDocs = await Promise.all(
+          (data ?? []).map(async (r: any) => {
+            const f = mapFile(r.attachments, r.letter_id);
             return { ...f, size: await getFileSize(f.path) };
           }),
         );

--- a/src/shared/types/unitArchive.ts
+++ b/src/shared/types/unitArchive.ts
@@ -12,4 +12,6 @@ export interface UnitArchive {
   defectDocs: ArchiveFile[];
   /** Документы по судебным делам */
   courtDocs: ArchiveFile[];
+  /** Файлы из писем */
+  letterDocs: ArchiveFile[];
 }

--- a/src/shared/ui/AttachmentEditorTable.tsx
+++ b/src/shared/ui/AttachmentEditorTable.tsx
@@ -44,6 +44,10 @@ interface Props {
     showLink?: boolean;
     /** Получить ссылку для просмотра сущности */
     getLink?: (file: RemoteFile) => string | undefined;
+    /** Текст ссылки */
+    getLinkLabel?: (file: RemoteFile) => React.ReactNode;
+    /** Обработчик клика по ссылке. Если указан, getLink не используется */
+    onOpenLink?: (file: RemoteFile) => void;
     /** Показывать размер файла */
     showSize?: boolean;
     /** Карта изменённых описаний по id */
@@ -68,6 +72,8 @@ export default function AttachmentEditorTable({
   showDetails = false,
   showLink = false,
   getLink,
+  getLinkLabel,
+  onOpenLink,
   showSize = false,
   changedMap,
   showHeader = false,
@@ -209,26 +215,39 @@ export default function AttachmentEditorTable({
                     title: 'Ссылка',
                     dataIndex: 'link',
                     width: 120,
-                    render: (_: unknown, row) =>
-                        row.isRemote && row.id && getLink
-                            ? (() => {
-                                  const url = getLink({
-                                      id: row.id,
-                                      name: row.name,
-                                      path: row.path ?? '',
-                                      mime: row.mime,
-                                  });
-                                  return url ? (
-                                      <a
-                                          href={url}
-                                          target="_blank"
-                                          rel="noopener noreferrer"
-                                      >
-                                          Открыть
-                                      </a>
-                                  ) : null;
-                              })()
-                            : null,
+                    render: (_: unknown, row) => {
+                        if (!row.isRemote || !row.id) return null;
+                        const file = {
+                            id: row.id,
+                            name: row.name,
+                            path: row.path ?? '',
+                            mime: row.mime,
+                        } as RemoteFile;
+                        const label = getLinkLabel ? getLinkLabel(file) : 'Открыть';
+                        if (onOpenLink) {
+                            return (
+                                <a
+                                    href="#"
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        onOpenLink(file);
+                                    }}
+                                >
+                                    {label}
+                                </a>
+                            );
+                        }
+                        if (getLink) {
+                            const url = getLink(file);
+                            return url ? (
+                                <a href={url} target="_blank" rel="noopener noreferrer">
+                                    {label}
+                                </a>
+                            ) : null;
+                        }
+                        return null;
+                        return null;
+                    },
                 } as ColumnsType<Row>[number],
             ]
             : []),


### PR DESCRIPTION
## Summary
- include letterDocs in unit archive data
- extend AttachmentEditorTable with optional link handlers
- show letter attachments on ObjectArchivePage
- open entity view modals directly from archive page

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861512ceab8832eb98924eb5bfeb2b3