### PR TITLE
Add creator info to object archive page

### DIFF
--- a/src/entities/unitArchive.ts
+++ b/src/entities/unitArchive.ts
@@ -23,6 +23,8 @@ function mapFile(a: any, entityId?: number): ArchiveFile {
     description: a.description ?? null,
     size: null,
     entityId,
+    createdAt: a.created_at ?? null,
+    createdBy: a.created_by ?? null,
   };
 }
 
@@ -119,12 +121,12 @@ export function useUnitArchive(unitId?: number) {
         .eq('unit_id', unitId);
       const letterIds = (letterRows ?? []).map((r: any) => r.letter_id);
       if (letterIds.length) {
-        const { data } = await supabase
-          .from('letter_attachments')
-          .select(
-            'letter_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description)',
-          )
-          .in('letter_id', letterIds);
+      const { data } = await supabase
+        .from('letter_attachments')
+        .select(
+            'letter_id, attachments(id, storage_path, file_url:path, file_type:mime_type, original_name, description, created_at, created_by)',
+        )
+        .in('letter_id', letterIds);
         result.letterDocs = await Promise.all(
           (data ?? []).map(async (r: any) => {
             const f = mapFile(r.attachments, r.letter_id);

--- a/src/shared/types/archiveFile.ts
+++ b/src/shared/types/archiveFile.ts
@@ -16,4 +16,8 @@ export interface ArchiveFile {
   entityId?: number;
   /** Размер файла в байтах */
   size?: number | null;
+  /** Дата создания файла */
+  createdAt?: string | null;
+  /** Автор создания (id профиля) */
+  createdBy?: string | null;
 }

--- a/src/shared/ui/AttachmentEditorTable.tsx
+++ b/src/shared/ui/AttachmentEditorTable.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import dayjs from 'dayjs';
 import { Table, Button, Space, Tooltip, Input } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import {
@@ -20,6 +21,10 @@ interface RemoteFile {
     size?: number | null;
     /** Идентификатор связанной сущности */
     entityId?: number;
+    /** Дата создания файла */
+    createdAt?: string | null;
+    /** Имя автора создания */
+    createdByName?: string | null;
 }
 
 interface NewFile {
@@ -56,6 +61,10 @@ interface Props {
     changedMap?: Record<string, boolean>;
     /** Показывать заголовок таблицы */
     showHeader?: boolean;
+    /** Показывать дату создания */
+    showCreatedAt?: boolean;
+    /** Показывать автора создания */
+    showCreatedBy?: boolean;
 }
 
 /**
@@ -79,6 +88,8 @@ export default function AttachmentEditorTable({
   showSize = false,
   changedMap,
   showHeader = false,
+  showCreatedAt = false,
+  showCreatedBy = false,
 }: Props) {
     const [cache, setCache] = React.useState<Record<string, string>>({});
 
@@ -131,6 +142,8 @@ export default function AttachmentEditorTable({
         description?: string;
         size?: number | null;
         entityId?: number;
+        createdAt?: string | null;
+        createdByName?: string | null;
         isRemote: boolean;
     }
 
@@ -144,6 +157,8 @@ export default function AttachmentEditorTable({
             description: f.description,
             size: f.size ?? null,
             entityId: f.entityId,
+            createdAt: f.createdAt ?? null,
+            createdByName: f.createdByName ?? null,
             isRemote: true,
         })),
         ...newFiles.map<Row>((f, i) => ({
@@ -211,6 +226,27 @@ export default function AttachmentEditorTable({
                         />
                     ),
                 } as ColumnsType<Row>[number],
+            ]
+            : []),
+        ...(showCreatedAt
+            ? [
+                {
+                    title: 'Создан',
+                    dataIndex: 'createdAt',
+                    width: 160,
+                    render: (v: string | null) =>
+                        v ? dayjs(v).format('DD.MM.YYYY HH:mm') : '—',
+                } as ColumnsType<Row>[number]
+            ]
+            : []),
+        ...(showCreatedBy
+            ? [
+                {
+                    title: 'Автор',
+                    dataIndex: 'createdByName',
+                    width: 160,
+                    render: (v: string | null) => v || '—',
+                } as ColumnsType<Row>[number]
             ]
             : []),
         ...(showLink


### PR DESCRIPTION
## Summary
- extend `ArchiveFile` with creator fields
- show creator columns in `AttachmentEditorTable`
- fetch creator data in `useUnitArchive`
- display creator name/date on ObjectArchivePage

## Testing
- `npm test`
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*
- `npm run lint` *(fails: parsing error due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_6861730fdfe0832e99629cab0f737db3