### PR TITLE
Fix correspondence sorting

### DIFF
--- a/src/entities/correspondence/index.ts
+++ b/src/entities/correspondence/index.ts
@@ -62,7 +62,7 @@ export function useLetters() {
       if (onlyAssigned) {
         query = query.in('project_id', projectIds.length ? projectIds : [-1]);
       }
-      const { data, error } = await query.order('id');
+      const { data, error } = await query.order('id', { ascending: false });
       if (error) throw error;
 
       const letterIds = (data ?? []).map((r: any) => r.id) as number[];

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -311,7 +311,13 @@ export default function CorrespondencePage() {
           );
         },
       },
-      id: { title: 'ID', dataIndex: 'id', width: 80 },
+      id: {
+        title: 'ID',
+        dataIndex: 'id',
+        width: 80,
+        sorter: (a: any, b: any) => Number(a.id) - Number(b.id),
+        defaultSortOrder: 'descend' as const,
+      },
       type: {
         title: 'Тип',
         dataIndex: 'type',

--- a/src/widgets/CorrespondenceTable.tsx
+++ b/src/widgets/CorrespondenceTable.tsx
@@ -147,6 +147,7 @@ export default function CorrespondenceTable({
       dataIndex: 'id',
       width: 80,
       sorter: (a, b) => Number(a.id) - Number(b.id),
+      defaultSortOrder: 'descend' as const,
     },
     {
       title: 'Тип',


### PR DESCRIPTION
## Summary
- show newest correspondence first
- enable ID sorting for correspondence table

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68617494517c832e895cc457b87148ed