### PR TITLE
Sort court cases by id desc

### DIFF
--- a/src/entities/courtCase/index.ts
+++ b/src/entities/courtCase/index.ts
@@ -24,7 +24,8 @@ export function useCourtCases() {
       if (onlyAssigned) {
         query = query.in('project_id', projectIds.length ? projectIds : [-1]);
       }
-      query = query.order('created_at', { ascending: false });
+      // Sort cases by ID in descending order for consistent latest-first view
+      query = query.order('id', { ascending: false });
       const { data, error } = await query;
       if (error) throw error;
 

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -296,6 +296,7 @@ export default function CourtCasesPage() {
       dataIndex: 'id',
       width: 80,
       sorter: (a, b) => a.id - b.id,
+      defaultSortOrder: 'descend',
       render: (id: number) => <span style={{ whiteSpace: 'nowrap' }}>{id}</span>,
     },
     projectName: {


### PR DESCRIPTION
## Summary
- sort court cases by ID descending in database query
- show table sorted by ID in descending order by default

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686174d9c5a0832e88271cbdbfc3b561