### PR TITLE
Добавлена возможность редактировать описание файлов претензии

### DIFF
--- a/src/features/claim/ClaimAttachmentsBlock.tsx
+++ b/src/features/claim/ClaimAttachmentsBlock.tsx
@@ -22,6 +22,8 @@ export interface ClaimAttachmentsBlockProps {
   onRemoveNew?: (index: number) => void;
   /** Изменить описание локального файла */
   onDescNew?: (index: number, description: string) => void;
+  /** Изменить описание загруженного файла */
+  onDescRemote?: (id: string, description: string) => void;
   /** Показывать ли область загрузки */
   showUpload?: boolean;
   /** Получить подписанную ссылку */
@@ -37,6 +39,7 @@ export default function ClaimAttachmentsBlock({
   onRemoveRemote,
   onRemoveNew,
   onDescNew,
+  onDescRemote,
   showUpload = true,
   getSignedUrl,
   onPreview,
@@ -59,9 +62,11 @@ export default function ClaimAttachmentsBlock({
         }))}
         onRemoveRemote={onRemoveRemote}
         onRemoveNew={onRemoveNew}
+        onDescRemote={onDescRemote}
         onDescNew={onDescNew}
         getSignedUrl={getSignedUrl}
         showDetails
+        onPreview={onPreview}
       />
     </Form.Item>
   );

--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -23,6 +23,7 @@ import {
   signedUrl,
   markClaimDefectsPreTrial,
 } from '@/entities/claim';
+import { updateAttachmentDescription } from '@/entities/attachment';
 import { supabase } from '@/shared/api/supabaseClient';
 import { useVisibleProjects } from '@/entities/project';
 import { useUnitsByProject } from '@/entities/unit';
@@ -197,6 +198,13 @@ const ClaimFormAntdEdit = React.forwardRef<
           mime_type: u.file_type,
         }));
       attachments.appendRemote(uploaded);
+      }
+      if (Object.keys(attachments.changedDesc).length) {
+        await Promise.all(
+          Object.entries(attachments.changedDesc).map(([id, val]) =>
+            updateAttachmentDescription(Number(id), val),
+          ),
+        );
       }
       attachments.markPersisted();
       notify.success('Претензия обновлена');

--- a/src/features/claim/ClaimViewModal.tsx
+++ b/src/features/claim/ClaimViewModal.tsx
@@ -375,6 +375,7 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
             onFiles={attachments.addFiles}
             onRemoveRemote={attachments.removeRemote}
             onRemoveNew={attachments.removeNew}
+            onDescRemote={attachments.setRemoteDescription}
             onDescNew={attachments.setDescription}
             getSignedUrl={(path, name) => signedUrl(path, name)}
             onPreview={(f) => setPreviewFile(f)}


### PR DESCRIPTION
## Summary
- позволили редактировать описание загруженных файлов претензии
- обновили форму редактирования претензии и модальное окно просмотра

## Testing
- `npm run lint` *(fails: eslint missing plugins)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686175be01bc832eaf67fce2c4b1d63c