### PR TITLE
Fix attachments editing

### DIFF
--- a/src/entities/claim.ts
+++ b/src/entities/claim.ts
@@ -45,6 +45,7 @@ function mapClaim(r: any): ClaimWithNames {
           name,
           url: a.file_url,
           mime_type: a.mime_type,
+          description: a.description ?? null,
         } as import('@/shared/types/claimFile').RemoteClaimFile;
       })
     : [];

--- a/src/widgets/TicketDefectsEditorTable.tsx
+++ b/src/widgets/TicketDefectsEditorTable.tsx
@@ -47,6 +47,13 @@ interface Props {
   fileMap?: Record<number, NewDefectFile[]>;
   remoteFileMap?: Record<number, RemoteClaimFile[]>;
   onFilesChange?: (id: number, files: NewDefectFile[]) => void;
+  onRemoveRemoteFile?: (defectId: number, fileId: string) => void;
+  onDescRemoteFile?: (
+    defectId: number,
+    fileId: string,
+    description: string,
+  ) => void;
+  getSignedUrl?: (path: string, name: string) => Promise<string>;
 }
 
 /**
@@ -64,6 +71,9 @@ export default function TicketDefectsEditorTable({
   fileMap = {},
   remoteFileMap = {},
   onFilesChange,
+  onRemoveRemoteFile,
+  onDescRemoteFile,
+  getSignedUrl,
 }: Props) {
   const fmt = (d: string | null) => (d ? dayjs(d).format('DD.MM.YYYY') : undefined);
 
@@ -249,6 +259,8 @@ export default function TicketDefectsEditorTable({
                 description: f.description ?? '',
               }))}
               newFiles={files.map((f) => ({ file: f.file, mime: f.file.type, description: f.description }))}
+              onRemoveRemote={(id) => onRemoveRemoteFile?.(record.id, id)}
+              onDescRemote={(id, d) => onDescRemoteFile?.(record.id, id, d)}
               onRemoveNew={(idx) => {
                 const arr = files.filter((_, i) => i !== idx);
                 onFilesChange?.(record.id, arr);
@@ -257,6 +269,7 @@ export default function TicketDefectsEditorTable({
                 const arr = files.map((ff, i) => (i === idx ? { ...ff, description: d } : ff));
                 onFilesChange?.(record.id, arr);
               }}
+              getSignedUrl={getSignedUrl}
               showMime={false}
               showDetails
             />


### PR DESCRIPTION
## Summary
- include description field when mapping claim attachments
- enable editing remote defect files in ClaimViewModal
- add bulk removal for defect attachments
- wire editing actions in TicketDefectsEditorTable

## Testing
- `npm run lint` *(fails: Parsing errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686178db6bc0832eb0baeb4ec38b79f3