### PR TITLE
Fix claim ID sorting in defects table

### DIFF
--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -37,7 +37,7 @@ import ExportDefectsButton from "@/features/defect/ExportDefectsButton";
 import DefectFixModal from "@/features/defect/DefectFixModal";
 import { useCancelDefectFix } from "@/entities/defect";
 import { filterDefects } from "@/shared/utils/defectFilter";
-import { naturalCompare } from "@/shared/utils/naturalSort";
+import { naturalCompare, naturalCompareArrays } from "@/shared/utils/naturalSort";
 import formatUnitName from "@/shared/utils/formatUnitName";
 import { useUsers } from "@/entities/user";
 import type { DefectWithInfo } from "@/shared/types/defect";
@@ -236,7 +236,7 @@ export default function DefectsPage() {
         dataIndex: "claimIds",
         width: 120,
         sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
-          a.claimIds.join(",").localeCompare(b.claimIds.join(",")),
+          naturalCompareArrays(a.claimIds, b.claimIds),
         render: (v: number[]) => v.join(", "),
       },
       days: {

--- a/src/shared/utils/naturalSort.ts
+++ b/src/shared/utils/naturalSort.ts
@@ -8,3 +8,24 @@
 export function naturalCompare(a: string | number, b: string | number): number {
   return String(a).localeCompare(String(b), undefined, { numeric: true, sensitivity: 'base' });
 }
+
+/**
+ * Лексикографическое сравнение массивов чисел.
+ * Используется для корректной сортировки колонок с несколькими ID.
+ *
+ * @param a первый массив
+ * @param b второй массив
+ */
+export function naturalCompareArrays(a: number[], b: number[]): number {
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i += 1) {
+    const av = a[i];
+    const bv = b[i];
+    if (av === undefined && bv === undefined) return 0;
+    if (av === undefined) return -1;
+    if (bv === undefined) return 1;
+    const diff = naturalCompare(av, bv);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -17,6 +17,7 @@ import type { DefectWithInfo } from "@/shared/types/defect";
 import type { DefectFilters } from "@/shared/types/defectFilters";
 import { filterDefects } from "@/shared/utils/defectFilter";
 import { useResizableColumns } from "@/shared/hooks/useResizableColumns";
+import { naturalCompareArrays } from "@/shared/utils/naturalSort";
 
 const fmt = (v: string | null) => (v ? dayjs(v).format("DD.MM.YYYY") : "—");
 const fmtDateTime = (v: string | null) =>
@@ -55,8 +56,7 @@ export default function DefectsTable({
       title: "ID претензии",
       dataIndex: "claimIds",
       width: 120,
-      sorter: (a, b) =>
-        a.claimIds.join(",").localeCompare(b.claimIds.join(",")),
+      sorter: (a, b) => naturalCompareArrays(a.claimIds, b.claimIds),
       render: (v: number[]) => v.join(", "),
     },
     {


### PR DESCRIPTION
## Summary
- add naturalCompareArrays util for array comparison
- use new util in DefectsTable and DefectsPage to sort claim IDs correctly

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68617c5b4d88832eaf3f13bcf9a2a26b