### PR TITLE
Fix claim defect creation

### DIFF
--- a/src/entities/defect.ts
+++ b/src/entities/defect.ts
@@ -149,7 +149,11 @@ export function useDefectsWithNames(ids?: number[]) {
   });
 }
 
-/** Создать несколько дефектов и вернуть их ID */
+/**
+ * Создать несколько дефектов одним запросом и вернуть массив их идентификаторов.
+ * Возвращаемые ID могут быть строками при большом значении, поэтому
+ * преобразуем их к `number` для единообразия.
+ */
 export function useCreateDefects() {
   const qc = useQueryClient();
   const notify = useNotify();
@@ -166,7 +170,7 @@ export function useCreateDefects() {
         .insert(rows)
         .select('id');
       if (error) throw error;
-      return (data as { id: number }[]).map((d) => d.id);
+      return (data as { id: string | number }[]).map((d) => Number(d.id));
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: [TABLE] }),
     onError: (e) => notify.error(e.message),

--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -222,6 +222,9 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
       case_uid_id: values.case_uid_id ?? null,
     }));
     const defectIds = await createDefects.mutateAsync(newDefs);
+    if (defectIds.length !== newDefs.length) {
+      notify.error('Не удалось сохранить все дефекты');
+    }
 
     for (let i = 0; i < defectIds.length; i += 1) {
       const filesFor = defectFiles[i] ?? [];


### PR DESCRIPTION
## Summary
- return numeric IDs from `useCreateDefects`
- warn on partial defect creation in claim form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68617dc2ad84832ea6e69b88a2aa197a