### PR TITLE
Sort defects by ID desc

### DIFF
--- a/src/entities/defect.ts
+++ b/src/entities/defect.ts
@@ -42,7 +42,7 @@ export function useDefects() {
           'id, description, type_id, status_id, project_id, unit_id, created_by, updated_by, updated_at, brigade_id, contractor_id, is_warranty, received_at, fixed_at, fixed_by, created_at,' +
           ' defect_type:defect_types!fk_defects_type(id,name), defect_status:statuses!fk_defects_status(id,name,color), fixed_by_user:profiles!fk_defects_fixed_by(id,name)'
         )
-        .order('id');
+        .order('id', { ascending: false });
       if (error) throw error;
       return data as unknown as DefectRecord[];
     },

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -230,6 +230,7 @@ export default function DefectsPage() {
         dataIndex: "id",
         width: 80,
         sorter: (a: DefectWithInfo, b: DefectWithInfo) => a.id - b.id,
+        defaultSortOrder: 'descend' as const,
       },
       claims: {
         title: "ID претензии",

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -51,6 +51,7 @@ export default function DefectsTable({
       dataIndex: "id",
       width: 80,
       sorter: (a, b) => a.id - b.id,
+      defaultSortOrder: 'descend' as const,
     },
     {
       title: "ID претензии",


### PR DESCRIPTION
## Summary
- sort default defect query by id desc
- show descending sort in Defects page and table

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686182257984832e86a43796a5bc3518