### PR TITLE
Fix defect listing limit

### DIFF
--- a/src/entities/defect.ts
+++ b/src/entities/defect.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/shared/api/supabaseClient';
+import { fetchAllRows } from '@/shared/api/fetchAllSupabase';
 import { useNotify } from '@/shared/hooks/useNotify';
 import { addDefectAttachments, getAttachmentsByIds, ATTACH_BUCKET } from '@/entities/attachment';
 import { useAuthStore } from '@/shared/store/authStore';
@@ -36,15 +37,15 @@ export function useDefects() {
   return useQuery<DefectRecord[]>({
     queryKey: [TABLE],
     queryFn: async () => {
-      const { data, error } = await supabase
+      const baseQuery = supabase
         .from(TABLE)
         .select(
           'id, description, type_id, status_id, project_id, unit_id, created_by, updated_by, updated_at, brigade_id, contractor_id, is_warranty, received_at, fixed_at, fixed_by, created_at,' +
-          ' defect_type:defect_types!fk_defects_type(id,name), defect_status:statuses!fk_defects_status(id,name,color), fixed_by_user:profiles!fk_defects_fixed_by(id,name)'
+            ' defect_type:defect_types!fk_defects_type(id,name), defect_status:statuses!fk_defects_status(id,name,color), fixed_by_user:profiles!fk_defects_fixed_by(id,name)'
         )
         .order('id');
-      if (error) throw error;
-      return data as unknown as DefectRecord[];
+      const rows = await fetchAllRows(baseQuery);
+      return rows as unknown as DefectRecord[];
     },
     staleTime: 5 * 60_000,
   });

--- a/src/shared/api/fetchAllSupabase.ts
+++ b/src/shared/api/fetchAllSupabase.ts
@@ -1,0 +1,24 @@
+import { PostgrestFilterBuilder } from '@supabase/supabase-js';
+
+/**
+ * Загружает все строки по переданному запросу, обходя лимит Supabase на 1000 записей.
+ * @param baseQuery Базовый запрос без диапазона, например `supabase.from('table').select('*').order('id')`
+ * @param chunkSize Размер порции выборки (по умолчанию 1000)
+ */
+export async function fetchAllRows<T>(
+  baseQuery: PostgrestFilterBuilder<any, any, T>,
+  chunkSize = 1000,
+): Promise<T[]> {
+  const result: T[] = [];
+  let from = 0;
+  while (true) {
+    const { data, error } = await baseQuery
+      .range(from, from + chunkSize - 1);
+    if (error) throw error;
+    if (!data?.length) break;
+    result.push(...data);
+    if (data.length < chunkSize) break;
+    from += chunkSize;
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- implement helper `fetchAllRows` to load Supabase queries in chunks
- use the helper in `useDefects` to fetch all defect rows

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error)*
- `npx tsc --noEmit` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_686183b2a424832e804c3af6d3dd4b4a