### PR TITLE
fix: load all defects and claims

### DIFF
--- a/src/entities/defect.ts
+++ b/src/entities/defect.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/shared/api/supabaseClient';
+import { fetchPaged } from '@/shared/api/fetchAll';
 import { useNotify } from '@/shared/hooks/useNotify';
 import { addDefectAttachments, getAttachmentsByIds, ATTACH_BUCKET } from '@/entities/attachment';
 import { useAuthStore } from '@/shared/store/authStore';
@@ -36,15 +37,17 @@ export function useDefects() {
   return useQuery<DefectRecord[]>({
     queryKey: [TABLE],
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from(TABLE)
-        .select(
-          'id, description, type_id, status_id, project_id, unit_id, created_by, updated_by, updated_at, brigade_id, contractor_id, is_warranty, received_at, fixed_at, fixed_by, created_at,' +
-          ' defect_type:defect_types!fk_defects_type(id,name), defect_status:statuses!fk_defects_status(id,name,color), fixed_by_user:profiles!fk_defects_fixed_by(id,name)'
-        )
-        .order('id', { ascending: false });
-      if (error) throw error;
-      return data as unknown as DefectRecord[];
+      const rows = await fetchPaged<DefectRecord>((from, to) =>
+        supabase
+          .from(TABLE)
+          .select(
+            'id, description, type_id, status_id, project_id, unit_id, created_by, updated_by, updated_at, brigade_id, contractor_id, is_warranty, received_at, fixed_at, fixed_by, created_at,' +
+              ' defect_type:defect_types!fk_defects_type(id,name), defect_status:statuses!fk_defects_status(id,name,color), fixed_by_user:profiles!fk_defects_fixed_by(id,name)'
+          )
+          .order('id', { ascending: false })
+          .range(from, to),
+      );
+      return rows;
     },
     staleTime: 5 * 60_000,
   });

--- a/src/shared/api/fetchAll.ts
+++ b/src/shared/api/fetchAll.ts
@@ -1,0 +1,40 @@
+import type { PostgrestSingleResponse } from '@supabase/supabase-js';
+
+const CHUNK_SIZE = 1000;
+
+/**
+ * Запрашивает все строки супаБейза постранично, учитывая ограничение 1000 записей.
+ * @param fn Функция, возвращающая промис запроса с указанием диапазона строк.
+ */
+export async function fetchPaged<T>(
+  fn: (from: number, to: number) => Promise<PostgrestSingleResponse<T[]>>,
+): Promise<T[]> {
+  const result: T[] = [];
+  for (let from = 0; ; from += CHUNK_SIZE) {
+    const { data, error } = await fn(from, from + CHUNK_SIZE - 1);
+    if (error) throw error;
+    const part = data ?? [];
+    result.push(...part);
+    if (part.length < CHUNK_SIZE) break;
+  }
+  return result;
+}
+
+/**
+ * Делит набор значений на чанки и выполняет запрос с оператором `in`.
+ * Используется для обхода ограничений на количество параметров.
+ * @param values Массив идентификаторов
+ * @param fn Функция, возвращающая запрос для части значений
+ */
+export async function fetchByChunks<T>(
+  values: readonly number[],
+  fn: (chunk: readonly number[]) => Promise<PostgrestSingleResponse<T[]>>,
+): Promise<T[]> {
+  const result: T[] = [];
+  for (let i = 0; i < values.length; i += CHUNK_SIZE) {
+    const { data, error } = await fn(values.slice(i, i + CHUNK_SIZE));
+    if (error) throw error;
+    result.push(...(data ?? []));
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- fetch Supabase data in chunks to avoid 1000 row limit
- load all defects without losing older rows
- load all claims and related units/defects regardless of count

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686185934a38832ea26cfdd5c72fa553