### PR TITLE
Fix missing claim IDs on defects page

### DIFF
--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -95,19 +95,21 @@ export default function DefectsPage() {
       { id: number; unit_ids: number[]; project_id: number; pre_trial_claim: boolean }[]
     >();
     claims.forEach((c: any) => {
+      const claimId = Number(c.id);
       (c.claim_defects || []).forEach((cd: any) => {
-        const arr = claimsMap.get(cd.defect_id) || [];
+        const defectId = Number(cd.defect_id);
+        const arr = claimsMap.get(defectId) || [];
         arr.push({
-          id: c.id,
+          id: claimId,
           unit_ids: c.unit_ids || [],
           project_id: c.project_id,
           pre_trial_claim: cd.pre_trial_claim ?? false,
         });
-        claimsMap.set(cd.defect_id, arr);
+        claimsMap.set(defectId, arr);
       });
     });
     return defects.map((d: any) => {
-      const claimLinked = claimsMap.get(d.id) || [];
+      const claimLinked = claimsMap.get(Number(d.id)) || [];
       const linked = claimLinked;
       const hasPretrial = linked.some((l) => l.pre_trial_claim);
       const unitIdsFromClaims = Array.from(new Set(linked.flatMap((l) => l.unit_ids)));


### PR DESCRIPTION
## Summary
- map claim IDs using numeric keys to avoid string mismatch
- ensure claim links retrieved with numeric defect IDs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68618eb3c5d4832eb9c41de12d77f22d