### PR TITLE
Fix claim ID display in defects list

### DIFF
--- a/src/shared/types/claimIdsMap.ts
+++ b/src/shared/types/claimIdsMap.ts
@@ -1,0 +1,5 @@
+/**
+ * Соответствие ID дефекта и связанных ID претензий.
+ * Ключ — `defect_id`, значение — массив `claim_id`.
+ */
+export type ClaimIdsMap = Record<number, number[]>;


### PR DESCRIPTION
## Summary
- create `ClaimIdsMap` type for mapping defect IDs to claim IDs
- add `useClaimIdsByDefectIds` hook to load claim IDs from `claim_defects`
- show claim IDs in `/defects` table using the new hook

## Testing
- `npm test`
- `npm run lint` *(fails: module resolution issues)*

------
https://chatgpt.com/codex/tasks/task_e_686194b5c8a0832e9f47680d9fb6ef72