### PR TITLE
Fix TypeScript issues

### DIFF
--- a/src/entities/unit.ts
+++ b/src/entities/unit.ts
@@ -53,7 +53,16 @@ export const useUnits = () => {
     });
 };
 
-export const useUnitsByProject = (projectId, building) =>
+/**
+ * Получить объекты (units) по идентификатору проекта.
+ *
+ * @param projectId идентификатор проекта
+ * @param building  optional номер/название корпуса
+ */
+export const useUnitsByProject = (
+    projectId: number | null,
+    building?: number | string,
+) =>
     useQuery({
         queryKey: ['units', projectId ?? 'all', building ?? ''],
         enabled : !!projectId,

--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -310,7 +310,11 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
             <Select
               mode="multiple"
               showSearch
-              filterOption={(i, o) => (o?.label ?? '').toLowerCase().includes(i.toLowerCase())}
+              filterOption={(i, o) =>
+                String(o?.label ?? '')
+                  .toLowerCase()
+                  .includes(i.toLowerCase())
+              }
               options={units.map((u) => ({ value: u.id, label: u.name }))}
               disabled={!projectId}
             />

--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -183,11 +183,7 @@ const ClaimFormAntdEdit = React.forwardRef<
       if (attachments.newFiles.length) {
         const res = await addAtt.mutateAsync({
           claimId: claim.id,
-          files: attachments.newFiles.map((f) => ({
-            file: f.file,
-            type_id: null,
-            description: f.description,
-          })),
+          files: attachments.newFiles.map((f) => f.file),
         });
         uploaded = res.map((u) => ({
           id: u.id,

--- a/src/features/correspondence/model/useLetterAttachments.ts
+++ b/src/features/correspondence/model/useLetterAttachments.ts
@@ -45,6 +45,14 @@ export function useLetterAttachments(options: {
     setRemoteFiles((p) => p.filter((f) => String(f.id) !== String(id)));
     setRemovedIds((p) => [...p, id]);
   }, []);
+  const setDescription = useCallback((idx: number, val: string) => {
+    setNewFiles((p) => p.map((f, i) => (i === idx ? { ...f, description: val } : f)));
+  }, []);
+  const setRemoteDescription = useCallback((id: string, val: string) => {
+    setRemoteFiles((p) =>
+      p.map((f) => (String(f.id) === String(id) ? { ...f, description: val } : f)),
+    );
+  }, []);
   const changeRemoteType = useCallback((_id: string, _type: number | null) => {}, []);
   const changeNewType = useCallback((_idx: number, _type: number | null) => {}, []);
   const appendRemote = useCallback((files: RemoteLetterFile[]) => {
@@ -70,6 +78,8 @@ export function useLetterAttachments(options: {
     addFiles,
     removeNew,
     removeRemote,
+    setDescription,
+    setRemoteDescription,
     changeRemoteType,
     changeNewType,
     appendRemote,

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -198,8 +198,10 @@ export default function DefectsPage() {
 
     const uniq = (values: (string | number | null | undefined)[]) =>
       Array.from(new Set(values.filter(Boolean) as (string | number)[])).sort(naturalCompare);
-    const mapOptions = (vals: (string | number | null | undefined)[]) =>
-      uniq(vals).map((v) => ({ label: String(v), value: v }));
+    const mapNumOptions = (vals: (number | null | undefined)[]) =>
+      uniq(vals).map((v) => ({ label: String(v), value: Number(v) }));
+    const mapStrOptions = (vals: (string | null | undefined)[]) =>
+      uniq(vals).map((v) => ({ label: String(v), value: String(v) }));
 
     const uniqPairs = (pairs: [number | null, string | null][]) => {
       const map = new Map<number, string>();
@@ -214,15 +216,15 @@ export default function DefectsPage() {
     const unitMap = new Map(units.map((u) => [u.id, u.name]));
     const projectMap = new Map(projects.map((p) => [p.id, p.name]));
 
-    return {
-      ids: mapOptions(filtered('id').map((d) => d.id)),
+      return {
+        ids: mapNumOptions(filtered('id').map((d) => d.id)),
       units: Array.from(
         new Set(filtered('units').flatMap((d) => d.unitIds)),
       )
         .map((id) => ({ label: unitMap.get(id) ?? String(id), value: id }))
         .sort((a, b) => naturalCompare(a.label, b.label)),
-      buildings: mapOptions(
-        filtered('building').flatMap((d) => d.buildingNamesList || []),
+        buildings: mapStrOptions(
+          filtered('building').flatMap((d) => d.buildingNamesList || []),
       ),
       projects: Array.from(
         new Set(filtered('projectId').flatMap((d) => d.projectIds || [])),
@@ -233,8 +235,8 @@ export default function DefectsPage() {
       statuses: uniqPairs(
         filtered('statusId').map((d) => [d.status_id, d.defectStatusName]),
       ),
-      fixBy: mapOptions(filtered('fixBy').map((d) => d.fixByName)),
-    };
+        fixBy: mapStrOptions(filtered('fixBy').map((d) => d.fixByName)),
+      };
   }, [filteredData, filters, units, projects]);
   const [viewId, setViewId] = useState<number | null>(null);
   const [fixId, setFixId] = useState<number | null>(null);

--- a/src/shared/api/fetchAll.ts
+++ b/src/shared/api/fetchAll.ts
@@ -7,7 +7,10 @@ const CHUNK_SIZE = 1000;
  * @param fn Функция, возвращающая промис запроса с указанием диапазона строк.
  */
 export async function fetchPaged<T>(
-  fn: (from: number, to: number) => Promise<PostgrestSingleResponse<T[]>>,
+  fn: (
+    from: number,
+    to: number,
+  ) => PromiseLike<PostgrestSingleResponse<T[]>>,
 ): Promise<T[]> {
   const result: T[] = [];
   for (let from = 0; ; from += CHUNK_SIZE) {
@@ -28,7 +31,9 @@ export async function fetchPaged<T>(
  */
 export async function fetchByChunks<T>(
   values: readonly number[],
-  fn: (chunk: readonly number[]) => Promise<PostgrestSingleResponse<T[]>>,
+  fn: (
+    chunk: readonly number[],
+  ) => PromiseLike<PostgrestSingleResponse<T[]>>,
 ): Promise<T[]> {
   const result: T[] = [];
   for (let i = 0; i < values.length; i += CHUNK_SIZE) {

--- a/src/shared/ui/AttachmentEditorTable.tsx
+++ b/src/shared/ui/AttachmentEditorTable.tsx
@@ -6,7 +6,9 @@ import {
     FileOutlined,
     DeleteOutlined,
     DownloadOutlined,
+    EyeOutlined,
 } from '@ant-design/icons';
+import type { PreviewFile } from '@/shared/types/previewFile';
 
 // Типы лучше хранить в "@/shared/types", но оставляю здесь
 // для цельного примера. Можно вынести при рефакторинге.
@@ -55,6 +57,8 @@ interface Props {
     getLinkLabel?: (file: RemoteFile) => React.ReactNode;
     /** Обработчик клика по ссылке. Если указан, getLink не используется */
     onOpenLink?: (file: RemoteFile) => void;
+    /** Открыть предпросмотр файла */
+    onPreview?: (file: PreviewFile) => void;
     /** Показывать размер файла */
     showSize?: boolean;
     /** Карта изменённых описаний по id */
@@ -85,6 +89,7 @@ export default function AttachmentEditorTable({
   getLink,
   getLinkLabel,
   onOpenLink,
+  onPreview,
   showSize = false,
   changedMap,
   showHeader = false,
@@ -295,11 +300,26 @@ export default function AttachmentEditorTable({
         {
             title: 'Действия',
             dataIndex: 'actions',
-            width: 100,
+            width: 120,
             render: (_: unknown, row) => {
                 const idx = row.isRemote ? null : Number(row.key.split('-')[1]);
                 return (
                     <Space>
+                        <Tooltip title="Просмотреть">
+                            <Button
+                                type="text"
+                                size="small"
+                                icon={<EyeOutlined />}
+                                onClick={async () => {
+                                    if (row.isRemote && row.id && row.path) {
+                                        const url = await signed(row.path, row.name, row.id);
+                                        if (url) onPreview?.({ url, name: row.name, mime: row.mime });
+                                    } else if (idx != null) {
+                                        onPreview?.({ url: objUrls[idx], name: row.name, mime: row.mime });
+                                    }
+                                }}
+                            />
+                        </Tooltip>
                         <Tooltip title="Скачать">
                             {row.isRemote ? (
                                 <Button


### PR DESCRIPTION
## Summary
- update fetch helpers to accept PromiseLike
- make building parameter optional in `useUnitsByProject`
- fix filter option in claim form
- adjust claim attachment upload
- extend letter attachments hook
- tweak defects page options mapping
- support preview in `AttachmentEditorTable`

## Testing
- `npm install`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Property errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_686212d60fbc832eaf081420f55c609b