### PR TITLE
Добавление фильтра по корпусу

### DIFF
--- a/src/shared/types/courtCasesFilters.ts
+++ b/src/shared/types/courtCasesFilters.ts
@@ -1,0 +1,18 @@
+import { Dayjs } from 'dayjs';
+
+/** Набор фильтров для списка судебных дел */
+export interface CourtCasesFiltersValues {
+  ids?: number[];
+  projectId?: number;
+  /** Корпус */
+  building?: string;
+  objectId?: number;
+  number?: string;
+  dateRange?: [Dayjs, Dayjs];
+  status?: number;
+  plaintiff?: string;
+  defendant?: string;
+  fixStartRange?: [Dayjs, Dayjs];
+  lawyerId?: string;
+  hideClosed?: boolean;
+}


### PR DESCRIPTION
## Summary
- расширен интерфейс фильтров судебных дел
- добавлен выбор корпуса при создании дела
- добавлен фильтр по корпусу на странице судебных дел
- обновлена логика фильтрации в списке дел

## Testing
- `npm test`
- `npm run lint` *(ошибка: eslint не запущен из-за отсутствия зависимостей)*

------
https://chatgpt.com/codex/tasks/task_e_68621b51c040832ebcf090a806dafffa