### PR TITLE
Fix column title parsing

### DIFF
--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -477,9 +477,11 @@ export default function DefectsPage() {
   ] as const;
 
   const getTitleText = (t: React.ReactNode): string => {
-    if (typeof t === 'string') return t;
+    if (t == null || typeof t === 'boolean') return '';
+    if (typeof t === 'string' || typeof t === 'number') return String(t);
+    if (Array.isArray(t)) return t.map(getTitleText).join(' ');
     if (React.isValidElement(t)) {
-      return React.Children.toArray(t.props.children).join(' ');
+      return getTitleText(t.props.children);
     }
     return String(t);
   };


### PR DESCRIPTION
## Summary
- handle React node recursively when extracting text

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_6862ce266900832eb0eecdd2b75f70e9