### PR TITLE
Fix columns drawer crash

### DIFF
--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -117,7 +117,14 @@ export default function ClaimsPage() {
     try {
       const saved = localStorage.getItem(LS_COLUMNS_KEY);
       if (saved) {
-        const parsed = JSON.parse(saved) as TableColumnSetting[];
+        let parsed = JSON.parse(saved) as TableColumnSetting[];
+        parsed = parsed.map((c) => {
+          if (typeof c.title !== 'string') {
+            const def = defaults.find((d) => d.key === c.key);
+            return { ...c, title: def?.title ?? '' };
+          }
+          return c;
+        });
         const filtered = parsed.filter((c) => base[c.key]);
         const missing = defaults.filter(
           (d) => !filtered.some((f) => f.key === d.key),

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -453,7 +453,14 @@ export default function CorrespondencePage() {
     try {
       const saved = localStorage.getItem(LS_COLUMNS_KEY);
       if (saved) {
-        const parsed = JSON.parse(saved) as TableColumnSetting[];
+        let parsed = JSON.parse(saved) as TableColumnSetting[];
+        parsed = parsed.map((c) => {
+          if (typeof c.title !== 'string') {
+            const def = defaults.find((d) => d.key === c.key);
+            return { ...c, title: def?.title ?? '' };
+          }
+          return c;
+        });
         return parsed.filter((c) => base[c.key]);
       }
     } catch {}

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -469,7 +469,14 @@ export default function CourtCasesPage() {
     try {
       const saved = localStorage.getItem(LS_COLUMNS_KEY);
       if (saved) {
-        const parsed = JSON.parse(saved) as TableColumnSetting[];
+        let parsed = JSON.parse(saved) as TableColumnSetting[];
+        parsed = parsed.map((c) => {
+          if (typeof c.title !== 'string') {
+            const def = defaults.find((d) => d.key === c.key);
+            return { ...c, title: def?.title ?? '' };
+          }
+          return c;
+        });
         return parsed.filter((c) => baseColumns[c.key]);
       }
     } catch {}

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -496,7 +496,14 @@ export default function DefectsPage() {
     try {
       const saved = localStorage.getItem(LS_COLUMNS_KEY);
       if (saved) {
-        const parsed = JSON.parse(saved) as TableColumnSetting[];
+        let parsed = JSON.parse(saved) as TableColumnSetting[];
+        parsed = parsed.map((c) => {
+          if (typeof c.title !== 'string') {
+            const def = defaults.find((d) => d.key === c.key);
+            return { ...c, title: def?.title ?? '' };
+          }
+          return c;
+        });
         const filtered = parsed.filter((c) => base[c.key]);
         const missing = defaults.filter(
           (d) => !filtered.some((f) => f.key === d.key),


### PR DESCRIPTION
## Summary
- sanitize saved column settings on all pages

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6862cf16ef00832e86c50869104d5534