### PR TITLE
Fix sticky navbar on claims page

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -34,6 +34,13 @@ body {
   background: #f5f5f5;
   white-space: pre-line;
 }
+/* Закрепляем заголовки таблиц Ant Design под навбаром */
+.ant-table-thead > tr > th {
+  position: sticky;
+  top: 64px;         /* высота NavBar */
+  z-index: 2;
+  background: #fff;
+}
 .MuiTableCell-root {
   padding: 12px 16px;
   overflow: hidden;

--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -385,19 +385,21 @@ export default function ClaimsPage() {
               <ClaimsFilters options={options} onChange={setFilters} />
             </Card>
           )}
-          {error ? (
-            <Alert type="error" message={error.message} />
-          ) : (
-            <ClaimsTable
-              claims={claimsWithNames}
-              filters={filters}
-              loading={isLoading}
-              columns={columns}
-              onView={(id) => setViewId(id)}
-              onAddChild={setLinkFor}
-              onUnlink={(id) => unlinkClaim.mutate(id)}
-            />
-          )}
+          <div style={{ maxHeight: 'calc(100vh - 280px)', overflowY: 'auto' }}>
+            {error ? (
+              <Alert type="error" message={error.message} />
+            ) : (
+              <ClaimsTable
+                claims={claimsWithNames}
+                filters={filters}
+                loading={isLoading}
+                columns={columns}
+                onView={(id) => setViewId(id)}
+                onAddChild={setLinkFor}
+                onUnlink={(id) => unlinkClaim.mutate(id)}
+              />
+            )}
+          </div>
         </div>
         <Typography.Text style={{ display: 'block', marginTop: 8 }}>
           Всего претензий: {total}, из них закрытых: {closedCount} и не

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -195,6 +195,8 @@ export default function ClaimsTable({
       components={components}
       dataSource={treeData}
       loading={loading}
+      sticky={{ offsetHeader: 64 }}
+      scroll={{ y: 'calc(100vh - 320px)' }}
       pagination={{
         pageSize,
         showSizeChanger: true,

--- a/src/widgets/NavBar.tsx
+++ b/src/widgets/NavBar.tsx
@@ -35,6 +35,9 @@ const NavBar: React.FC = () => {
   return (
       <Layout.Header
           style={{
+            position: 'sticky',      // закрепляем навбар при прокрутке
+            top: 0,
+            zIndex: 1000,
             display: 'flex',
             alignItems: 'center',
             padding: '0 24px',


### PR DESCRIPTION
## Summary
- keep NavBar visible on scroll
- make Ant Design tables keep their headers visible
- constrain claims table to window height

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_6862dd1d75e4832e98064553315d163f