### PR TITLE
Fix sticky navbar and table headers

### DIFF
--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -607,6 +607,7 @@ export default function CourtCasesPage() {
             rowKey="id"
             columns={resizableColumns}
             components={components}
+            sticky={{ offsetHeader: 64 }}
             dataSource={treeData}
             loading={casesLoading}
             pagination={{

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -193,6 +193,7 @@ export default function ClaimsTable({
       rowKey="id"
       columns={columnsWithResize}
       components={components}
+      sticky={{ offsetHeader: 64 }}
       dataSource={treeData}
       loading={loading}
       pagination={{

--- a/src/widgets/NavBar.tsx
+++ b/src/widgets/NavBar.tsx
@@ -39,6 +39,10 @@ const NavBar: React.FC = () => {
             alignItems: 'center',
             padding: '0 24px',
             gap: 24,                 // аккуратный отступ между элементами
+            position: 'sticky',      // закрепляем навбар при прокрутке
+            top: 0,
+            zIndex: 1000,
+            width: '100%',
           }}
       >
         {/* Логотип */}


### PR DESCRIPTION
## Summary
- keep navbar fixed to top when scrolling
- pin table headers for claims and court cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862dd1d75e4832e98064553315d163f