### PR TITLE
Fix sticky header on defects table

### DIFF
--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -32,6 +32,10 @@ interface Props {
   onView?: (id: number) => void;
 }
 
+/**
+ * Таблица дефектов с возможностью изменения колонок и просмотра карточки.
+ * Заголовок фиксируется при прокрутке, как и на странице претензий.
+ */
 export default function DefectsTable({
   defects,
   filters,
@@ -227,6 +231,7 @@ export default function DefectsTable({
       rowKey="id"
       columns={columnsWithResize}
       components={components}
+      sticky={{ offsetHeader: 64 }}
       dataSource={filtered}
       pagination={{
         pageSize,


### PR DESCRIPTION
## Summary
- keep defects table header visible when scrolling
- document DefectsTable widget

## Testing
- `npm test`
- `npm run lint` *(fails: plugins missing)*

------
https://chatgpt.com/codex/tasks/task_e_6862dfba20d0832ebac3f5e09775bb6a