### PR TITLE
Fix sticky header for correspondence table

### DIFF
--- a/src/widgets/CorrespondenceTable.tsx
+++ b/src/widgets/CorrespondenceTable.tsx
@@ -302,6 +302,7 @@ export default function CorrespondenceTable({
       <Table
           rowKey="id"
           columns={columns}
+          sticky={{ offsetHeader: 64 }}
           dataSource={treeData}
           pagination={{
             pageSize,


### PR DESCRIPTION
## Summary
- keep the correspondence table header visible while scrolling like on other pages

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862e15a4a90832e95ceeab36929895f