### PR TITLE
Fix sticky header on structure page

### DIFF
--- a/src/pages/ProjectStructurePage/ProjectStructurePage.tsx
+++ b/src/pages/ProjectStructurePage/ProjectStructurePage.tsx
@@ -137,6 +137,9 @@ export default function ProjectStructurePage() {
                     mb: 2,
                     mx: "auto",
                     fontFamily: 'Roboto, "Segoe UI", Arial, sans-serif',
+                    position: "sticky",
+                    top: 64,
+                    zIndex: 800,
                 }}
             >
                 <Typography

--- a/src/widgets/UnitsMatrix/UnitsMatrix.tsx
+++ b/src/widgets/UnitsMatrix/UnitsMatrix.tsx
@@ -225,6 +225,8 @@ export default function UnitsMatrix({
           pl: 0,
           mt: 2,
           gap: 1,
+          maxHeight: "calc(100vh - 260px)",
+          overflowY: "auto",
         }}
       >
         {floors.map((floor) => (


### PR DESCRIPTION
## Summary
- keep project structure header sticky when scrolling floors
- limit matrix scroll area

## Testing
- `npm run --silent test`

------
https://chatgpt.com/codex/tasks/task_e_6862e1c4fe84832eac4e04da58f102be