### PR TITLE
Fix sticky project structure matrix

### DIFF
--- a/src/pages/ProjectStructurePage/ProjectStructurePage.tsx
+++ b/src/pages/ProjectStructurePage/ProjectStructurePage.tsx
@@ -137,6 +137,9 @@ export default function ProjectStructurePage() {
                     mb: 2,
                     mx: "auto",
                     fontFamily: 'Roboto, "Segoe UI", Arial, sans-serif',
+                    position: 'sticky',
+                    top: 64,
+                    zIndex: 500,
                 }}
             >
                 <Typography


### PR DESCRIPTION
## Summary
- keep project structure matrix header visible while scrolling

## Testing
- `npm run lint` *(fails: parsing errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862e1c4fe84832eac4e04da58f102be