### PR TITLE
Fix global horizontal scroll

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,19 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap");
 
+html,
+body {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+  box-sizing: border-box;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
 body {
   font-family: "Inter", system-ui, sans-serif;
   background-color: #f5f7ff;


### PR DESCRIPTION
## Summary
- prevent horizontal overflow on all pages by enforcing `box-sizing: border-box` and hiding horizontal scroll

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6862e12404e4832eb74914855e745b68