### PR TITLE
Set default table page size to 100

### DIFF
--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -63,7 +63,7 @@ export default function CourtCasesPage() {
   const [linkFor, setLinkFor] = useState<CourtCase | null>(null);
   const [showAddForm, setShowAddForm] = useState(false);
   /** Размер страницы таблицы дел */
-  const [pageSize, setPageSize] = useState(25);
+  const [pageSize, setPageSize] = useState(100);
   const [showFilters, setShowFilters] = useState(() => {
     try {
       const saved = localStorage.getItem(LS_FILTERS_VISIBLE_KEY);

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -170,7 +170,7 @@ export default function ClaimsTable({
   }, [filtered]);
 
   const [expandedRowKeys, setExpandedRowKeys] = React.useState<React.Key[]>([]);
-  const [pageSize, setPageSize] = React.useState(25);
+  const [pageSize, setPageSize] = React.useState(100);
 
   React.useEffect(() => {
     // По умолчанию все строки свернуты

--- a/src/widgets/CorrespondenceTable.tsx
+++ b/src/widgets/CorrespondenceTable.tsx
@@ -100,7 +100,7 @@ export default function CorrespondenceTable({
   }, [letters, maps]);
 
   const [expandedRowKeys, setExpandedRowKeys] = useState<React.Key[]>([]);
-  const [pageSize, setPageSize] = useState(25);
+  const [pageSize, setPageSize] = useState(100);
 
   useEffect(() => {
     try {

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -211,7 +211,7 @@ export default function DefectsTable({
 
   const { columns: columnsWithResize, components } =
     useResizableColumns(columnsProp ?? defaultColumns);
-  const [pageSize, setPageSize] = React.useState(25);
+  const [pageSize, setPageSize] = React.useState(100);
 
   if (loading) return <Skeleton active paragraph={{ rows: 6 }} />;
 


### PR DESCRIPTION
## Summary
- display 100 rows per page by default on Claims, Defects, Court Cases and Correspondence pages

## Testing
- `npm test`
- `npm run lint` *(fails: many parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862e433a380832e95c69353f9c8a68b