### PR TITLE
Fix logout button clipping

### DIFF
--- a/src/widgets/NavBar.tsx
+++ b/src/widgets/NavBar.tsx
@@ -79,6 +79,7 @@ const NavBar: React.FC = () => {
                   maxWidth: 1000,              // ⬅️ лимит ширины: ничего не «ломает» строку
                   overflow: 'hidden',
                   columnGap: 12,
+                  paddingRight: 24,            // добавили запас справа, чтобы кнопка "Выйти" не обрезалась
                 }}
             >
               <Space direction="vertical" size={0} align="end" style={{ flex: 1, minWidth: 0 }}>


### PR DESCRIPTION
## Summary
- fix logout button clipping by adding right padding in NavBar

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_6862eea7f04c832e95ce55e88452b5ed