### PR TITLE
Fix profile active project persistence

### DIFF
--- a/src/features/user/ActiveProjectSelect.tsx
+++ b/src/features/user/ActiveProjectSelect.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Select, Skeleton } from 'antd';
+import { Select, Skeleton, Button, Space } from 'antd';
 import { useAuthStore } from '@/shared/store/authStore';
 import { useVisibleProjects } from '@/entities/project';
+import { useNotify } from '@/shared/hooks/useNotify';
 
 /**
  * Выпадающий список для выбора активного проекта пользователя.
@@ -10,6 +11,13 @@ export default function ActiveProjectSelect() {
   const projectId = useAuthStore((s) => s.projectId);
   const setProjectId = useAuthStore((s) => s.setProjectId);
   const { data: projects = [], isPending } = useVisibleProjects();
+  const notify = useNotify();
+
+  const [selected, setSelected] = React.useState<number | null>(projectId);
+
+  React.useEffect(() => {
+    setSelected(projectId);
+  }, [projectId]);
 
   const options = React.useMemo(
     () => projects.map((p) => ({ value: p.id, label: p.name })),
@@ -20,14 +28,25 @@ export default function ActiveProjectSelect() {
     return <Skeleton.Button active size="small" style={{ width: 160 }} />;
   }
 
+  const onSave = () => {
+    setProjectId(selected);
+    notify.success('Активный проект сохранён');
+  };
+
   return (
-    <Select
-      size="small"
-      value={projectId ?? undefined}
-      onChange={(val) => setProjectId(val)}
-      options={options}
-      placeholder="Выберите проект"
-      style={{ width: '100%' }}
-    />
+    <Space.Compact block>
+      <Select
+        size="small"
+        value={selected ?? undefined}
+        onChange={(val) => setSelected(val)}
+        options={options}
+        placeholder="Выберите проект"
+      />
+      {selected !== projectId && (
+        <Button size="small" type="primary" onClick={onSave}>
+          Сохранить
+        </Button>
+      )}
+    </Space.Compact>
   );
 }

--- a/src/features/user/ChangePasswordForm.tsx
+++ b/src/features/user/ChangePasswordForm.tsx
@@ -29,10 +29,10 @@ export default function ChangePasswordForm() {
       >
         <Input.Password />
       </Form.Item>
-      <Typography.Paragraph type="secondary">
+      <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
         Просмотр текущего пароля невозможен
       </Typography.Paragraph>
-      <Form.Item>
+      <Form.Item style={{ marginTop: 16, marginBottom: 0 }}>
         <Button type="primary" onClick={onSave} loading={changePass.isPending}>
           Изменить пароль
         </Button>

--- a/src/shared/store/authStore.ts
+++ b/src/shared/store/authStore.ts
@@ -4,6 +4,24 @@
 import { create } from 'zustand';
 import type { User } from '@/shared/types/user';
 
+/**
+ * Ключ localStorage для сохранения выбранного проекта.
+ * Требуется для восстановления выбора после перезагрузки страницы.
+ */
+const LS_PROJECT_ID = 'activeProjectId';
+
+const readSavedProjectId = (): number | null => {
+  if (typeof localStorage === 'undefined') return null;
+  const val = localStorage.getItem(LS_PROJECT_ID);
+  return val ? Number(val) : null;
+};
+
+const saveProjectId = (id: number | null) => {
+  if (typeof localStorage === 'undefined') return;
+  if (id == null) localStorage.removeItem(LS_PROJECT_ID);
+  else localStorage.setItem(LS_PROJECT_ID, String(id));
+};
+
 interface AuthState {
   /** undefined → ещё грузится; null → гость; object → авторизован */
   profile: User | null | undefined;
@@ -21,23 +39,39 @@ interface AuthState {
 
 export const useAuthStore = create<AuthState>((set) => ({
   profile: undefined,
-  projectId: null,
+  projectId: readSavedProjectId(),
   setProfile: (profile) =>
-    set({
-      profile,
-      projectId: profile?.project_ids?.[0] ?? null,
+    set(() => {
+      const saved = readSavedProjectId();
+      const proj =
+        saved && profile?.project_ids?.includes(saved)
+          ? saved
+          : profile?.project_ids?.[0] ?? null;
+      saveProjectId(proj);
+      return { profile, projectId: proj };
     }),
-  clearProfile: () => set({ profile: null, projectId: null }),
-  setProjectId: (project_id) => set({ projectId: project_id ?? null }),
+  clearProfile: () => {
+    saveProjectId(null);
+    set({ profile: null, projectId: null });
+  },
+  setProjectId: (project_id) => {
+    saveProjectId(project_id);
+    set({ projectId: project_id ?? null });
+  },
   setProjectIds: (project_ids) =>
-    set((s) =>
-      s.profile
-        ? {
-            profile: { ...s.profile, project_ids },
-            projectId: s.projectId ?? project_ids[0] ?? null,
-          }
-        : {},
-    ),
+    set((s) => {
+      const saved = readSavedProjectId();
+      const proj =
+        saved && project_ids.includes(saved)
+          ? saved
+          : s.projectId && project_ids.includes(s.projectId)
+            ? s.projectId
+            : project_ids[0] ?? null;
+      saveProjectId(proj);
+      return s.profile
+        ? { profile: { ...s.profile, project_ids }, projectId: proj }
+        : {};
+    }),
 }));
 
 /** Селектор project_id (null, если пользователь гость либо проект не назначен) */


### PR DESCRIPTION
## Summary
- persist active project selection in `authStore`
- allow saving active project with a button
- tweak password form spacing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68635da4cd1c832e8240270ba6c11d5e