### PR TITLE
Fix active project persistence & sync with structure page

### DIFF
--- a/src/features/user/ActiveProjectSelect.tsx
+++ b/src/features/user/ActiveProjectSelect.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Select, Skeleton } from 'antd';
+import { Select, Skeleton, Button, Space } from 'antd';
 import { useAuthStore } from '@/shared/store/authStore';
 import { useVisibleProjects } from '@/entities/project';
 
@@ -9,6 +9,11 @@ import { useVisibleProjects } from '@/entities/project';
 export default function ActiveProjectSelect() {
   const projectId = useAuthStore((s) => s.projectId);
   const setProjectId = useAuthStore((s) => s.setProjectId);
+  const [selected, setSelected] = React.useState<number | null>(projectId);
+
+  React.useEffect(() => {
+    setSelected(projectId);
+  }, [projectId]);
   const { data: projects = [], isPending } = useVisibleProjects();
 
   const options = React.useMemo(
@@ -20,14 +25,29 @@ export default function ActiveProjectSelect() {
     return <Skeleton.Button active size="small" style={{ width: 160 }} />;
   }
 
+  const save = () => setProjectId(selected);
+  const cancel = () => setSelected(projectId);
+
   return (
-    <Select
-      size="small"
-      value={projectId ?? undefined}
-      onChange={(val) => setProjectId(val)}
-      options={options}
-      placeholder="Выберите проект"
-      style={{ width: '100%' }}
-    />
+    <Space direction="vertical" style={{ width: '100%' }}>
+      <Select
+        size="small"
+        value={selected ?? undefined}
+        onChange={(val) => setSelected(val)}
+        options={options}
+        placeholder="Выберите проект"
+        style={{ width: '100%' }}
+      />
+      {selected !== projectId && (
+        <div>
+          <Button type="primary" size="small" onClick={save}>
+            Сохранить
+          </Button>
+          <Button size="small" onClick={cancel} style={{ marginLeft: 8 }}>
+            Отмена
+          </Button>
+        </div>
+      )}
+    </Space>
   );
 }

--- a/src/features/user/ChangePasswordForm.tsx
+++ b/src/features/user/ChangePasswordForm.tsx
@@ -29,7 +29,7 @@ export default function ChangePasswordForm() {
       >
         <Input.Password />
       </Form.Item>
-      <Typography.Paragraph type="secondary">
+      <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
         Просмотр текущего пароля невозможен
       </Typography.Paragraph>
       <Form.Item>

--- a/src/shared/constants/storageKeys.ts
+++ b/src/shared/constants/storageKeys.ts
@@ -1,0 +1,5 @@
+/**
+ * Ключи для работы с localStorage.
+ */
+export const LS_ACTIVE_PROJECT = 'activeProjectId';
+export const LS_STRUCTURE_PAGE_SELECTION = 'structurePageSelection';

--- a/src/shared/hooks/useProjectStructure.ts
+++ b/src/shared/hooks/useProjectStructure.ts
@@ -4,11 +4,12 @@ import type { Project } from '@/shared/types/project';
 import type { ProjectStructureSelection } from '@/shared/types/projectStructure';
 import { useVisibleProjects } from '@/entities/project';
 import { useAuthStore } from '@/shared/store/authStore';
+import { LS_STRUCTURE_PAGE_SELECTION } from '@/shared/constants/storageKeys';
 
 /**
  * Ключ для хранения выбора проекта и корпуса в `localStorage`.
  */
-export const LS_KEY = 'structurePageSelection';
+export const LS_KEY = LS_STRUCTURE_PAGE_SELECTION;
 
 /**
  * Хук для выбора проекта, корпуса и секции.

--- a/src/shared/store/authStore.ts
+++ b/src/shared/store/authStore.ts
@@ -3,6 +3,49 @@
 // -----------------------------------------------------------------------------
 import { create } from 'zustand';
 import type { User } from '@/shared/types/user';
+import {
+  LS_ACTIVE_PROJECT,
+  LS_STRUCTURE_PAGE_SELECTION,
+} from '@/shared/constants/storageKeys';
+
+
+/** Возвращает ID активного проекта из `localStorage`. */
+const loadActiveProject = (): number | null => {
+  try {
+    const v = localStorage.getItem(LS_ACTIVE_PROJECT);
+    return v ? Number(v) : null;
+  } catch {
+    return null;
+  }
+};
+
+/** Сохраняет ID активного проекта в `localStorage`. */
+const saveActiveProject = (id: number | null) => {
+  try {
+    if (id) localStorage.setItem(LS_ACTIVE_PROJECT, String(id));
+    else localStorage.removeItem(LS_ACTIVE_PROJECT);
+  } catch {
+    /* ignore */
+  }
+};
+
+/**
+ * При изменении активного проекта также обновляем состояние
+ * страницы структуры, если оно сохранено в `localStorage`.
+ */
+const syncStructureSelection = (projectId: number | null) => {
+  try {
+    const raw = localStorage.getItem(LS_STRUCTURE_PAGE_SELECTION);
+    if (!raw) return;
+    const data = JSON.parse(raw);
+    localStorage.setItem(
+      LS_STRUCTURE_PAGE_SELECTION,
+      JSON.stringify({ ...data, projectId: projectId ?? '' }),
+    );
+  } catch {
+    /* ignore */
+  }
+};
 
 interface AuthState {
   /** undefined → ещё грузится; null → гость; object → авторизован */
@@ -21,23 +64,40 @@ interface AuthState {
 
 export const useAuthStore = create<AuthState>((set) => ({
   profile: undefined,
-  projectId: null,
+  projectId: loadActiveProject(),
   setProfile: (profile) =>
-    set({
-      profile,
-      projectId: profile?.project_ids?.[0] ?? null,
+    set(() => {
+      const saved = loadActiveProject();
+      const id =
+        saved && profile?.project_ids?.includes(saved)
+          ? saved
+          : profile?.project_ids?.[0] ?? null;
+      saveActiveProject(id);
+      syncStructureSelection(id);
+      return { profile, projectId: id };
     }),
-  clearProfile: () => set({ profile: null, projectId: null }),
-  setProjectId: (project_id) => set({ projectId: project_id ?? null }),
+  clearProfile: () => {
+    saveActiveProject(null);
+    syncStructureSelection(null);
+    set({ profile: null, projectId: null });
+  },
+  setProjectId: (project_id) => {
+    saveActiveProject(project_id ?? null);
+    syncStructureSelection(project_id ?? null);
+    set({ projectId: project_id ?? null });
+  },
   setProjectIds: (project_ids) =>
-    set((s) =>
-      s.profile
-        ? {
-            profile: { ...s.profile, project_ids },
-            projectId: s.projectId ?? project_ids[0] ?? null,
-          }
-        : {},
-    ),
+    set((s) => {
+      const current =
+        s.projectId && project_ids.includes(s.projectId)
+          ? s.projectId
+          : project_ids[0] ?? null;
+      saveActiveProject(current);
+      syncStructureSelection(current);
+      return s.profile
+        ? { profile: { ...s.profile, project_ids }, projectId: current }
+        : {};
+    }),
 }));
 
 /** Селектор project_id (null, если пользователь гость либо проект не назначен) */


### PR DESCRIPTION
## Summary
- centralize localStorage keys
- sync structure page selection when active project changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68635da4cd1c832e8240270ba6c11d5e