### PR TITLE
Add column width editor

### DIFF
--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -136,6 +136,14 @@ export default function ClaimsPage() {
     return defaults;
   });
 
+  const [columnWidths, setColumnWidths] = useState<Record<string, number>>(() => {
+    try {
+      return JSON.parse(localStorage.getItem(LS_COLUMN_WIDTHS_KEY) || '{}');
+    } catch {
+      return {};
+    }
+  });
+
   /**
    * Сброс колонок к начальному состоянию
    */
@@ -149,6 +157,7 @@ export default function ClaimsPage() {
     try {
       localStorage.removeItem(LS_COLUMN_WIDTHS_KEY);
     } catch {}
+    setColumnWidths({});
     setColumnsState(defaults);
   };
 
@@ -157,6 +166,12 @@ export default function ClaimsPage() {
       localStorage.setItem(LS_COLUMNS_KEY, JSON.stringify(columnsState));
     } catch {}
   }, [columnsState]);
+
+  React.useEffect(() => {
+    try {
+      localStorage.setItem(LS_COLUMN_WIDTHS_KEY, JSON.stringify(columnWidths));
+    } catch {}
+  }, [columnWidths]);
 
   const userMap = useMemo(() => {
     const map = {} as Record<string, string>;
@@ -316,7 +331,13 @@ export default function ClaimsPage() {
     } as Record<string, ColumnsType<any>[number]>;
   }
 
-  const baseColumns = useMemo(getBaseColumns, [deleteClaimMutation.isPending]);
+  const baseColumns = useMemo(() => {
+    const cols = getBaseColumns();
+    Object.keys(cols).forEach((key) => {
+      cols[key] = { ...cols[key], width: columnWidths[key] ?? cols[key].width };
+    });
+    return cols;
+  }, [columnWidths, deleteClaimMutation.isPending]);
   const columns: ColumnsType<any> = useMemo(() => columnsState.filter((c) => c.visible).map((c) => baseColumns[c.key]), [columnsState, baseColumns]);
 
   /** Общее количество претензий после учёта прав доступа */
@@ -378,6 +399,10 @@ export default function ClaimsPage() {
           <TableColumnsDrawer
             open={showColumnsDrawer}
             columns={columnsState}
+            widths={Object.fromEntries(
+              Object.keys(baseColumns).map((k) => [k, columnWidths[k] ?? baseColumns[k].width])
+            )}
+            onWidthsChange={setColumnWidths}
             onChange={setColumnsState}
             onClose={() => setShowColumnsDrawer(false)}
             onReset={handleResetColumns}
@@ -397,7 +422,6 @@ export default function ClaimsPage() {
               filters={filters}
               loading={isLoading}
               columns={columns}
-              storageKey={LS_COLUMN_WIDTHS_KEY}
               onView={(id) => setViewId(id)}
               onAddChild={setLinkFor}
               onUnlink={(id) => unlinkClaim.mutate(id)}

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -245,9 +245,9 @@ export default function DefectsPage() {
   const { mutateAsync: removeDefect, isPending: removing } = useDeleteDefect();
   const cancelFix = useCancelDefectFix();
 
-  const LS_FILTERS_VISIBLE_KEY = "defectsFiltersVisible";
-  const LS_COLUMNS_KEY = "defectsColumns";
-  const LS_COLUMN_WIDTHS_KEY = "defectsColumnWidths";
+const LS_FILTERS_VISIBLE_KEY = "defectsFiltersVisible";
+const LS_COLUMNS_KEY = "defectsColumns";
+const LS_COLUMN_WIDTHS_KEY = "defectsColumnWidths";
 
   const [showFilters, setShowFilters] = useState(() => {
     try {
@@ -259,7 +259,7 @@ export default function DefectsPage() {
   });
 
   const baseColumns = useMemo(() => {
-    return {
+    const cols = {
       id: {
         title: "ID дефекта",
         dataIndex: "id",
@@ -457,7 +457,11 @@ export default function DefectsPage() {
         ),
       } as any,
     } as Record<string, ColumnsType<DefectWithInfo>[number]>;
-  }, [removeDefect, removing]);
+    Object.keys(cols).forEach((k) => {
+      cols[k] = { ...cols[k], width: columnWidths[k] ?? cols[k].width };
+    });
+    return cols;
+  }, [removeDefect, removing, columnWidths]);
 
   const columnOrder = [
     "id",
@@ -515,6 +519,14 @@ export default function DefectsPage() {
     return defaults;
   });
 
+  const [columnWidths, setColumnWidths] = useState<Record<string, number>>(() => {
+    try {
+      return JSON.parse(localStorage.getItem(LS_COLUMN_WIDTHS_KEY) || '{}');
+    } catch {
+      return {};
+    }
+  });
+
   const handleResetColumns = () => {
     const base = baseColumns;
     const defaults = columnOrder.map((key) => ({
@@ -525,6 +537,7 @@ export default function DefectsPage() {
     try {
       localStorage.removeItem(LS_COLUMN_WIDTHS_KEY);
     } catch {}
+    setColumnWidths({});
     setColumnsState(defaults);
   };
 
@@ -533,6 +546,12 @@ export default function DefectsPage() {
       localStorage.setItem(LS_COLUMNS_KEY, JSON.stringify(columnsState));
     } catch {}
   }, [columnsState]);
+
+  React.useEffect(() => {
+    try {
+      localStorage.setItem(LS_COLUMN_WIDTHS_KEY, JSON.stringify(columnWidths));
+    } catch {}
+  }, [columnWidths]);
 
   React.useEffect(() => {
     try {
@@ -581,12 +600,15 @@ export default function DefectsPage() {
           loading={isPending}
           onView={setViewId}
           columns={columns}
-          storageKey={LS_COLUMN_WIDTHS_KEY}
         />
         <React.Suspense fallback={null}>
           <TableColumnsDrawer
             open={showColumnsDrawer}
             columns={columnsState}
+            widths={Object.fromEntries(
+              Object.keys(baseColumns).map((k) => [k, columnWidths[k] ?? baseColumns[k].width])
+            )}
+            onWidthsChange={setColumnWidths}
             onChange={setColumnsState}
             onClose={() => setShowColumnsDrawer(false)}
             onReset={handleResetColumns}

--- a/src/shared/types/tableColumnSetting.ts
+++ b/src/shared/types/tableColumnSetting.ts
@@ -5,4 +5,6 @@ export interface TableColumnSetting {
   title: string;
   /** Виден ли столбец */
   visible: boolean;
+  /** Ширина столбца в пикселях */
+  width?: number;
 }

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -14,7 +14,6 @@ import { useDeleteClaim } from '@/entities/claim';
 import type { ClaimFilters } from '@/shared/types/claimFilters';
 import type { ClaimWithNames } from '@/shared/types/claimWithNames';
 import ClaimStatusSelect from '@/features/claim/ClaimStatusSelect';
-import { useResizableColumns } from '@/shared/hooks/useResizableColumns';
 
 const fmt = (d: any) =>
   d && dayjs.isDayjs(d) && d.isValid() ? d.format('DD.MM.YYYY') : '—';
@@ -30,8 +29,6 @@ interface Props {
   onView?: (id: number) => void;
   onAddChild?: (parent: ClaimWithNames) => void;
   onUnlink?: (id: number) => void;
-  /** Ключ localStorage для хранения ширины колонок */
-  storageKey?: string;
 }
 
 export default function ClaimsTable({
@@ -42,7 +39,6 @@ export default function ClaimsTable({
   onView,
   onAddChild,
   onUnlink,
-  storageKey,
 }: Props) {
   const { mutateAsync: remove, isPending } = useDeleteClaim();
   const defaultColumns: ColumnsType<any> = useMemo(
@@ -126,8 +122,7 @@ export default function ClaimsTable({
     [onView, remove, isPending],
   );
 
-  const { columns: columnsWithResize, components } =
-    useResizableColumns(columnsProp ?? defaultColumns, { storageKey });
+  const columnsWithResize = columnsProp ?? defaultColumns;
 
   const filtered = useMemo(() => {
     return claims.filter((c) => {
@@ -195,7 +190,6 @@ export default function ClaimsTable({
     <Table
       rowKey="id"
       columns={columnsWithResize}
-      components={components}
       sticky={{ offsetHeader: 64 }}
       dataSource={treeData}
       loading={loading}

--- a/src/widgets/CorrespondenceTable.tsx
+++ b/src/widgets/CorrespondenceTable.tsx
@@ -6,7 +6,6 @@ import { DeleteOutlined, PlusOutlined, MailOutlined, BranchesOutlined, LinkOutli
 import { CorrespondenceLetter } from '@/shared/types/correspondence';
 import LetterStatusSelect from '@/features/correspondence/LetterStatusSelect';
 import LetterDirectionSelect from '@/features/correspondence/LetterDirectionSelect';
-import { useResizableColumns } from '@/shared/hooks/useResizableColumns';
 
 interface Option { id: number | string; name: string; }
 
@@ -23,8 +22,6 @@ interface CorrespondenceTableProps {
   projects: Option[];
   units: Option[];
   statuses: Option[];
-  /** Ключ localStorage для хранения ширины колонок */
-  storageKey?: string;
 }
 
 /** Ключ в localStorage для хранения раскрывшихся строк */
@@ -43,7 +40,6 @@ export default function CorrespondenceTable({
                                               projects,
                                               units,
                                               statuses,
-                                              storageKey,
                                             }: CorrespondenceTableProps) {
   const maps = useMemo(() => {
     const m = {
@@ -295,8 +291,7 @@ export default function CorrespondenceTable({
   ],
     [onAddChild, onUnlink, onDelete, onView],
   );
-  const { columns: resizableColumns, components } =
-    useResizableColumns(columnsProp ?? defaultColumns, { storageKey });
+  const resizableColumns = columnsProp ?? defaultColumns;
 
   const rowClassName = (record: any) => {
     if (!record.parent_id) return 'main-letter-row';
@@ -307,7 +302,6 @@ export default function CorrespondenceTable({
       <Table
           rowKey="id"
           columns={resizableColumns}
-          components={components}
           sticky={{ offsetHeader: 64 }}
           dataSource={treeData}
           pagination={{

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -16,7 +16,6 @@ import DefectStatusSelect from "@/features/defect/DefectStatusSelect";
 import type { DefectWithInfo } from "@/shared/types/defect";
 import type { DefectFilters } from "@/shared/types/defectFilters";
 import { filterDefects } from "@/shared/utils/defectFilter";
-import { useResizableColumns } from "@/shared/hooks/useResizableColumns";
 import { naturalCompareArrays } from "@/shared/utils/naturalSort";
 
 const fmt = (v: string | null) => (v ? dayjs(v).format("DD.MM.YYYY") : "—");
@@ -30,8 +29,6 @@ interface Props {
   /** Колонки таблицы. Если не переданы, используется набор по умолчанию */
   columns?: ColumnsType<DefectWithInfo>;
   onView?: (id: number) => void;
-  /** Ключ localStorage для хранения ширины колонок */
-  storageKey?: string;
 }
 
 /**
@@ -44,7 +41,6 @@ export default function DefectsTable({
   loading,
   columns: columnsProp,
   onView,
-  storageKey,
 }: Props) {
   const { mutateAsync: remove, isPending } = useDeleteDefect();
   const filtered = useMemo(
@@ -212,8 +208,7 @@ export default function DefectsTable({
     },
   ];
 
-  const { columns: columnsWithResize, components } =
-    useResizableColumns(columnsProp ?? defaultColumns, { storageKey });
+  const columnsWithResize = columnsProp ?? defaultColumns;
   const [pageSize, setPageSize] = React.useState(100);
 
   if (loading) return <Skeleton active paragraph={{ rows: 6 }} />;
@@ -233,7 +228,6 @@ export default function DefectsTable({
     <Table
       rowKey="id"
       columns={columnsWithResize}
-      components={components}
       sticky={{ offsetHeader: 64 }}
       dataSource={filtered}
       pagination={{

--- a/src/widgets/TableColumnsDrawer.tsx
+++ b/src/widgets/TableColumnsDrawer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Drawer, Switch, Button } from 'antd';
+import { Drawer, Switch, Button, InputNumber } from 'antd';
 import { UpOutlined, DownOutlined } from '@ant-design/icons';
 import type { TableColumnSetting } from '@/shared/types/tableColumnSetting';
 
@@ -8,6 +8,9 @@ interface Props {
   columns: TableColumnSetting[];
   onChange: (cols: TableColumnSetting[]) => void;
   onClose: () => void;
+  /** Текущие ширины столбцов */
+  widths: Record<string, number | undefined>;
+  onWidthsChange: (w: Record<string, number | undefined>) => void;
   /** Сбросить состояние столбцов к изначальному */
   onReset?: () => void;
 }
@@ -15,7 +18,7 @@ interface Props {
 /**
  * Боковая панель настройки столбцов таблицы.
  */
-export default function TableColumnsDrawer({ open, columns, onChange, onClose, onReset }: Props) {
+export default function TableColumnsDrawer({ open, columns, onChange, onClose, widths, onWidthsChange, onReset }: Props) {
   const move = (from: number, to: number) => {
     if (to < 0 || to >= columns.length) return;
     const updated = [...columns];
@@ -36,6 +39,14 @@ export default function TableColumnsDrawer({ open, columns, onChange, onClose, o
         <div key={c.key} style={{ display: 'flex', alignItems: 'center', marginBottom: 8 }}>
           <Switch checked={c.visible} onChange={(v) => toggle(idx, v)} size="small" />
           <span style={{ marginLeft: 8, flexGrow: 1 }}>{c.title || '(без названия)'}</span>
+          <InputNumber
+            style={{ width: 80, marginRight: 8 }}
+            min={40}
+            value={widths[c.key]}
+            onChange={(v) =>
+              onWidthsChange({ ...widths, [c.key]: typeof v === 'number' ? v : widths[c.key] })
+            }
+          />
           <Button
             size="small"
             type="text"


### PR DESCRIPTION
## Summary
- enable column width editing from the settings drawer
- persist column width settings per page
- remove manual table column resizing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686362ef46ac832e8b16aa41c7f2efa9