### PR TITLE
Fix column width types and units query

### DIFF
--- a/src/entities/unit.ts
+++ b/src/entities/unit.ts
@@ -92,17 +92,17 @@ export const useUnitsByProject = (
     });
 
 
-export const useUnitsByIds = (ids) =>
-    useQuery({
+export const useUnitsByIds = (ids: number[]) =>
+    useQuery<import('@/shared/types/unit').Unit[], Error>({
         queryKey: ['units-by-ids', ids?.join(',')],
         enabled : Array.isArray(ids) && ids.length > 0,
         queryFn : async () => {
             const { data, error } = await supabase
                 .from('units')
-                .select('id, name, building, floor')
+                .select('id, name, building, floor, project_id')
                 .in('id', ids);
             if (error) throw error;
-            return data ?? [];
+            return (data ?? []) as import('@/shared/types/unit').Unit[];
         },
         staleTime: 5 * 60_000,
     });

--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -399,9 +399,11 @@ export default function ClaimsPage() {
           <TableColumnsDrawer
             open={showColumnsDrawer}
             columns={columnsState}
-            widths={Object.fromEntries(
-              Object.keys(baseColumns).map((k) => [k, columnWidths[k] ?? baseColumns[k].width])
-            )}
+            widths={
+              Object.fromEntries(
+                Object.keys(baseColumns).map((k) => [k, columnWidths[k] ?? baseColumns[k].width])
+              ) as Record<string, number>
+            }
             onWidthsChange={setColumnWidths}
             onChange={setColumnsState}
             onClose={() => setShowColumnsDrawer(false)}

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -634,9 +634,11 @@ export default function CorrespondencePage() {
           <TableColumnsDrawer
             open={showColumnsDrawer}
             columns={columnsState}
-            widths={Object.fromEntries(
-              Object.keys(baseColumns).map((k) => [k, columnWidths[k] ?? baseColumns[k].width])
-            )}
+            widths={
+              Object.fromEntries(
+                Object.keys(baseColumns).map((k) => [k, columnWidths[k] ?? baseColumns[k].width])
+              ) as Record<string, number>
+            }
             onWidthsChange={setColumnWidths}
             onChange={setColumnsState}
             onClose={() => setShowColumnsDrawer(false)}

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -583,9 +583,11 @@ export default function CourtCasesPage() {
           <TableColumnsDrawer
             open={showColumnsDrawer}
             columns={columnsState}
-            widths={Object.fromEntries(
-              Object.keys(baseColumns).map((k) => [k, columnWidths[k] ?? baseColumns[k].width])
-            )}
+            widths={
+              Object.fromEntries(
+                Object.keys(baseColumns).map((k) => [k, columnWidths[k] ?? baseColumns[k].width])
+              ) as Record<string, number>
+            }
             onWidthsChange={setColumnWidths}
             onChange={setColumnsState}
             onClose={() => setShowColumnsDrawer(false)}

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -608,9 +608,11 @@ const LS_COLUMN_WIDTHS_KEY = "defectsColumnWidths";
           <TableColumnsDrawer
             open={showColumnsDrawer}
             columns={columnsState}
-            widths={Object.fromEntries(
-              Object.keys(baseColumns).map((k) => [k, columnWidths[k] ?? baseColumns[k].width])
-            )}
+            widths={
+              Object.fromEntries(
+                Object.keys(baseColumns).map((k) => [k, columnWidths[k] ?? baseColumns[k].width])
+              ) as Record<string, number>
+            }
             onWidthsChange={setColumnWidths}
             onChange={setColumnsState}
             onClose={() => setShowColumnsDrawer(false)}

--- a/src/shared/hooks/useResizableColumns.tsx
+++ b/src/shared/hooks/useResizableColumns.tsx
@@ -37,7 +37,8 @@ export function useResizableColumns<T>(
       if (saved) {
         const map = JSON.parse(saved) as Record<string, number>;
         return cols.map((c) => {
-          const key = String(c.key ?? c.dataIndex);
+          const key =
+            'dataIndex' in c ? String(c.key ?? c.dataIndex) : String(c.key);
           const width = map[key];
           return width ? { ...c, width } : c;
         });
@@ -66,7 +67,8 @@ export function useResizableColumns<T>(
     try {
       const map: Record<string, number> = {};
       cols.forEach((c) => {
-        const key = String(c.key ?? c.dataIndex);
+        const key =
+          'dataIndex' in c ? String(c.key ?? c.dataIndex) : String(c.key);
         if (c.width) map[key] = c.width as number;
       });
       localStorage.setItem(storageKey, JSON.stringify(map));


### PR DESCRIPTION
## Summary
- adjust useResizableColumns to handle ColumnGroupType properly
- cast column width props when using TableColumnsDrawer
- extend unit query to include `project_id`

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm test`
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_686369c55e38832e800fd3e60684e061