### PR TITLE
Add inline username edit in admin

### DIFF
--- a/src/features/user/UserNameEdit.tsx
+++ b/src/features/user/UserNameEdit.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { Input, Skeleton } from "antd";
+import { useUpdateUserName } from "@/entities/user";
+import type { User } from "@/shared/types/user";
+
+interface UserNameEditProps {
+  user: User;
+  /** Показывать скелетон вместо контента */
+  loading?: boolean;
+}
+
+/**
+ * Инлайн-редактор имени пользователя.
+ * При клике на текущее значение отображает поле ввода.
+ */
+export default function UserNameEdit({
+  user,
+  loading = false,
+}: UserNameEditProps) {
+  const updateName = useUpdateUserName();
+  const [editing, setEditing] = React.useState(false);
+  const [value, setValue] = React.useState<string | null>(user.name);
+
+  React.useEffect(() => {
+    setValue(user.name);
+  }, [user.name]);
+
+  const save = () => {
+    updateName.mutate(
+      { id: user.id, name: value },
+      { onSettled: () => setEditing(false) },
+    );
+  };
+
+  if (loading) {
+    return <Skeleton.Input active size="small" style={{ width: 120 }} />;
+  }
+
+  if (!editing) {
+    return (
+      <div onClick={() => setEditing(true)} style={{ cursor: "pointer" }}>
+        {user.name ?? "—"}
+      </div>
+    );
+  }
+
+  return (
+    <Input
+      size="small"
+      autoFocus
+      value={value ?? ""}
+      onChange={(e) => setValue(e.target.value)}
+      onPressEnter={save}
+      onBlur={save}
+      disabled={updateName.isPending}
+    />
+  );
+}

--- a/src/widgets/UsersTable.tsx
+++ b/src/widgets/UsersTable.tsx
@@ -9,6 +9,7 @@ import AdminDataGrid from "@/shared/ui/AdminDataGrid";
 import { useNotify } from "@/shared/hooks/useNotify";
 import RoleSelect from "@/features/user/RoleSelect";
 import UserProjectsSelect from "@/features/user/UserProjectsSelect";
+import UserNameEdit from "@/features/user/UserNameEdit";
 
 // Интерфейс для пропсов с пагинацией
 interface UsersTableProps {
@@ -29,7 +30,12 @@ export default function UsersTable({
   // Таблица
   const columns = [
     { field: "id", headerName: "ID", width: 70 },
-    { field: "name", headerName: "Имя пользователя", flex: 1 },
+    {
+      field: "name",
+      headerName: "Имя пользователя",
+      flex: 1,
+      renderCell: ({ row }) => <UserNameEdit user={row} loading={uLoad} />,
+    },
     { field: "email", headerName: "E-mail", flex: 1 },
     {
       field: "role",
@@ -40,8 +46,8 @@ export default function UsersTable({
       ),
     },
     {
-      field: 'project_ids',
-      headerName: 'Проекты',
+      field: "project_ids",
+      headerName: "Проекты",
       flex: 1,
       renderCell: ({ row }) => (
         <UserProjectsSelect user={row} projects={projects} loading={pLoad} />


### PR DESCRIPTION
## Summary
- add `UserNameEdit` inline editor
- support username editing inside `UsersTable`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68640e1c9134832ea6afb8babe4e0047