### PR TITLE
Add user stats block to dashboard

### DIFF
--- a/src/pages/DashboardPage/DashboardPage.tsx
+++ b/src/pages/DashboardPage/DashboardPage.tsx
@@ -5,6 +5,7 @@ import { useVisibleProjects } from '@/entities/project';
 import { useAuthStore } from '@/shared/store/authStore';
 import ProjectsMultiSelect from '@/features/project/ProjectsMultiSelect';
 import ProjectStatsCard from '@/widgets/ProjectStatsCard';
+import UserStatsBlock from '@/widgets/UserStatsBlock';
 
 /** Главная страница с инфографикой. */
 export default function DashboardPage() {
@@ -35,6 +36,8 @@ export default function DashboardPage() {
       {selected.map((id) => (
         <ProjectStatsCard key={id} projectId={id} />
       ))}
+
+      <UserStatsBlock />
     </Space>
   );
 }

--- a/src/shared/hooks/useUserStats.ts
+++ b/src/shared/hooks/useUserStats.ts
@@ -1,0 +1,113 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { supabase } from '@/shared/api/supabaseClient';
+import { fetchPaged } from '@/shared/api/fetchAll';
+import { useClaimStatuses } from '@/entities/claimStatus';
+import { useDefectStatuses } from '@/entities/defectStatus';
+import type { UserStats, StatusCount } from '@/shared/types/userStats';
+
+/**
+ * Загружает статистику активности пользователя за выбранный период.
+ * Подписывается на изменения в таблицах claims и defects.
+ *
+ * @param userId идентификатор пользователя
+ * @param period массив из двух ISO-дат [from, to]
+ */
+export function useUserStats(
+  userId?: string | null,
+  period?: [string, string] | null,
+) {
+  const { data: claimStatuses = [] } = useClaimStatuses();
+  const { data: defectStatuses = [] } = useDefectStatuses();
+  const qc = useQueryClient();
+
+  const from = period?.[0] ?? null;
+  const to = period?.[1] ?? null;
+
+  const query = useQuery<UserStats>({
+    queryKey: ['user-stats', userId, from, to],
+    enabled: !!userId && !!from && !!to,
+    queryFn: async () => {
+      const [claimRows, defectRows] = await Promise.all([
+        fetchPaged<any>((f, t) =>
+          supabase
+            .from('claims')
+            .select('id, claim_status_id, created_at')
+            .eq('created_by', userId as string)
+            .gte('created_at', from as string)
+            .lte('created_at', to as string)
+            .order('id')
+            .range(f, t),
+        ),
+        fetchPaged<any>((f, t) =>
+          supabase
+            .from('defects')
+            .select('id, status_id, created_at')
+            .eq('created_by', userId as string)
+            .gte('created_at', from as string)
+            .lte('created_at', to as string)
+            .order('id')
+            .range(f, t),
+        ),
+      ]);
+
+      const claimMap: Record<string, number> = {};
+      claimRows.forEach((r: any) => {
+        const id = r.claim_status_id ?? 'null';
+        claimMap[id] = (claimMap[id] || 0) + 1;
+      });
+      const defectMap: Record<string, number> = {};
+      defectRows.forEach((r: any) => {
+        const id = r.status_id ?? 'null';
+        defectMap[id] = (defectMap[id] || 0) + 1;
+      });
+
+      const claimStatusCounts: StatusCount[] = Object.entries(claimMap).map(
+        ([id, count]) => ({
+          statusId: id === 'null' ? null : Number(id),
+          statusName:
+            id === 'null'
+              ? null
+              : claimStatuses.find((s) => s.id === Number(id))?.name ?? null,
+          count,
+        }),
+      );
+
+      const defectStatusCounts: StatusCount[] = Object.entries(defectMap).map(
+        ([id, count]) => ({
+          statusId: id === 'null' ? null : Number(id),
+          statusName:
+            id === 'null'
+              ? null
+              : defectStatuses.find((s) => s.id === Number(id))?.name ?? null,
+          count,
+        }),
+      );
+
+      return {
+        claimCount: claimRows.length,
+        defectCount: defectRows.length,
+        claimStatusCounts,
+        defectStatusCounts,
+      } as UserStats;
+    },
+    staleTime: 60_000,
+  });
+
+  useEffect(() => {
+    if (!userId) return;
+    const filter = `created_by=eq.${userId}`;
+    const key = ['user-stats', userId, from, to];
+    const invalidate = () => qc.invalidateQueries({ queryKey: key });
+    const channel = supabase
+      .channel(`user-stats-${userId}`)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'claims', filter }, invalidate)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'defects', filter }, invalidate);
+    channel.subscribe();
+    return () => {
+      channel.unsubscribe();
+    };
+  }, [userId, from, to, qc]);
+
+  return query;
+}

--- a/src/shared/types/userStats.ts
+++ b/src/shared/types/userStats.ts
@@ -1,0 +1,12 @@
+export interface StatusCount {
+  statusId: number | null;
+  statusName: string | null;
+  count: number;
+}
+
+export interface UserStats {
+  claimCount: number;
+  defectCount: number;
+  claimStatusCounts: StatusCount[];
+  defectStatusCounts: StatusCount[];
+}

--- a/src/widgets/UserStatsBlock.tsx
+++ b/src/widgets/UserStatsBlock.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import { ConfigProvider, Card, Select, DatePicker, Space, Skeleton, Statistic } from 'antd';
+import ruRU from 'antd/locale/ru_RU';
+import { useUsers } from '@/entities/user';
+import { useUserStats } from '@/shared/hooks/useUserStats';
+import { Dayjs } from 'dayjs';
+
+const { RangePicker } = DatePicker;
+
+/**
+ * Блок статистики по выбранному пользователю и периоду.
+ */
+dayjs.locale('ru');
+
+export default function UserStatsBlock() {
+  const { data: users = [], isPending } = useUsers();
+  const [userId, setUserId] = React.useState<string | null>(null);
+  const [range, setRange] = React.useState<[Dayjs, Dayjs] | null>(null);
+
+  const period = React.useMemo(() => {
+    if (!range) return null;
+    return [
+      range[0].startOf('day').toISOString(),
+      range[1].endOf('day').toISOString(),
+    ] as [string, string];
+  }, [range]);
+
+  const { data, isPending: loadingStats } = useUserStats(userId, period);
+
+  const userOptions = users.map((u) => ({
+    value: u.id,
+    label: u.name ?? u.email,
+  }));
+
+  return (
+    <ConfigProvider locale={ruRU}>
+      <Card title="Статистика пользователя" style={{ maxWidth: 360, margin: '0 auto', width: '100%' }}>
+        <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+          <Select
+            showSearch
+            allowClear
+            placeholder="Выберите пользователя"
+            options={userOptions}
+            value={userId ?? undefined}
+            onChange={(val) => setUserId(val)}
+            loading={isPending}
+            style={{ width: '100%' }}
+          />
+          <RangePicker
+            style={{ width: '100%' }}
+            value={range ?? undefined}
+            onChange={(v) => setRange(v as [Dayjs, Dayjs] | null)}
+            format="DD.MM.YYYY"
+          />
+          {loadingStats && userId && period ? (
+            <Skeleton active paragraph={{ rows: 2 }} />
+          ) : null}
+          {data && !loadingStats ? (
+            <Space direction="vertical" style={{ width: '100%' }} size="small">
+              <Statistic title="Создано замечаний" value={data.claimCount} />
+              {data.claimStatusCounts.map((s) => (
+                <div
+                  key={`c-${s.statusId}`}
+                  style={{ display: 'flex', justifyContent: 'space-between' }}
+                >
+                  <span>{s.statusName ?? 'Без статуса'}</span>
+                  <span>{s.count}</span>
+                </div>
+              ))}
+              <Statistic title="Создано дефектов" value={data.defectCount} style={{ marginTop: 8 }} />
+              {data.defectStatusCounts.map((s) => (
+                <div
+                  key={`d-${s.statusId}`}
+                  style={{ display: 'flex', justifyContent: 'space-between' }}
+                >
+                  <span>{s.statusName ?? 'Без статуса'}</span>
+                  <span>{s.count}</span>
+                </div>
+              ))}
+            </Space>
+          ) : null}
+        </Space>
+      </Card>
+    </ConfigProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- create `useUserStats` hook to collect counts of defects and claims
- define related `UserStats` types
- add `UserStatsBlock` widget with user and date selection
- show new block on dashboard page
- make user stats card compact and set locale to Russian

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6864b55a4f38832e918292d33822f0a4