### PR TITLE
Fix left alignment of user statistics

### DIFF
--- a/src/widgets/UserStatsBlock.tsx
+++ b/src/widgets/UserStatsBlock.tsx
@@ -35,7 +35,7 @@ export default function UserStatsBlock() {
 
   return (
     <ConfigProvider locale={ruRU}>
-      <Card title="Статистика пользователя" style={{ maxWidth: 360, margin: '0 auto', width: '100%' }}>
+      <Card title="Статистика пользователя" style={{ maxWidth: 360, margin: 0, width: '100%' }}>
         <Space direction="vertical" size="middle" style={{ width: '100%' }}>
           <Select
             showSearch


### PR DESCRIPTION
## Summary
- align the user statistics block to the left on the dashboard

## Testing
- `npm test`
- `npm run lint` *(fails: parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_6864ba7bf5dc832eb271479211263ac7