### PR TITLE
Enable building change in claim view

### DIFF
--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -27,6 +27,8 @@ import { updateAttachmentDescription } from '@/entities/attachment';
 import { supabase } from '@/shared/api/supabaseClient';
 import { useVisibleProjects } from '@/entities/project';
 import { useUnitsByProject, useUnitsByIds } from '@/entities/unit';
+import useProjectBuildings from '@/shared/hooks/useProjectBuildings';
+import { useDebounce } from '@/shared/hooks/useDebounce';
 import { useUsers } from '@/entities/user';
 import { useClaimStatuses } from '@/entities/claimStatus';
 
@@ -62,6 +64,7 @@ export interface ClaimFormAntdEditProps {
 export interface ClaimFormAntdEditValues {
   project_id: number | null;
   unit_ids: number[];
+  building: string | null;
   claim_status_id: number | null;
   claim_no: string;
   claimed_on: Dayjs | null;
@@ -100,7 +103,13 @@ const ClaimFormAntdEdit = React.forwardRef<
   const globalProjectId = useProjectId();
   const projectIdWatch = Form.useWatch('project_id', form);
   const projectId = projectIdWatch != null ? Number(projectIdWatch) : globalProjectId;
-  const { data: units = [] } = useUnitsByProject(projectId);
+  const buildingWatch = Form.useWatch('building', form) ?? null;
+  const buildingDebounced = useDebounce(buildingWatch);
+  const { buildings = [] } = useProjectBuildings(projectId);
+  const { data: units = [] } = useUnitsByProject(
+    projectId,
+    buildingDebounced ?? undefined,
+  );
   const { data: users = [] } = useUsers();
   const { data: statuses = [] } = useClaimStatuses();
   const { data: caseUids = [] } = useCaseUids();
@@ -115,13 +124,6 @@ const ClaimFormAntdEdit = React.forwardRef<
   const unitIdsWatch = Form.useWatch('unit_ids', form) ?? [];
   const { data: selectedUnits = [] } = useUnitsByIds(
     Array.isArray(unitIdsWatch) ? unitIdsWatch : [],
-  );
-  const buildingsText = React.useMemo(
-    () =>
-      Array.from(
-        new Set(selectedUnits.map((u) => u.building).filter(Boolean)),
-      ).join(', '),
-    [selectedUnits],
   );
 
   useImperativeHandle(ref, () => ({
@@ -151,6 +153,27 @@ const ClaimFormAntdEdit = React.forwardRef<
       description: claim.description ?? '',
     });
   }, [claim, form]);
+
+  const prevProjectIdRef = React.useRef<number | null>(null);
+
+  useEffect(() => {
+    const prev = prevProjectIdRef.current;
+    if (prev != null && projectId != null && prev !== projectId) {
+      form.setFieldsValue({ unit_ids: [], building: undefined });
+    }
+    prevProjectIdRef.current = projectId ?? null;
+  }, [projectId, form]);
+
+  useEffect(() => {
+    if (!form.getFieldValue('building') && selectedUnits.length) {
+      const uniq = Array.from(
+        new Set(selectedUnits.map((u) => u.building).filter(Boolean)),
+      );
+      if (uniq.length === 1) {
+        form.setFieldValue('building', uniq[0]);
+      }
+    }
+  }, [selectedUnits, form]);
 
   const onFinish = async (values: ClaimFormAntdEditValues) => {
     if (!claim) return;
@@ -272,8 +295,12 @@ const ClaimFormAntdEdit = React.forwardRef<
           </Form.Item>
         </Col>
         <Col span={8}>
-          <Form.Item label="Корпус">
-            <Input value={buildingsText} disabled />
+          <Form.Item name="building" label="Корпус">
+            <Select
+              allowClear
+              options={buildings.map((b) => ({ value: b, label: b }))}
+              disabled={!projectId}
+            />
           </Form.Item>
         </Col>
         <Col span={8}>
@@ -406,6 +433,7 @@ const ClaimFormAntdEdit = React.forwardRef<
     </Form>
     </>
   );
+
 });
 
 export default ClaimFormAntdEdit;


### PR DESCRIPTION
## Summary
- allow selecting building when editing a claim
- filter objects by building in edit form
- keep building select in sync with existing unit selection

## Testing
- `npm run lint` *(fails: eslint config missing)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6864b65cc100832eb78bdcea799ec6c3