### PR TITLE
Enable building select in claim view

### DIFF
--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -33,6 +33,7 @@ import { useClaimStatuses } from '@/entities/claimStatus';
 import { useCaseUids } from '@/entities/caseUid';
 import { useNotify } from '@/shared/hooks/useNotify';
 import { useProjectId } from '@/shared/hooks/useProjectId';
+import { useDebounce } from '@/shared/hooks/useDebounce';
 import { useAuthStore } from '@/shared/store/authStore';
 import { useRolePermission } from '@/entities/rolePermission';
 import type { RoleName } from '@/shared/types/rolePermission';
@@ -43,6 +44,7 @@ import FileDropZone from '@/shared/ui/FileDropZone';
 import { useClaimAttachments } from './model/useClaimAttachments';
 import type { RemoteClaimFile } from '@/shared/types/claimFile';
 import type { ClaimFormAntdEditRef } from '@/shared/types/claimFormAntdEditRef';
+import useProjectBuildings from '@/shared/hooks/useProjectBuildings';
 
 
 export interface ClaimFormAntdEditProps {
@@ -62,6 +64,8 @@ export interface ClaimFormAntdEditProps {
 export interface ClaimFormAntdEditValues {
   project_id: number | null;
   unit_ids: number[];
+  /** Корпус */
+  building: string | null;
   claim_status_id: number | null;
   claim_no: string;
   claimed_on: Dayjs | null;
@@ -100,7 +104,13 @@ const ClaimFormAntdEdit = React.forwardRef<
   const globalProjectId = useProjectId();
   const projectIdWatch = Form.useWatch('project_id', form);
   const projectId = projectIdWatch != null ? Number(projectIdWatch) : globalProjectId;
-  const { data: units = [] } = useUnitsByProject(projectId);
+  const { data: buildings = [] } = useProjectBuildings(projectId);
+  const buildingWatch = Form.useWatch('building', form) ?? null;
+  const buildingDebounced = useDebounce(buildingWatch);
+  const { data: units = [] } = useUnitsByProject(
+    projectId,
+    buildingDebounced ?? undefined,
+  );
   const { data: users = [] } = useUsers();
   const { data: statuses = [] } = useClaimStatuses();
   const { data: caseUids = [] } = useCaseUids();
@@ -116,13 +126,6 @@ const ClaimFormAntdEdit = React.forwardRef<
   const { data: selectedUnits = [] } = useUnitsByIds(
     Array.isArray(unitIdsWatch) ? unitIdsWatch : [],
   );
-  const buildingsText = React.useMemo(
-    () =>
-      Array.from(
-        new Set(selectedUnits.map((u) => u.building).filter(Boolean)),
-      ).join(', '),
-    [selectedUnits],
-  );
 
   useImperativeHandle(ref, () => ({
     submit: () => form.submit(),
@@ -133,6 +136,8 @@ const ClaimFormAntdEdit = React.forwardRef<
     changedFields[name as string]
       ? { background: '#fffbe6', padding: 4, borderRadius: 2 }
       : {};
+
+  const prevProjectIdRef = React.useRef<number | null>(null);
 
   useEffect(() => {
     if (!claim) return;
@@ -149,8 +154,29 @@ const ClaimFormAntdEdit = React.forwardRef<
       case_uid_id: claim.case_uid_id ?? null,
       pre_trial_claim: claim.pre_trial_claim ?? false,
       description: claim.description ?? '',
+      building: null,
     });
   }, [claim, form]);
+
+  useEffect(() => {
+    if (!form.getFieldValue('building') && selectedUnits.length) {
+      const uniq = Array.from(
+        new Set(selectedUnits.map((u) => u.building).filter(Boolean)),
+      );
+      if (uniq.length === 1) {
+        form.setFieldValue('building', uniq[0]);
+      }
+    }
+  }, [selectedUnits, form]);
+
+  // Сброс выбранных объектов при изменении проекта
+  useEffect(() => {
+    const prev = prevProjectIdRef.current;
+    if (prev != null && projectId != null && prev !== projectId) {
+      form.setFieldsValue({ unit_ids: [], building: undefined });
+    }
+    prevProjectIdRef.current = projectId ?? null;
+  }, [projectId, form]);
 
   const onFinish = async (values: ClaimFormAntdEditValues) => {
     if (!claim) return;
@@ -272,8 +298,12 @@ const ClaimFormAntdEdit = React.forwardRef<
           </Form.Item>
         </Col>
         <Col span={8}>
-          <Form.Item label="Корпус">
-            <Input value={buildingsText} disabled />
+          <Form.Item name="building" label="Корпус">
+            <Select
+              allowClear
+              options={buildings.map((b) => ({ value: b, label: b }))}
+              disabled={!projectId}
+            />
           </Form.Item>
         </Col>
         <Col span={8}>


### PR DESCRIPTION
## Summary
- allow editing building when viewing claims
- retain building and object values when opening a claim

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_686578b76de4832e9e375f15951ca04a