### PR TITLE
Fix column width alignment

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -143,3 +143,16 @@ body {
   cursor: col-resize;
   z-index: 1;
 }
+
+/* Настройка столбцов таблицы */
+.columns-drawer-row {
+  display: grid;
+  grid-template-columns: auto 1fr 80px auto auto;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.columns-drawer-input {
+  width: 80px;
+}

--- a/src/widgets/TableColumnsDrawer.tsx
+++ b/src/widgets/TableColumnsDrawer.tsx
@@ -36,11 +36,11 @@ export default function TableColumnsDrawer({ open, columns, onChange, onClose, w
   return (
     <Drawer title="Настройка столбцов" placement="right" onClose={onClose} open={open}>
       {columns.map((c, idx) => (
-        <div key={c.key} style={{ display: 'flex', alignItems: 'center', marginBottom: 8 }}>
+        <div key={c.key} className="columns-drawer-row">
           <Switch checked={c.visible} onChange={(v) => toggle(idx, v)} size="small" />
-          <span style={{ marginLeft: 8, flexGrow: 1 }}>{c.title || '(без названия)'}</span>
+          <span>{c.title || '(без названия)'}</span>
           <InputNumber
-            style={{ width: 80, marginRight: 8 }}
+            className="columns-drawer-input"
             min={40}
             value={widths[c.key]}
             onChange={(v) =>


### PR DESCRIPTION
## Summary
- use grid layout in TableColumnsDrawer rows so width fields align vertically
- add styles for new drawer layout

## Testing
- `npm run lint` *(fails: parsing errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68658fc18054832e8dca277a9e171f52