### PR TITLE
Fix column widths in correspondence settings

### DIFF
--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -351,6 +351,7 @@ export default function CorrespondencePage() {
       sender: {
         title: 'Отправитель',
         dataIndex: 'sender',
+        width: 160,
         sorter: (a: any, b: any) => (a.sender || '').localeCompare(b.sender || ''),
         render: (val: string, record: any) => (
           <span style={record.parent_id ? { color: '#888' } : {}}>{val}</span>
@@ -359,6 +360,7 @@ export default function CorrespondencePage() {
       receiver: {
         title: 'Получатель',
         dataIndex: 'receiver',
+        width: 160,
         sorter: (a: any, b: any) => (a.receiver || '').localeCompare(b.receiver || ''),
         render: (val: string, record: any) => (
           <span style={record.parent_id ? { color: '#888' } : {}}>{val}</span>
@@ -376,21 +378,25 @@ export default function CorrespondencePage() {
       projectName: {
         title: 'Проект',
         dataIndex: 'projectName',
+        width: 180,
         sorter: (a: any, b: any) => (a.projectName || '').localeCompare(b.projectName || ''),
       },
       unitNames: {
         title: 'Объекты',
         dataIndex: 'unitNames',
+        width: 200,
         sorter: (a: any, b: any) => (a.unitNames || '').localeCompare(b.unitNames || ''),
       },
       letterTypeName: {
         title: 'Категория',
         dataIndex: 'letterTypeName',
+        width: 160,
         sorter: (a: any, b: any) => (a.letterTypeName || '').localeCompare(b.letterTypeName || ''),
       },
       statusName: {
         title: 'Статус',
         dataIndex: 'statusName',
+        width: 160,
         sorter: (a: any, b: any) => (a.statusName || '').localeCompare(b.statusName || ''),
         render: (_: any, row: any) => (
           <LetterStatusSelect letterId={row.id} statusId={row.status_id} statusName={row.statusName} />
@@ -399,6 +405,7 @@ export default function CorrespondencePage() {
       responsibleName: {
         title: 'Ответственный',
         dataIndex: 'responsibleName',
+        width: 160,
         sorter: (a: any, b: any) => (a.responsibleName || '').localeCompare(b.responsibleName || ''),
         render: (name: string) => name || '—',
       },

--- a/src/widgets/CorrespondenceTable.tsx
+++ b/src/widgets/CorrespondenceTable.tsx
@@ -176,6 +176,7 @@ export default function CorrespondenceTable({
     {
       title: 'Отправитель',
       dataIndex: 'sender',
+      width: 160,
       sorter: (a, b) => (a.sender || '').localeCompare(b.sender || ''),
       render: (val: string, record: any) => (
         <span style={record.parent_id ? { color: '#888' } : {}}>{val}</span>
@@ -184,6 +185,7 @@ export default function CorrespondenceTable({
     {
       title: 'Получатель',
       dataIndex: 'receiver',
+      width: 160,
       sorter: (a, b) => (a.receiver || '').localeCompare(b.receiver || ''),
       render: (val: string, record: any) => (
         <span style={record.parent_id ? { color: '#888' } : {}}>{val}</span>
@@ -200,22 +202,26 @@ export default function CorrespondenceTable({
     {
       title: 'Проект',
       dataIndex: 'projectName',
+      width: 180,
       sorter: (a, b) => (a.projectName || '').localeCompare(b.projectName || ''),
     },
     {
       title: 'Объекты',
       dataIndex: 'unitNames',
+      width: 200,
       sorter: (a, b) => (a.unitNames || '').localeCompare(b.unitNames || ''),
     },
     {
       title: 'Категория',
       dataIndex: 'letterTypeName',
+      width: 160,
       sorter: (a, b) =>
           (a.letterTypeName || '').localeCompare(b.letterTypeName || ''),
     },
     {
       title: 'Статус',
       dataIndex: 'statusName',
+      width: 160,
       sorter: (a, b) => (a.statusName || '').localeCompare(b.statusName || ''),
       render: (_: any, row: any) => (
         <LetterStatusSelect
@@ -228,6 +234,7 @@ export default function CorrespondenceTable({
     {
       title: 'Ответственный',
       dataIndex: 'responsibleName',
+      width: 160,
       sorter: (a, b) =>
           (a.responsibleName || '').localeCompare(b.responsibleName || ''),
       render: (name: string) => name || '—',


### PR DESCRIPTION
## Summary
- add default widths for correspondence columns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865925e931c832eb58304ec1f77d50c