### PR TITLE
Fix party selection updates

### DIFF
--- a/src/features/contractor/ContractorModalId.tsx
+++ b/src/features/contractor/ContractorModalId.tsx
@@ -11,7 +11,11 @@ import { useNotify } from '@/shared/hooks/useNotify';
 export interface ContractorModalIdProps {
   open: boolean;
   onClose: () => void;
-  onSelect: (id: number) => void;
+  /**
+   * Возвращает id созданной/обновлённой записи или `null`,
+   * если контрагент был удалён.
+   */
+  onSelect: (id: number | null) => void;
   initialData?: any | null;
 }
 
@@ -56,7 +60,7 @@ export default function ContractorModalId({
     try {
       await remove.mutateAsync(initialData.id);
       notify.success('Контрагент удалён');
-      onSelect(initialData.id);
+      onSelect(null);
       onClose();
     } catch (e: any) {
       notify.error(e.message);

--- a/src/features/courtCase/AddCourtCaseFormAntd.tsx
+++ b/src/features/courtCase/AddCourtCaseFormAntd.tsx
@@ -207,14 +207,15 @@ export default function AddCourtCaseFormAntd({
     role: 'plaintiff' | 'defendant',
   ) =>
     (tagProps: any) => {
-      const { label, value, closable, onClose } = tagProps;
+      const { value, closable, onClose } = tagProps;
+      const person = personsList.find((p) => p.id === Number(value));
       return (
         <Tag
           closable={closable}
           onClose={onClose}
           style={{ display: 'flex', alignItems: 'center' }}
         >
-          <span>{label}</span>
+          <span>{person?.full_name || value}</span>
           <EditOutlined
             style={{ marginLeft: 4 }}
             onClick={(e) => {
@@ -252,14 +253,15 @@ export default function AddCourtCaseFormAntd({
     role: 'plaintiff' | 'defendant',
   ) =>
     (tagProps: any) => {
-      const { label, value, closable, onClose } = tagProps;
+      const { value, closable, onClose } = tagProps;
+      const contractor = contractors.find((c) => c.id === Number(value));
       return (
         <Tag
           closable={closable}
           onClose={onClose}
           style={{ display: 'flex', alignItems: 'center' }}
         >
-          <span>{label}</span>
+          <span>{contractor?.name || value}</span>
           <EditOutlined
             style={{ marginLeft: 4 }}
             onClick={(e) => {
@@ -435,6 +437,8 @@ export default function AddCourtCaseFormAntd({
               <Space.Compact style={{ width: '100%' }}>
                 <Select
                   mode="multiple"
+                  showSearch
+                  optionFilterProp="label"
                   tagRender={personTagRender('plaintiff_person_ids', 'plaintiff')}
                   loading={personsLoading}
                   options={projectPersons.map((p) => ({ value: p.id, label: p.full_name }))}
@@ -448,6 +452,8 @@ export default function AddCourtCaseFormAntd({
               <Space.Compact style={{ width: '100%' }}>
                 <Select
                   mode="multiple"
+                  showSearch
+                  optionFilterProp="label"
                   tagRender={contractorTagRender('plaintiff_contractor_ids', 'plaintiff')}
                   loading={contractorsLoading}
                   options={contractors.map((c) => ({ value: c.id, label: c.name }))}
@@ -462,6 +468,8 @@ export default function AddCourtCaseFormAntd({
               <Space.Compact style={{ width: '100%' }}>
                 <Select
                   mode="multiple"
+                  showSearch
+                  optionFilterProp="label"
                   tagRender={personTagRender('defendant_person_ids', 'defendant')}
                   loading={personsLoading}
                   options={projectPersons.map((p) => ({ value: p.id, label: p.full_name }))}
@@ -474,6 +482,8 @@ export default function AddCourtCaseFormAntd({
               <Space.Compact style={{ width: '100%' }}>
                 <Select
                   mode="multiple"
+                  showSearch
+                  optionFilterProp="label"
                   tagRender={contractorTagRender('defendant_contractor_ids', 'defendant')}
                   loading={contractorsLoading}
                   options={contractors.map((c) => ({ value: c.id, label: c.name }))}
@@ -576,9 +586,17 @@ export default function AddCourtCaseFormAntd({
           setPartyRole(null);
         }}
         onSelect={(id) => {
-          const field = partyRole === 'defendant' ? 'defendant_person_ids' : 'plaintiff_person_ids';
-          const current = form.getFieldValue(field) || [];
-          form.setFieldValue(field, Array.from(new Set([...current, id])));
+          const field =
+            partyRole === 'defendant' ? 'defendant_person_ids' : 'plaintiff_person_ids';
+          const current: number[] = form.getFieldValue(field) || [];
+          if (id == null) {
+            form.setFieldValue(
+              field,
+              current.filter((v) => v !== personModal?.id),
+            );
+          } else {
+            form.setFieldValue(field, Array.from(new Set([...current, id])));
+          }
           setPartyRole(null);
         }}
         unitId={Form.useWatch('unit_ids', form)?.[0] ?? null}
@@ -591,9 +609,19 @@ export default function AddCourtCaseFormAntd({
           setPartyRole(null);
         }}
         onSelect={(id) => {
-          const field = partyRole === 'plaintiff' ? 'plaintiff_contractor_ids' : 'defendant_contractor_ids';
-          const current = form.getFieldValue(field) || [];
-          form.setFieldValue(field, Array.from(new Set([...current, id])));
+          const field =
+            partyRole === 'plaintiff'
+              ? 'plaintiff_contractor_ids'
+              : 'defendant_contractor_ids';
+          const current: number[] = form.getFieldValue(field) || [];
+          if (id == null) {
+            form.setFieldValue(
+              field,
+              current.filter((v) => v !== contractorModal?.id),
+            );
+          } else {
+            form.setFieldValue(field, Array.from(new Set([...current, id])));
+          }
           setPartyRole(null);
         }}
         initialData={contractorModal}

--- a/src/features/courtCase/CourtCaseFormAntdEdit.tsx
+++ b/src/features/courtCase/CourtCaseFormAntdEdit.tsx
@@ -504,7 +504,11 @@ export default function CourtCaseFormAntdEdit({
       onSelect={(id) => {
         if (!partyRole) return;
         const field = partyRole === 'plaintiff' ? 'plaintiff_id' : 'defendant_id';
-        form.setFieldValue(field, id);
+        if (id == null) {
+          form.setFieldValue(field, null);
+        } else {
+          form.setFieldValue(field, id);
+        }
         setPartyRole(null);
       }}
       unitId={Form.useWatch('unit_ids', form)?.[0] ?? null}
@@ -519,7 +523,11 @@ export default function CourtCaseFormAntdEdit({
       onSelect={(id) => {
         if (!partyRole) return;
         const field = partyRole === 'plaintiff' ? 'plaintiff_id' : 'defendant_id';
-        form.setFieldValue(field, id);
+        if (id == null) {
+          form.setFieldValue(field, null);
+        } else {
+          form.setFieldValue(field, id);
+        }
         setPartyRole(null);
       }}
       initialData={contractorModal}

--- a/src/features/person/PersonModalId.tsx
+++ b/src/features/person/PersonModalId.tsx
@@ -13,7 +13,11 @@ export interface PersonModalIdProps {
   open: boolean;
   onClose: () => void;
   unitId?: number | null;
-  onSelect: (id: number) => void;
+  /**
+   * Возвращает идентификатор созданной/обновлённой записи или `null`,
+   * если запись была удалена.
+   */
+  onSelect: (id: number | null) => void;
   initialData?: any | null;
 }
 
@@ -63,7 +67,7 @@ export default function PersonModalId({
       await remove.mutateAsync(initialData.id);
       notify.success('Физлицо удалено');
       qc.invalidateQueries({ queryKey: ['projectPersons'] });
-      onSelect(initialData.id);
+      onSelect(null);
       onClose();
     } catch (e: any) {
       notify.error(e.message);


### PR DESCRIPTION
## Summary
- update `PersonModalId` and `ContractorModalId` to return `null` on delete
- refresh tags by using latest names in `AddCourtCaseFormAntd`
- handle deletion in modal callbacks
- enable searching of parties

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686744e4dcf4832ea698187f9eaa0442