### PR TITLE
Fix parties creation and new party modals

### DIFF
--- a/src/entities/courtCase/index.ts
+++ b/src/entities/courtCase/index.ts
@@ -118,7 +118,10 @@ export function useAddCourtCase() {
           court_case_id: caseId,
           unit_id: uid,
         }));
-        await supabase.from(CASE_UNITS_TABLE).insert(rows);
+        const { error: unitsErr } = await supabase
+          .from(CASE_UNITS_TABLE)
+          .insert(rows);
+        if (unitsErr) throw unitsErr;
       }
 
       if (attachment_ids.length) {
@@ -126,7 +129,10 @@ export function useAddCourtCase() {
           court_case_id: caseId,
           attachment_id: aid,
         }));
-        await supabase.from(CASE_ATTACH_TABLE).insert(rows);
+        const { error: attErr } = await supabase
+          .from(CASE_ATTACH_TABLE)
+          .insert(rows);
+        if (attErr) throw attErr;
       }
 
       const partyRows: any[] = [];
@@ -167,7 +173,10 @@ export function useAddCourtCase() {
         }),
       );
       if (partyRows.length) {
-        await supabase.from(CASE_PARTIES_TABLE).insert(partyRows);
+        const { error: partiesErr } = await supabase
+          .from(CASE_PARTIES_TABLE)
+          .insert(partyRows);
+        if (partiesErr) throw partiesErr;
       }
 
       return { ...inserted, unit_ids, attachment_ids, parties: partyRows } as CourtCase;
@@ -204,7 +213,10 @@ export function useUpdateCourtCase() {
         await supabase.from(CASE_UNITS_TABLE).delete().eq('court_case_id', id);
         if (unit_ids.length) {
           const rows = unit_ids.map((uid) => ({ court_case_id: id, unit_id: uid }));
-          await supabase.from(CASE_UNITS_TABLE).insert(rows);
+          const { error: unitsErr } = await supabase
+            .from(CASE_UNITS_TABLE)
+            .insert(rows);
+          if (unitsErr) throw unitsErr;
         }
       }
 
@@ -215,7 +227,10 @@ export function useUpdateCourtCase() {
             court_case_id: id,
             attachment_id: aid,
           }));
-          await supabase.from(CASE_ATTACH_TABLE).insert(rows);
+          const { error: attErr } = await supabase
+            .from(CASE_ATTACH_TABLE)
+            .insert(rows);
+          if (attErr) throw attErr;
         }
       }
 
@@ -229,7 +244,10 @@ export function useUpdateCourtCase() {
             contractor_id: p.contractor_id ?? null,
             project_id: p.project_id,
           }));
-          await supabase.from(CASE_PARTIES_TABLE).insert(rows);
+          const { error: partiesErr } = await supabase
+            .from(CASE_PARTIES_TABLE)
+            .insert(rows);
+          if (partiesErr) throw partiesErr;
         }
       }
 

--- a/src/features/courtCase/AddCourtCaseFormAntd.tsx
+++ b/src/features/courtCase/AddCourtCaseFormAntd.tsx
@@ -445,7 +445,13 @@ export default function AddCourtCaseFormAntd({
                   disabled={!projectId}
                   style={{ width: '100%' }}
                 />
-                <Button icon={<PlusOutlined />} onClick={() => { setPartyRole('plaintiff'); setPersonModal(null); }} />
+                <Button
+                  icon={<PlusOutlined />}
+                  onClick={() => {
+                    setPartyRole('plaintiff');
+                    setPersonModal({});
+                  }}
+                />
               </Space.Compact>
             </Form.Item>
             <Form.Item name="plaintiff_contractor_ids" label="Истцы (контрагенты)">
@@ -459,7 +465,13 @@ export default function AddCourtCaseFormAntd({
                   options={contractors.map((c) => ({ value: c.id, label: c.name }))}
                   style={{ width: '100%' }}
                 />
-                <Button icon={<PlusOutlined />} onClick={() => { setPartyRole('plaintiff'); setContractorModal(null); }} />
+                <Button
+                  icon={<PlusOutlined />}
+                  onClick={() => {
+                    setPartyRole('plaintiff');
+                    setContractorModal({});
+                  }}
+                />
               </Space.Compact>
             </Form.Item>
           </Col>
@@ -475,7 +487,13 @@ export default function AddCourtCaseFormAntd({
                   options={projectPersons.map((p) => ({ value: p.id, label: p.full_name }))}
                   style={{ width: '100%' }}
                 />
-                <Button icon={<PlusOutlined />} onClick={() => { setPartyRole('defendant'); setPersonModal(null); }} />
+                <Button
+                  icon={<PlusOutlined />}
+                  onClick={() => {
+                    setPartyRole('defendant');
+                    setPersonModal({});
+                  }}
+                />
               </Space.Compact>
             </Form.Item>
             <Form.Item name="defendant_contractor_ids" label="Ответчики (контрагенты)">
@@ -489,7 +507,13 @@ export default function AddCourtCaseFormAntd({
                   options={contractors.map((c) => ({ value: c.id, label: c.name }))}
                   style={{ width: '100%' }}
                 />
-                <Button icon={<PlusOutlined />} onClick={() => { setPartyRole('defendant'); setContractorModal(null); }} />
+                <Button
+                  icon={<PlusOutlined />}
+                  onClick={() => {
+                    setPartyRole('defendant');
+                    setContractorModal({});
+                  }}
+                />
               </Space.Compact>
             </Form.Item>
           </Col>


### PR DESCRIPTION
## Summary
- ensure Supabase insert errors are handled when creating or updating court cases
- fix buttons for adding new plaintiffs and defendants so modals open correctly

## Testing
- `npm test --silent`
- `npm run lint --silent` *(fails: @eslint/eslintrc not found)*

------
https://chatgpt.com/codex/tasks/task_e_686747fea47c832e9c1be43d66977643