### PR TITLE
Fix parties insertion for new court cases

### DIFF
--- a/src/entities/courtCase/index.ts
+++ b/src/entities/courtCase/index.ts
@@ -96,14 +96,19 @@ export function useAddCourtCase() {
         defendant_contractor_ids = [],
         ...rest
       } = payload as unknown as {
-        unit_ids?: number[];
-        attachment_ids?: number[];
-        plaintiff_person_ids?: number[];
-        plaintiff_contractor_ids?: number[];
-        defendant_person_ids?: number[];
-        defendant_contractor_ids?: number[];
+        unit_ids?: number[] | string[];
+        attachment_ids?: number[] | string[];
+        plaintiff_person_ids?: number[] | string[];
+        plaintiff_contractor_ids?: number[] | string[];
+        defendant_person_ids?: number[] | string[];
+        defendant_contractor_ids?: number[] | string[];
         [k: string]: any;
       };
+
+      const personPlIds = (plaintiff_person_ids as (number | string)[]).map(Number);
+      const contrPlIds = (plaintiff_contractor_ids as (number | string)[]).map(Number);
+      const personDefIds = (defendant_person_ids as (number | string)[]).map(Number);
+      const contrDefIds = (defendant_contractor_ids as (number | string)[]).map(Number);
 
       const { data: inserted, error } = await supabase
         .from(CASES_TABLE)
@@ -136,7 +141,7 @@ export function useAddCourtCase() {
       }
 
       const partyRows: any[] = [];
-      (plaintiff_person_ids as number[]).forEach((pid) =>
+      personPlIds.forEach((pid) =>
         partyRows.push({
           case_id: caseId,
           role: 'plaintiff',
@@ -145,7 +150,7 @@ export function useAddCourtCase() {
           project_id: rest.project_id,
         }),
       );
-      (plaintiff_contractor_ids as number[]).forEach((cid) =>
+      contrPlIds.forEach((cid) =>
         partyRows.push({
           case_id: caseId,
           role: 'plaintiff',
@@ -154,7 +159,7 @@ export function useAddCourtCase() {
           project_id: rest.project_id,
         }),
       );
-      (defendant_person_ids as number[]).forEach((pid) =>
+      personDefIds.forEach((pid) =>
         partyRows.push({
           case_id: caseId,
           role: 'defendant',
@@ -163,7 +168,7 @@ export function useAddCourtCase() {
           project_id: rest.project_id,
         }),
       );
-      (defendant_contractor_ids as number[]).forEach((cid) =>
+      contrDefIds.forEach((cid) =>
         partyRows.push({
           case_id: caseId,
           role: 'defendant',

--- a/src/features/courtCase/AddCourtCaseFormAntd.tsx
+++ b/src/features/courtCase/AddCourtCaseFormAntd.tsx
@@ -294,44 +294,87 @@ export default function AddCourtCaseFormAntd({
   const handleAddCase = async (values: any) => {
     try {
       const uidId = await getOrCreateCaseUid(values.case_uid);
-      const newCase = await addCaseMutation.mutateAsync({
-        project_id: values.project_id,
-        unit_ids: values.unit_ids || [],
-        number: values.number,
-        date: values.date.format('YYYY-MM-DD'),
-        case_uid_id: uidId,
-        plaintiff_person_ids: values.plaintiff_person_ids || [],
-        plaintiff_contractor_ids: values.plaintiff_contractor_ids || [],
-        defendant_person_ids: values.defendant_person_ids || [],
-        defendant_contractor_ids: values.defendant_contractor_ids || [],
-        responsible_lawyer_id: values.responsible_lawyer_id,
-        status: values.status,
-        fix_start_date: values.fix_start_date
-          ? (values.fix_start_date as Dayjs).format('YYYY-MM-DD')
-          : null,
-        fix_end_date: values.fix_end_date
-          ? (values.fix_end_date as Dayjs).format('YYYY-MM-DD')
-          : null,
-        description: values.description || '',
-        created_by: profileId,
-      } as any);
+    const newCase = await addCaseMutation.mutateAsync({
+      project_id: values.project_id,
+      unit_ids: values.unit_ids || [],
+      number: values.number,
+      date: values.date.format('YYYY-MM-DD'),
+      case_uid_id: uidId,
+      plaintiff_person_ids: (values.plaintiff_person_ids || []).map(Number),
+      plaintiff_contractor_ids: (values.plaintiff_contractor_ids || []).map(Number),
+      defendant_person_ids: (values.defendant_person_ids || []).map(Number),
+      defendant_contractor_ids: (values.defendant_contractor_ids || []).map(Number),
+      responsible_lawyer_id: values.responsible_lawyer_id,
+      status: values.status,
+      fix_start_date: values.fix_start_date
+        ? (values.fix_start_date as Dayjs).format('YYYY-MM-DD')
+        : null,
+      fix_end_date: values.fix_end_date
+        ? (values.fix_end_date as Dayjs).format('YYYY-MM-DD')
+        : null,
+      description: values.description || '',
+      created_by: profileId,
+    } as any);
 
-      let newAtts: { id: number }[] = [];
-      if (caseFiles.length) {
-        newAtts = await addCaseAttachments(
-          caseFiles.map((f) => ({
-            file: f.file,
-            type_id: f.type_id,
-            description: f.description,
-          })),
-          newCase.id,
-        );
-        await updateCaseMutation.mutateAsync({
-          id: newCase.id,
-          updates: { attachment_ids: newAtts.map((a) => a.id) },
-        });
-        qc.invalidateQueries({ queryKey: ['court_cases'] });
-      }
+    let newAtts: { id: number }[] = [];
+    if (caseFiles.length) {
+      newAtts = await addCaseAttachments(
+        caseFiles.map((f) => ({
+          file: f.file,
+          type_id: f.type_id,
+          description: f.description,
+        })),
+        newCase.id,
+      );
+      await updateCaseMutation.mutateAsync({
+        id: newCase.id,
+        updates: { attachment_ids: newAtts.map((a) => a.id) },
+      });
+      qc.invalidateQueries({ queryKey: ['court_cases'] });
+    }
+
+    const parties: any[] = [];
+    (values.plaintiff_person_ids || []).forEach((pid: number) =>
+      parties.push({
+        role: 'plaintiff',
+        person_id: pid,
+        contractor_id: null,
+        project_id: values.project_id,
+      }),
+    );
+    (values.plaintiff_contractor_ids || []).forEach((cid: number) =>
+      parties.push({
+        role: 'plaintiff',
+        contractor_id: cid,
+        person_id: null,
+        project_id: values.project_id,
+      }),
+    );
+    (values.defendant_person_ids || []).forEach((pid: number) =>
+      parties.push({
+        role: 'defendant',
+        person_id: pid,
+        contractor_id: null,
+        project_id: values.project_id,
+      }),
+    );
+    (values.defendant_contractor_ids || []).forEach((cid: number) =>
+      parties.push({
+        role: 'defendant',
+        contractor_id: cid,
+        person_id: null,
+        project_id: values.project_id,
+      }),
+    );
+    if (parties.length) {
+      await updateCaseMutation.mutateAsync({
+        id: newCase.id,
+        updates: {
+          parties,
+        },
+      });
+      qc.invalidateQueries({ queryKey: ['court_cases'] });
+    }
 
       const claims: any[] = (values.claims || []).filter((c: any) =>
         ['claimed_amount', 'confirmed_amount', 'paid_amount', 'agreed_amount'].some((k) => c[k] != null && c[k] !== '')


### PR DESCRIPTION
## Summary
- ensure party arrays are numeric for insertions
- update case creation logic to save parties after uploading attachments

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68674e6ee74c832eaa8ac094fcc2c549