### PR TITLE
Fix parties insertion for new court cases

### DIFF
--- a/src/entities/courtCase/index.ts
+++ b/src/entities/courtCase/index.ts
@@ -96,14 +96,19 @@ export function useAddCourtCase() {
         defendant_contractor_ids = [],
         ...rest
       } = payload as unknown as {
-        unit_ids?: number[];
-        attachment_ids?: number[];
-        plaintiff_person_ids?: number[];
-        plaintiff_contractor_ids?: number[];
-        defendant_person_ids?: number[];
-        defendant_contractor_ids?: number[];
+        unit_ids?: number[] | string[];
+        attachment_ids?: number[] | string[];
+        plaintiff_person_ids?: number[] | string[];
+        plaintiff_contractor_ids?: number[] | string[];
+        defendant_person_ids?: number[] | string[];
+        defendant_contractor_ids?: number[] | string[];
         [k: string]: any;
       };
+
+      const personPlIds = (plaintiff_person_ids as (number | string)[]).map(Number);
+      const contrPlIds = (plaintiff_contractor_ids as (number | string)[]).map(Number);
+      const personDefIds = (defendant_person_ids as (number | string)[]).map(Number);
+      const contrDefIds = (defendant_contractor_ids as (number | string)[]).map(Number);
 
       const { data: inserted, error } = await supabase
         .from(CASES_TABLE)
@@ -136,7 +141,7 @@ export function useAddCourtCase() {
       }
 
       const partyRows: any[] = [];
-      (plaintiff_person_ids as number[]).forEach((pid) =>
+      personPlIds.forEach((pid) =>
         partyRows.push({
           case_id: caseId,
           role: 'plaintiff',
@@ -145,7 +150,7 @@ export function useAddCourtCase() {
           project_id: rest.project_id,
         }),
       );
-      (plaintiff_contractor_ids as number[]).forEach((cid) =>
+      contrPlIds.forEach((cid) =>
         partyRows.push({
           case_id: caseId,
           role: 'plaintiff',
@@ -154,7 +159,7 @@ export function useAddCourtCase() {
           project_id: rest.project_id,
         }),
       );
-      (defendant_person_ids as number[]).forEach((pid) =>
+      personDefIds.forEach((pid) =>
         partyRows.push({
           case_id: caseId,
           role: 'defendant',
@@ -163,7 +168,7 @@ export function useAddCourtCase() {
           project_id: rest.project_id,
         }),
       );
-      (defendant_contractor_ids as number[]).forEach((cid) =>
+      contrDefIds.forEach((cid) =>
         partyRows.push({
           case_id: caseId,
           role: 'defendant',


### PR DESCRIPTION
## Summary
- ensure party arrays are numeric for insertions
- update case creation logic to save parties inside add-case mutation

## Testing
- `npm run lint` *(fails: parsing errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68674e6ee74c832eaa8ac094fcc2c549