### PR TITLE
Fix party editor actions and show person info

### DIFF
--- a/src/entities/courtCaseParty.ts
+++ b/src/entities/courtCaseParty.ts
@@ -59,7 +59,12 @@ export function useAddCaseParties() {
     },
     onSuccess: (rows) => {
       if (rows.length) {
-        qc.invalidateQueries({ queryKey: [TABLE, rows[0].case_id] });
+        const caseId = rows[0].case_id;
+        qc.setQueryData<(CourtCaseParty & { persons?: { full_name: string } | null; contractors?: { name: string } | null; })[]>(
+          [TABLE, caseId],
+          (curr = []) => [...curr, ...rows],
+        );
+        qc.invalidateQueries({ queryKey: [TABLE, caseId] });
       }
     },
   });

--- a/src/widgets/CasePartiesEditorTable.tsx
+++ b/src/widgets/CasePartiesEditorTable.tsx
@@ -1,5 +1,14 @@
 import React, { useState } from 'react';
-import { Table, Button, Select, Popconfirm, Tooltip, Skeleton, Modal } from 'antd';
+import {
+  Table,
+  Button,
+  Select,
+  Popconfirm,
+  Tooltip,
+  Skeleton,
+  Modal,
+  Typography,
+} from 'antd';
 import { PlusOutlined, DeleteOutlined, EditOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import {
@@ -155,7 +164,14 @@ export default function CasePartiesEditorTable({ caseId, projectId }: Props) {
 
 interface ModalProps {
   open: boolean;
-  persons: { id: number; full_name: string }[];
+  persons: {
+    id: number;
+    full_name: string;
+    passport_series?: string | null;
+    passport_number?: string | null;
+    phone?: string | null;
+    email?: string | null;
+  }[];
   contractors: { id: number; name: string }[];
   initial?: { role: CasePartyRole; type: 'person' | 'contractor'; entityId: number };
   onClose: () => void;
@@ -179,6 +195,21 @@ function CasePartyModal({ open, persons, contractors, initial, onClose, onSubmit
     type === 'person'
       ? persons.map((p) => ({ value: p.id, label: p.full_name }))
       : contractors.map((c) => ({ value: c.id, label: c.name }));
+
+  const selectedPerson =
+    type === 'person' ? persons.find((p) => p.id === entityId) : null;
+
+  const info = selectedPerson
+    ? [
+        selectedPerson.passport_series && selectedPerson.passport_number
+          ? `паспорт: ${selectedPerson.passport_series} ${selectedPerson.passport_number}`
+          : null,
+        selectedPerson.phone ? `тел: ${selectedPerson.phone}` : null,
+        selectedPerson.email ? `email: ${selectedPerson.email}` : null,
+      ]
+        .filter(Boolean)
+        .join(', ')
+    : '';
 
   const handleOk = () => {
     if (entityId != null) {
@@ -219,6 +250,9 @@ function CasePartyModal({ open, persons, contractors, initial, onClose, onSubmit
               .includes(input.toLowerCase())
           }
         />
+        {type === 'person' && info && (
+          <Typography.Text type="secondary">{info}</Typography.Text>
+        )}
       </div>
     </Modal>
   );

--- a/src/widgets/CourtCasePartiesTable.tsx
+++ b/src/widgets/CourtCasePartiesTable.tsx
@@ -8,6 +8,7 @@ import {
   Skeleton,
   Space,
   Popconfirm,
+  Typography,
 } from "antd";
 import { PlusOutlined, DeleteOutlined, EditOutlined } from "@ant-design/icons";
 import type { ColumnsType } from "antd/es/table";
@@ -124,13 +125,30 @@ export default function CourtCasePartiesTable({ fields, add, remove }: Props) {
               type === "contractor"
                 ? contractors.map((c) => ({ value: c.id, label: c.name }))
                 : persons.map((p) => ({ value: p.id, label: p.full_name }));
+
+            const selectedPerson =
+              type === "person" ? persons.find((p) => p.id === entityId) : null;
+
+            const info = selectedPerson
+              ? [
+                  selectedPerson.passport_series && selectedPerson.passport_number
+                    ? `паспорт: ${selectedPerson.passport_series} ${selectedPerson.passport_number}`
+                    : null,
+                  selectedPerson.phone ? `тел: ${selectedPerson.phone}` : null,
+                  selectedPerson.email ? `email: ${selectedPerson.email}` : null,
+                ]
+                  .filter(Boolean)
+                  .join(', ')
+              : '';
+
             return (
-              <Space.Compact style={{ width: "100%" }}>
-                <Form.Item
-                  name={[field.name, "entityId"]}
-                  rules={[{ required: true }]}
-                  noStyle
-                >
+              <div style={{ display: "flex", flexDirection: "column", width: "100%" }}>
+                <Space.Compact style={{ width: "100%" }}>
+                  <Form.Item
+                    name={[field.name, "entityId"]}
+                    rules={[{ required: true }]}
+                    noStyle
+                  >
                   <Select
                     allowClear
                     showSearch
@@ -189,7 +207,13 @@ export default function CourtCasePartiesTable({ fields, add, remove }: Props) {
                     disabled={!entityId}
                   />
                 </Popconfirm>
-              </Space.Compact>
+                </Space.Compact>
+                {type === "person" && info && (
+                  <Typography.Text type="secondary" style={{ marginTop: 4 }}>
+                    {info}
+                  </Typography.Text>
+                )}
+              </div>
             );
           }}
         </Form.Item>


### PR DESCRIPTION
## Summary
- fix useAddCaseParties to update React-Query cache instantly
- show passport and contacts when selecting a person in party editors

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6868a8d6d854832e8410a83ea6a0014d