### PR TITLE
Fix party actions state and show info

### DIFF
--- a/src/widgets/CourtCasePartiesTable.tsx
+++ b/src/widgets/CourtCasePartiesTable.tsx
@@ -106,7 +106,9 @@ export default function CourtCasePartiesTable({ fields, add, remove }: Props) {
           noStyle
           shouldUpdate={(prev, curr) =>
             prev.parties?.[field.name]?.type !==
-            curr.parties?.[field.name]?.type
+              curr.parties?.[field.name]?.type ||
+            prev.parties?.[field.name]?.entityId !==
+              curr.parties?.[field.name]?.entityId
           }
         >
           {() => {
@@ -124,13 +126,18 @@ export default function CourtCasePartiesTable({ fields, add, remove }: Props) {
               type === "contractor"
                 ? contractors.map((c) => ({ value: c.id, label: c.name }))
                 : persons.map((p) => ({ value: p.id, label: p.full_name }));
+            const selectedPerson =
+              type === "person" && entityId
+                ? persons.find((p) => p.id === entityId)
+                : null;
             return (
-              <Space.Compact style={{ width: "100%" }}>
-                <Form.Item
-                  name={[field.name, "entityId"]}
-                  rules={[{ required: true }]}
-                  noStyle
-                >
+              <>
+                <Space.Compact style={{ width: "100%" }}>
+                  <Form.Item
+                    name={[field.name, "entityId"]}
+                    rules={[{ required: true }]}
+                    noStyle
+                  >
                   <Select
                     allowClear
                     showSearch
@@ -189,7 +196,15 @@ export default function CourtCasePartiesTable({ fields, add, remove }: Props) {
                     disabled={!entityId}
                   />
                 </Popconfirm>
-              </Space.Compact>
+                </Space.Compact>
+                {selectedPerson && (
+                  <div style={{ fontSize: 12, color: "#888" }}>
+                    {selectedPerson.passport_series} {selectedPerson.passport_number}
+                    {selectedPerson.phone ? `, ${selectedPerson.phone}` : ""}
+                    {selectedPerson.email ? `, ${selectedPerson.email}` : ""}
+                  </div>
+                )}
+              </>
             );
           }}
         </Form.Item>


### PR DESCRIPTION
## Summary
- fix update condition so action buttons enable right away
- show selected person's passport and contact info below their name

## Testing
- `npm run lint --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6868a8d6d854832e8410a83ea6a0014d