### PR TITLE
feat: show extended party info

### DIFF
--- a/src/entities/courtCaseParty.ts
+++ b/src/entities/courtCaseParty.ts
@@ -6,7 +6,9 @@ import type { CourtCaseParty } from '@/shared/types/courtCaseParty';
 const TABLE = 'court_case_parties';
 
 const FIELDS =
-  'id, case_id, person_id, contractor_id, project_id, role, created_at, persons(full_name), contractors(name)';
+  'id, case_id, person_id, contractor_id, project_id, role, created_at,' +
+  ' persons(full_name, passport_series, passport_number, phone, email),' +
+  ' contractors(name, inn)';
 
 export function useCaseParties(caseId?: number | null) {
   return useQuery({
@@ -20,8 +22,14 @@ export function useCaseParties(caseId?: number | null) {
         .order('id');
       if (error) throw error;
       return (data ?? []) as (CourtCaseParty & {
-        persons?: { full_name: string } | null;
-        contractors?: { name: string } | null;
+        persons?: {
+          full_name: string;
+          passport_series?: string | null;
+          passport_number?: string | null;
+          phone?: string | null;
+          email?: string | null;
+        } | null;
+        contractors?: { name: string; inn?: string | null } | null;
       })[];
     },
     staleTime: 5 * 60_000,
@@ -37,8 +45,14 @@ export function useCasePartiesByCaseIds(caseIds: number[]) {
         supabase.from(TABLE).select(FIELDS).in('case_id', chunk),
       );
       return (rows ?? []) as (CourtCaseParty & {
-        persons?: { full_name: string } | null;
-        contractors?: { name: string } | null;
+        persons?: {
+          full_name: string;
+          passport_series?: string | null;
+          passport_number?: string | null;
+          phone?: string | null;
+          email?: string | null;
+        } | null;
+        contractors?: { name: string; inn?: string | null } | null;
       })[];
     },
     staleTime: 5 * 60_000,
@@ -59,7 +73,7 @@ export function useAddCaseParties() {
     },
     onSuccess: (rows) => {
       if (rows.length) {
-        qc.invalidateQueries({ queryKey: [TABLE, rows[0].case_id] });
+        qc.invalidateQueries({ queryKey: [TABLE] });
       }
     },
   });
@@ -78,8 +92,8 @@ export function useUpdateCaseParty() {
       if (error) throw error;
       return data as CourtCaseParty;
     },
-    onSuccess: (row) => {
-      qc.invalidateQueries({ queryKey: [TABLE, row.case_id] });
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: [TABLE] });
     },
   });
 }
@@ -99,6 +113,6 @@ export function useDeleteCaseParty() {
       if (delErr) throw delErr;
       return caseId;
     },
-    onSuccess: (caseId) => qc.invalidateQueries({ queryKey: [TABLE, caseId] }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: [TABLE] }),
   });
 }

--- a/src/widgets/CasePartiesEditorTable.tsx
+++ b/src/widgets/CasePartiesEditorTable.tsx
@@ -61,7 +61,21 @@ export default function CasePartiesEditorTable({ caseId, projectId }: Props) {
     {
       title: 'Сторона',
       dataIndex: 'name',
-      render: (v: string, row) => v,
+      render: (_: string, row) => (
+        <>
+          <div>{row.name}</div>
+          {row.persons && (
+            <div style={{ fontSize: 12, color: '#888' }}>
+              {row.persons.passport_series} {row.persons.passport_number}
+              {row.persons.phone ? `, ${row.persons.phone}` : ''}
+              {row.persons.email ? `, ${row.persons.email}` : ''}
+            </div>
+          )}
+          {row.contractors?.inn && (
+            <div style={{ fontSize: 12, color: '#888' }}>ИНН {row.contractors.inn}</div>
+          )}
+        </>
+      ),
     },
     {
       title: '',

--- a/src/widgets/CourtCasePartiesTable.tsx
+++ b/src/widgets/CourtCasePartiesTable.tsx
@@ -130,6 +130,10 @@ export default function CourtCasePartiesTable({ fields, add, remove }: Props) {
               type === "person" && entityId
                 ? persons.find((p) => p.id === entityId)
                 : null;
+            const selectedContractor =
+              type === "contractor" && entityId
+                ? contractors.find((c) => c.id === entityId)
+                : null;
             return (
               <>
                 <Space.Compact style={{ width: "100%" }}>
@@ -203,6 +207,9 @@ export default function CourtCasePartiesTable({ fields, add, remove }: Props) {
                     {selectedPerson.phone ? `, ${selectedPerson.phone}` : ""}
                     {selectedPerson.email ? `, ${selectedPerson.email}` : ""}
                   </div>
+                )}
+                {selectedContractor?.inn && (
+                  <div style={{ fontSize: 12, color: "#888" }}>ИНН {selectedContractor.inn}</div>
                 )}
               </>
             );


### PR DESCRIPTION
## Summary
- display detailed party info when selecting in Add Court Case form
- show passport and contact info for persons, and INN for contractors in case view
- refresh case list after updating parties

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6868ac2a7134832ea8dd7d98fe0e98f6