### PR TITLE
Add total claim column

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,12 @@ VITE_ATTACH_BUCKET=<название корзины для вложений>
 Индексы: [db_indexes_summary.md](db_indexes_summary.md).
 
 
+
+## Обновление схемы базы данных
+
+Для добавления колонки `total_claim_amount` выполните файл [sql/update_total_claim_amount.sql](sql/update_total_claim_amount.sql):
+```bash
+psql -f sql/update_total_claim_amount.sql
+```
+
+

--- a/database_structure.json
+++ b/database_structure.json
@@ -637,6 +637,13 @@
     "column_default": null
   },
   {
+    "table_name": "court_cases",
+    "column_name": "total_claim_amount",
+    "data_type": "numeric",
+    "is_nullable": "YES",
+    "column_default": null
+  },
+  {
     "table_name": "defect_attachments",
     "column_name": "defect_id",
     "data_type": "bigint",

--- a/sql/update_total_claim_amount.sql
+++ b/sql/update_total_claim_amount.sql
@@ -1,0 +1,11 @@
+ALTER TABLE court_cases ADD COLUMN IF NOT EXISTS total_claim_amount numeric;
+
+UPDATE court_cases cc
+SET total_claim_amount = sub.sum_claim
+FROM (
+  SELECT case_id, SUM(claimed_amount) AS sum_claim
+  FROM court_case_claims
+  GROUP BY case_id
+) AS sub
+WHERE cc.id = sub.case_id;
+

--- a/src/entities/courtCase/index.ts
+++ b/src/entities/courtCase/index.ts
@@ -51,10 +51,23 @@ export function useCourtCases() {
       const linkMap = new Map<number, number>();
       (links ?? []).forEach((l) => linkMap.set(l.child_id, l.parent_id));
 
+      const { data: claimRows } = ids.length
+        ? await supabase
+            .from('court_case_claims')
+            .select('case_id, claimed_amount')
+            .in('case_id', ids)
+        : { data: [] };
+      const claimMap = new Map<number, number>();
+      (claimRows ?? []).forEach((r: any) => {
+        const sum = claimMap.get(r.case_id) || 0;
+        claimMap.set(r.case_id, sum + Number(r.claimed_amount) || 0);
+      });
+
       return (data ?? []).map((row: any) => ({
         ...row,
         unit_ids: unitMap.get(row.id) || [],
         parent_id: linkMap.get(row.id) ?? null,
+        total_claim_amount: claimMap.get(row.id) ?? null,
       })) as CourtCase[];
     },
     staleTime: 5 * 60_000,

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -16,6 +16,7 @@ import {
 } from "antd";
 import ruRU from "antd/locale/ru_RU";
 import type { ColumnsType } from "antd/es/table";
+import { formatRub } from "@/shared/utils/formatCurrency";
 import type { CourtCase } from "@/shared/types/courtCase";
 import { useVisibleProjects } from "@/entities/project";
 import { useUnitsByIds } from "@/entities/unit";
@@ -242,6 +243,7 @@ export default function CourtCasesPage() {
           .filter(Boolean),
       ),
     ).join(", "),
+    totalClaimAmount: c.total_claim_amount ?? 0,
     responsibleLawyer:
       users.find((u) => u.id === c.responsible_lawyer_id)?.name ??
       c.responsibleLawyer,
@@ -417,6 +419,14 @@ export default function CourtCasesPage() {
       dataIndex: "defendants",
       width: 200,
       sorter: (a, b) => (a.defendants || "").localeCompare(b.defendants || ""),
+    },
+    totalClaimAmount: {
+      title: "Сумма требований",
+      dataIndex: "totalClaimAmount",
+      width: 150,
+      sorter: (a, b) =>
+        (a.totalClaimAmount ?? 0) - (b.totalClaimAmount ?? 0),
+      render: (v: number) => formatRub(v),
     },
     daysSinceFixStart: {
       title: "Прошло дней с начала устранения",

--- a/src/shared/types/courtCase.ts
+++ b/src/shared/types/courtCase.ts
@@ -28,6 +28,8 @@ export interface CourtCase {
   number: string;
   responsible_lawyer_id: string | null;
   status: number;
+  /** Общая сумма исковых требований */
+  total_claim_amount?: number | null;
   /** Автор создания записи */
   created_by?: string | null;
   /** Дата создания записи */


### PR DESCRIPTION
## Summary
- include `total_claim_amount` in DB structure
- compute total claim amount when fetching court cases
- expose new field in type definitions
- show claim total column in court cases table
- add SQL script to backfill `total_claim_amount`
- document migration script

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6868ac68671c832eb7373d4a1ce3fd83