### PR TITLE
Fix sluggish claim amount inputs

### DIFF
--- a/src/shared/ui/RubInput.tsx
+++ b/src/shared/ui/RubInput.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { InputNumber } from 'antd';
+import { formatRub, parseRub } from '@/shared/utils/formatCurrency';
+
+/**
+ * Поле ввода денежных сумм в рублях с сохранением значения при потере фокуса.
+ */
+interface Props {
+  value?: number | null;
+  /** Вызывается при завершении ввода (onBlur). */
+  onCommit?: (value: number | null) => void;
+}
+
+export default function RubInput({ value, onCommit }: Props) {
+  const [internal, setInternal] = React.useState<number | null | undefined>(
+    value ?? undefined,
+  );
+
+  React.useEffect(() => {
+    setInternal(value ?? undefined);
+  }, [value]);
+
+  const handleBlur = () => {
+    onCommit?.(internal ?? null);
+  };
+
+  return (
+    <InputNumber
+      min={0}
+      style={{ width: '100%' }}
+      value={internal ?? undefined}
+      formatter={(val) => formatRub(Number(val))}
+      parser={parseRub}
+      onChange={(v) => setInternal(v ?? null)}
+      onBlur={handleBlur}
+    />
+  );
+}

--- a/src/widgets/CaseClaimsEditorTable.tsx
+++ b/src/widgets/CaseClaimsEditorTable.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import {
   Table,
   Select,
-  InputNumber,
   Button,
   Tooltip,
   Popconfirm,
   Skeleton,
 } from 'antd';
-import { formatRub, parseRub } from '@/shared/utils/formatCurrency';
+import { formatRub } from '@/shared/utils/formatCurrency';
+import RubInput from '@/shared/ui/RubInput';
 import { PlusOutlined, DeleteOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import { useLawsuitClaimTypes } from '@/entities/lawsuitClaimType';
@@ -77,14 +77,10 @@ export default function CaseClaimsEditorTable({ caseId }: Props) {
       dataIndex: 'claimed_amount',
       width: 150,
       render: (v: number | null, row) => (
-        <InputNumber
-          min={0}
-          style={{ width: '100%' }}
-          value={v ?? undefined}
-          formatter={(val) => formatRub(Number(val))}
-          parser={parseRub}
-          onChange={(val) =>
-            updateClaim.mutate({ id: row.id, updates: { claimed_amount: val ?? null } })
+        <RubInput
+          value={v}
+          onCommit={(val) =>
+            updateClaim.mutate({ id: row.id, updates: { claimed_amount: val } })
           }
         />
       ),
@@ -94,14 +90,10 @@ export default function CaseClaimsEditorTable({ caseId }: Props) {
       dataIndex: 'confirmed_amount',
       width: 150,
       render: (v: number | null, row) => (
-        <InputNumber
-          min={0}
-          style={{ width: '100%' }}
-          value={v ?? undefined}
-          formatter={(val) => formatRub(Number(val))}
-          parser={parseRub}
-          onChange={(val) =>
-            updateClaim.mutate({ id: row.id, updates: { confirmed_amount: val ?? null } })
+        <RubInput
+          value={v}
+          onCommit={(val) =>
+            updateClaim.mutate({ id: row.id, updates: { confirmed_amount: val } })
           }
         />
       ),
@@ -111,13 +103,11 @@ export default function CaseClaimsEditorTable({ caseId }: Props) {
       dataIndex: 'paid_amount',
       width: 150,
       render: (v: number | null, row) => (
-        <InputNumber
-          min={0}
-          style={{ width: '100%' }}
-          value={v ?? undefined}
-          formatter={(val) => formatRub(Number(val))}
-          parser={parseRub}
-          onChange={(val) => updateClaim.mutate({ id: row.id, updates: { paid_amount: val ?? null } })}
+        <RubInput
+          value={v}
+          onCommit={(val) =>
+            updateClaim.mutate({ id: row.id, updates: { paid_amount: val } })
+          }
         />
       ),
     },
@@ -126,14 +116,10 @@ export default function CaseClaimsEditorTable({ caseId }: Props) {
       dataIndex: 'agreed_amount',
       width: 150,
       render: (v: number | null, row) => (
-        <InputNumber
-          min={0}
-          style={{ width: '100%' }}
-          value={v ?? undefined}
-          formatter={(val) => formatRub(Number(val))}
-          parser={parseRub}
-          onChange={(val) =>
-            updateClaim.mutate({ id: row.id, updates: { agreed_amount: val ?? null } })
+        <RubInput
+          value={v}
+          onCommit={(val) =>
+            updateClaim.mutate({ id: row.id, updates: { agreed_amount: val } })
           }
         />
       ),

--- a/src/widgets/CourtCaseClaimsTable.tsx
+++ b/src/widgets/CourtCaseClaimsTable.tsx
@@ -3,13 +3,13 @@ import {
   Table,
   Form,
   Select,
-  InputNumber,
   Button,
   Tooltip,
   Skeleton,
   Typography,
 } from 'antd';
-import { formatRub, parseRub } from '@/shared/utils/formatCurrency';
+import { formatRub } from '@/shared/utils/formatCurrency';
+import RubInput from '@/shared/ui/RubInput';
 import { PlusOutlined, DeleteOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import { useLawsuitClaimTypes } from '@/entities/lawsuitClaimType';
@@ -61,12 +61,7 @@ export default function CourtCaseClaimsTable({ fields, add, remove }: Props) {
       width: 150,
       render: (_: unknown, field: any) => (
         <Form.Item name={[field.name, 'claimed_amount']} noStyle>
-          <InputNumber
-            min={0}
-            style={{ width: '100%' }}
-            formatter={(v) => formatRub(Number(v))}
-            parser={parseRub}
-          />
+          <RubInput />
         </Form.Item>
       ),
     },
@@ -76,12 +71,7 @@ export default function CourtCaseClaimsTable({ fields, add, remove }: Props) {
       width: 150,
       render: (_: unknown, field: any) => (
         <Form.Item name={[field.name, 'confirmed_amount']} noStyle>
-          <InputNumber
-            min={0}
-            style={{ width: '100%' }}
-            formatter={(v) => formatRub(Number(v))}
-            parser={parseRub}
-          />
+          <RubInput />
         </Form.Item>
       ),
     },
@@ -91,12 +81,7 @@ export default function CourtCaseClaimsTable({ fields, add, remove }: Props) {
       width: 150,
       render: (_: unknown, field: any) => (
         <Form.Item name={[field.name, 'paid_amount']} noStyle>
-          <InputNumber
-            min={0}
-            style={{ width: '100%' }}
-            formatter={(v) => formatRub(Number(v))}
-            parser={parseRub}
-          />
+          <RubInput />
         </Form.Item>
       ),
     },
@@ -106,12 +91,7 @@ export default function CourtCaseClaimsTable({ fields, add, remove }: Props) {
       width: 150,
       render: (_: unknown, field: any) => (
         <Form.Item name={[field.name, 'agreed_amount']} noStyle>
-          <InputNumber
-            min={0}
-            style={{ width: '100%' }}
-            formatter={(v) => formatRub(Number(v))}
-            parser={parseRub}
-          />
+          <RubInput />
         </Form.Item>
       ),
     },


### PR DESCRIPTION
## Summary
- add `RubInput` component with onBlur commit
- switch claim tables to use `RubInput` for sum columns

## Testing
- `npm run lint` *(fails: Parsing error in unrelated files)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868fbb3f138832e90ddcdd2b53a4d11