### PR TITLE
feat: improve claim input UX

### DIFF
--- a/src/shared/ui/MoneyInput.tsx
+++ b/src/shared/ui/MoneyInput.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { InputNumber, InputNumberProps } from 'antd';
+import { formatRub, parseRub } from '@/shared/utils/formatCurrency';
+
+export interface MoneyInputProps extends Omit<InputNumberProps, 'formatter' | 'parser'> {}
+
+/**
+ * Поле ввода денежных сумм в рублях с форматированием.
+ */
+export default function MoneyInput(props: MoneyInputProps) {
+  return (
+    <InputNumber
+      {...props}
+      precision={2}
+      controls={false}
+      inputMode="decimal"
+      formatter={(value) => formatRub(Number(value))}
+      parser={parseRub}
+    />
+  );
+}

--- a/src/widgets/CaseClaimsEditorTable.tsx
+++ b/src/widgets/CaseClaimsEditorTable.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import {
   Table,
   Select,
-  InputNumber,
   Button,
   Tooltip,
   Popconfirm,
   Skeleton,
 } from 'antd';
-import { formatRub, parseRub } from '@/shared/utils/formatCurrency';
+import MoneyInput from '@/shared/ui/MoneyInput';
+import { formatRub } from '@/shared/utils/formatCurrency';
 import { PlusOutlined, DeleteOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import { useLawsuitClaimTypes } from '@/entities/lawsuitClaimType';
@@ -77,12 +77,10 @@ export default function CaseClaimsEditorTable({ caseId }: Props) {
       dataIndex: 'claimed_amount',
       width: 150,
       render: (v: number | null, row) => (
-        <InputNumber
+        <MoneyInput
           min={0}
           style={{ width: '100%' }}
           value={v ?? undefined}
-          formatter={(val) => formatRub(Number(val))}
-          parser={parseRub}
           onChange={(val) =>
             updateClaim.mutate({ id: row.id, updates: { claimed_amount: val ?? null } })
           }
@@ -94,12 +92,10 @@ export default function CaseClaimsEditorTable({ caseId }: Props) {
       dataIndex: 'confirmed_amount',
       width: 150,
       render: (v: number | null, row) => (
-        <InputNumber
+        <MoneyInput
           min={0}
           style={{ width: '100%' }}
           value={v ?? undefined}
-          formatter={(val) => formatRub(Number(val))}
-          parser={parseRub}
           onChange={(val) =>
             updateClaim.mutate({ id: row.id, updates: { confirmed_amount: val ?? null } })
           }
@@ -111,12 +107,10 @@ export default function CaseClaimsEditorTable({ caseId }: Props) {
       dataIndex: 'paid_amount',
       width: 150,
       render: (v: number | null, row) => (
-        <InputNumber
+        <MoneyInput
           min={0}
           style={{ width: '100%' }}
           value={v ?? undefined}
-          formatter={(val) => formatRub(Number(val))}
-          parser={parseRub}
           onChange={(val) => updateClaim.mutate({ id: row.id, updates: { paid_amount: val ?? null } })}
         />
       ),
@@ -126,12 +120,10 @@ export default function CaseClaimsEditorTable({ caseId }: Props) {
       dataIndex: 'agreed_amount',
       width: 150,
       render: (v: number | null, row) => (
-        <InputNumber
+        <MoneyInput
           min={0}
           style={{ width: '100%' }}
           value={v ?? undefined}
-          formatter={(val) => formatRub(Number(val))}
-          parser={parseRub}
           onChange={(val) =>
             updateClaim.mutate({ id: row.id, updates: { agreed_amount: val ?? null } })
           }

--- a/src/widgets/CourtCaseClaimsTable.tsx
+++ b/src/widgets/CourtCaseClaimsTable.tsx
@@ -3,13 +3,13 @@ import {
   Table,
   Form,
   Select,
-  InputNumber,
   Button,
   Tooltip,
   Skeleton,
   Typography,
 } from 'antd';
-import { formatRub, parseRub } from '@/shared/utils/formatCurrency';
+import MoneyInput from '@/shared/ui/MoneyInput';
+import { formatRub } from '@/shared/utils/formatCurrency';
 import { PlusOutlined, DeleteOutlined } from '@ant-design/icons';
 import type { ColumnsType } from 'antd/es/table';
 import { useLawsuitClaimTypes } from '@/entities/lawsuitClaimType';
@@ -61,12 +61,7 @@ export default function CourtCaseClaimsTable({ fields, add, remove }: Props) {
       width: 150,
       render: (_: unknown, field: any) => (
         <Form.Item name={[field.name, 'claimed_amount']} noStyle>
-          <InputNumber
-            min={0}
-            style={{ width: '100%' }}
-            formatter={(v) => formatRub(Number(v))}
-            parser={parseRub}
-          />
+          <MoneyInput min={0} style={{ width: '100%' }} />
         </Form.Item>
       ),
     },
@@ -76,12 +71,7 @@ export default function CourtCaseClaimsTable({ fields, add, remove }: Props) {
       width: 150,
       render: (_: unknown, field: any) => (
         <Form.Item name={[field.name, 'confirmed_amount']} noStyle>
-          <InputNumber
-            min={0}
-            style={{ width: '100%' }}
-            formatter={(v) => formatRub(Number(v))}
-            parser={parseRub}
-          />
+          <MoneyInput min={0} style={{ width: '100%' }} />
         </Form.Item>
       ),
     },
@@ -91,12 +81,7 @@ export default function CourtCaseClaimsTable({ fields, add, remove }: Props) {
       width: 150,
       render: (_: unknown, field: any) => (
         <Form.Item name={[field.name, 'paid_amount']} noStyle>
-          <InputNumber
-            min={0}
-            style={{ width: '100%' }}
-            formatter={(v) => formatRub(Number(v))}
-            parser={parseRub}
-          />
+          <MoneyInput min={0} style={{ width: '100%' }} />
         </Form.Item>
       ),
     },
@@ -106,12 +91,7 @@ export default function CourtCaseClaimsTable({ fields, add, remove }: Props) {
       width: 150,
       render: (_: unknown, field: any) => (
         <Form.Item name={[field.name, 'agreed_amount']} noStyle>
-          <InputNumber
-            min={0}
-            style={{ width: '100%' }}
-            formatter={(v) => formatRub(Number(v))}
-            parser={parseRub}
-          />
+          <MoneyInput min={0} style={{ width: '100%' }} />
         </Form.Item>
       ),
     },


### PR DESCRIPTION
## Summary
- add `MoneyInput` component for currency values
- use `MoneyInput` in claim tables to stabilise rendering

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6868fbb3f138832e90ddcdd2b53a4d11