### PR TITLE
Fix case parties block width and column title

### DIFF
--- a/src/widgets/CasePartiesEditorTable.tsx
+++ b/src/widgets/CasePartiesEditorTable.tsx
@@ -78,7 +78,7 @@ export default function CasePartiesEditorTable({ caseId, projectId }: Props) {
       ),
     },
     {
-      title: '',
+      title: 'Действия',
       dataIndex: 'actions',
       width: 80,
       render: (_: unknown, row) => (
@@ -145,7 +145,7 @@ export default function CasePartiesEditorTable({ caseId, projectId }: Props) {
   }
 
   return (
-    <div>
+    <div style={{ maxWidth: 640 }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
         <span style={{ fontWeight: 500 }}>Стороны дела</span>
         <Button type="dashed" icon={<PlusOutlined />} onClick={() => setModal({ mode: 'add' })}>

--- a/src/widgets/CourtCasePartiesTable.tsx
+++ b/src/widgets/CourtCasePartiesTable.tsx
@@ -218,7 +218,7 @@ export default function CourtCasePartiesTable({ fields, add, remove }: Props) {
       ),
     },
     {
-      title: "",
+      title: "Действия",
       dataIndex: "actions",
       width: 60,
       render: (_: unknown, field) => (
@@ -236,7 +236,7 @@ export default function CourtCasePartiesTable({ fields, add, remove }: Props) {
   ];
 
   return (
-    <div>
+    <div style={{ maxWidth: 640 }}>
       <div
         style={{
           display: "flex",


### PR DESCRIPTION
## Summary
- make case parties blocks compact in court case forms
- rename actions column header

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6868fc16cdf0832e8d17090ffeac498a