### PR TITLE
fix: prevent claims table jump

### DIFF
--- a/src/entities/courtCaseClaim.ts
+++ b/src/entities/courtCaseClaim.ts
@@ -14,7 +14,8 @@ export function useCaseClaims(caseId?: number | null) {
         .select(
           'id, case_id, claim_type_id, claimed_amount, confirmed_amount, paid_amount, agreed_amount'
         )
-        .eq('case_id', caseId as number);
+        .eq('case_id', caseId as number)
+        .order('id', { ascending: true });
       if (error) throw error;
       return (data ?? []) as CourtCaseClaim[];
     },

--- a/src/widgets/CaseClaimsEditorTable.tsx
+++ b/src/widgets/CaseClaimsEditorTable.tsx
@@ -159,6 +159,7 @@ export default function CaseClaimsEditorTable({ caseId }: Props) {
         size="small"
         pagination={false}
         rowKey="id"
+        scrollToFirstRowOnChange={false}
         columns={columns}
         dataSource={claims}
         summary={() => (


### PR DESCRIPTION
## Summary
- keep court case claims ordered by `id`
- prevent Ant Design Table from auto-scrolling to the first row after editing

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686901a35bd8832e99e6a3b83f418bde