### PR TITLE
Align case claim widths and add row numbering

### DIFF
--- a/src/widgets/CaseClaimsEditorTable.tsx
+++ b/src/widgets/CaseClaimsEditorTable.tsx
@@ -148,7 +148,7 @@ export default function CaseClaimsEditorTable({ caseId }: Props) {
   }
 
   return (
-    <div>
+    <div style={{ maxWidth: 1040 }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
         <span style={{ fontWeight: 500 }}>Исковые требования</span>
         <Button type="dashed" icon={<PlusOutlined />} onClick={handleAdd}>

--- a/src/widgets/CourtCaseClaimsTable.tsx
+++ b/src/widgets/CourtCaseClaimsTable.tsx
@@ -49,6 +49,13 @@ export default function CourtCaseClaimsTable({
 
   const columns: ColumnsType<any> = [
     {
+      title: '№',
+      dataIndex: 'index',
+      width: 60,
+      align: 'center' as const,
+      render: (_: unknown, __: any, idx: number) => idx + 1,
+    },
+    {
       title: 'Требование',
       dataIndex: 'type',
       width: 280,
@@ -140,7 +147,7 @@ export default function CourtCaseClaimsTable({
   }
 
   return (
-    <div>
+    <div style={{ maxWidth: 1040 }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
         <span style={{ fontWeight: 500 }}>Исковые требования</span>
         <Button type="dashed" icon={<PlusOutlined />} onClick={() => add({})}>
@@ -155,14 +162,15 @@ export default function CourtCaseClaimsTable({
         dataSource={fields}
         summary={() => (
           <Table.Summary.Row>
-            <Table.Summary.Cell index={0}>
+            <Table.Summary.Cell index={0} />
+            <Table.Summary.Cell index={1}>
               <Typography.Text strong>Итого</Typography.Text>
             </Table.Summary.Cell>
-            <Table.Summary.Cell index={1}>{formatRub(totals.claimed)}</Table.Summary.Cell>
-            <Table.Summary.Cell index={2}>{formatRub(totals.confirmed)}</Table.Summary.Cell>
-            <Table.Summary.Cell index={3}>{formatRub(totals.paid)}</Table.Summary.Cell>
-            <Table.Summary.Cell index={4}>{formatRub(totals.agreed)}</Table.Summary.Cell>
-            <Table.Summary.Cell index={5} />
+            <Table.Summary.Cell index={2}>{formatRub(totals.claimed)}</Table.Summary.Cell>
+            <Table.Summary.Cell index={3}>{formatRub(totals.confirmed)}</Table.Summary.Cell>
+            <Table.Summary.Cell index={4}>{formatRub(totals.paid)}</Table.Summary.Cell>
+            <Table.Summary.Cell index={5}>{formatRub(totals.agreed)}</Table.Summary.Cell>
+            <Table.Summary.Cell index={6} />
           </Table.Summary.Row>
         )}
       />


### PR DESCRIPTION
## Summary
- add max-width to CaseClaimsEditorTable
- unify block width for new case form claims table
- display row numbers for case claims

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686940747110832ea5b5b1744ad17de1