### PR TITLE
Fix UID input and claim totals

### DIFF
--- a/sql/fix_case_uid_format.sql
+++ b/sql/fix_case_uid_format.sql
@@ -1,0 +1,5 @@
+-- Удалить кавычки и квадратные скобки из поля uid
+UPDATE court_cases_uids
+SET uid = regexp_replace(uid, '^\["(.+)"\]$', '\1')
+WHERE uid ~ '^\[".*"\]$';
+

--- a/src/features/courtCase/AddCourtCaseFormAntd.tsx
+++ b/src/features/courtCase/AddCourtCaseFormAntd.tsx
@@ -1,5 +1,15 @@
 import React, { useState, useEffect, useRef } from "react";
-import { Form, Row, Col, Input, DatePicker, Select, Button, Space } from "antd";
+import {
+  Form,
+  Row,
+  Col,
+  Input,
+  DatePicker,
+  Select,
+  Button,
+  Space,
+  AutoComplete,
+} from "antd";
 import { Dayjs } from "dayjs";
 import { useVisibleProjects } from "@/entities/project";
 import { useUnitsByProject } from "@/entities/unit";
@@ -79,7 +89,7 @@ export default function AddCourtCaseFormAntd({
       form.setFieldValue("status", initialValues.status);
     }
     if (initialValues.case_uid) {
-      form.setFieldValue("case_uid", [initialValues.case_uid]);
+      form.setFieldValue("case_uid", initialValues.case_uid);
     }
   }, [initialValues, globalProjectId, profileId, form]);
 
@@ -131,10 +141,7 @@ export default function AddCourtCaseFormAntd({
 
   const handleAddCase = async (values: any) => {
     try {
-      const caseUid = Array.isArray(values.case_uid)
-        ? values.case_uid[0]
-        : values.case_uid;
-      const uidId = await getOrCreateCaseUid(caseUid);
+      const uidId = await getOrCreateCaseUid(values.case_uid);
 
       const newCase = await addCaseMutation.mutateAsync({
         project_id: values.project_id,
@@ -282,12 +289,15 @@ export default function AddCourtCaseFormAntd({
               validateTrigger="onBlur"
               rules={[{ required: true, message: "Укажите UID" }]}
             >
-              <Select
-                mode="tags"
-                open={false}
-                tokenSeparators={[","]}
+              <AutoComplete
+                allowClear
                 placeholder="UID"
-                options={caseUids.map((u) => ({ value: u.uid, label: u.uid }))}
+                options={caseUids.map((u) => ({ value: u.uid }))}
+                filterOption={(input, option) =>
+                  String(option?.value ?? '')
+                    .toLowerCase()
+                    .includes(input.toLowerCase())
+                }
               />
             </Form.Item>
           </Col>

--- a/src/features/courtCase/CourtCaseFormAntdEdit.tsx
+++ b/src/features/courtCase/CourtCaseFormAntdEdit.tsx
@@ -9,6 +9,7 @@ import {
   Col,
   Button,
   Skeleton,
+  AutoComplete,
 } from 'antd';
 import { useVisibleProjects } from '@/entities/project';
 import { useUnitsByProject } from '@/entities/unit';
@@ -193,12 +194,15 @@ export default function CourtCaseFormAntdEdit({
             rules={[{ required: true }]}
             style={highlight('case_uid')}
           >
-            <Select
-              mode="tags"
-              open={false}
-              tokenSeparators={[',']}
+            <AutoComplete
+              allowClear
               placeholder="UID"
-              options={caseUids.map((u) => ({ value: u.uid, label: u.uid }))}
+              options={caseUids.map((u) => ({ value: u.uid }))}
+              filterOption={(input, option) =>
+                String(option?.value ?? '')
+                  .toLowerCase()
+                  .includes(input.toLowerCase())
+              }
             />
           </Form.Item>
         </Col>

--- a/src/widgets/CourtCaseClaimsTable.tsx
+++ b/src/widgets/CourtCaseClaimsTable.tsx
@@ -73,7 +73,12 @@ export default function CourtCaseClaimsTable({
       dataIndex: 'claimed',
       width: 150,
       render: (_: unknown, field: any) => (
-        <Form.Item name={[field.name, 'claimed_amount']} noStyle>
+        <Form.Item
+          name={[field.name, 'claimed_amount']}
+          noStyle
+          valuePropName="value"
+          trigger="onCommit"
+        >
           <RubInput />
         </Form.Item>
       ),
@@ -83,7 +88,12 @@ export default function CourtCaseClaimsTable({
       dataIndex: 'confirmed',
       width: 150,
       render: (_: unknown, field: any) => (
-        <Form.Item name={[field.name, 'confirmed_amount']} noStyle>
+        <Form.Item
+          name={[field.name, 'confirmed_amount']}
+          noStyle
+          valuePropName="value"
+          trigger="onCommit"
+        >
           <RubInput />
         </Form.Item>
       ),
@@ -93,7 +103,12 @@ export default function CourtCaseClaimsTable({
       dataIndex: 'paid',
       width: 150,
       render: (_: unknown, field: any) => (
-        <Form.Item name={[field.name, 'paid_amount']} noStyle>
+        <Form.Item
+          name={[field.name, 'paid_amount']}
+          noStyle
+          valuePropName="value"
+          trigger="onCommit"
+        >
           <RubInput />
         </Form.Item>
       ),
@@ -103,7 +118,12 @@ export default function CourtCaseClaimsTable({
       dataIndex: 'agreed',
       width: 150,
       render: (_: unknown, field: any) => (
-        <Form.Item name={[field.name, 'agreed_amount']} noStyle>
+        <Form.Item
+          name={[field.name, 'agreed_amount']}
+          noStyle
+          valuePropName="value"
+          trigger="onCommit"
+        >
           <RubInput />
         </Form.Item>
       ),


### PR DESCRIPTION
## Summary
- fix case UID form inputs to use `AutoComplete`
- ensure claim amounts update totals and save correctly
- add SQL script to clean stored case UIDs

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686951d44128832eb38b12d16dd6397b