### PR TITLE
feat: link court case filters

### DIFF
--- a/src/features/courtCase/model/useCourtCasesFilterOptions.ts
+++ b/src/features/courtCase/model/useCourtCasesFilterOptions.ts
@@ -1,0 +1,128 @@
+import { useCallback, useMemo } from 'react';
+import dayjs from 'dayjs';
+import { naturalCompare } from '@/shared/utils/naturalSort';
+import type { CourtCasesFiltersValues } from '@/shared/types/courtCasesFilters';
+import type { CourtCase } from '@/shared/types/courtCase';
+import type { Project } from '@/shared/types/project';
+import type { Unit } from '@/shared/types/unit';
+import type { CourtCaseStatus } from '@/shared/types/courtCaseStatus';
+import type { User } from '@/shared/types/user';
+
+export interface FilterOptionsResult {
+  filteredCases: (CourtCase & any)[];
+  projectOptions: Project[];
+  buildingOptions: string[];
+  unitOptions: Unit[];
+  statusOptions: CourtCaseStatus[];
+  userOptions: User[];
+  idOptions: { value: number; label: string }[];
+}
+
+/**
+ * Calculate filtered cases and available filter options based on other filters.
+ */
+export function useCourtCasesFilterOptions(
+  cases: (CourtCase & any)[],
+  projects: Project[],
+  units: Unit[],
+  stages: CourtCaseStatus[],
+  users: User[],
+  filters: CourtCasesFiltersValues,
+  closedStageId?: number,
+): FilterOptionsResult {
+  const matchesFilters = useCallback(
+    (c: any, ignore: (keyof CourtCasesFiltersValues)[] = []) => {
+      const skip = (key: keyof CourtCasesFiltersValues) => ignore.includes(key);
+      if (!skip('status') && filters.status && c.status !== filters.status)
+        return false;
+      if (!skip('projectId') && filters.projectId && c.project_id !== filters.projectId)
+        return false;
+      if (!skip('objectId') && filters.objectId && !(c.unit_ids ?? []).includes(filters.objectId))
+        return false;
+      if (!skip('building') && filters.building && !(c.buildingNamesList ?? []).includes(filters.building))
+        return false;
+      if (!skip('number') && filters.number && !c.number.toLowerCase().includes(filters.number.toLowerCase()))
+        return false;
+      if (!skip('uid') && filters.uid && !(c.caseUid || '').toLowerCase().includes(filters.uid.toLowerCase()))
+        return false;
+      if (!skip('parties') && filters.parties && !(c.plaintiffs + ' ' + c.defendants).toLowerCase().includes(filters.parties.toLowerCase()))
+        return false;
+      if (!skip('description') && filters.description && !(c.description || '').toLowerCase().includes(filters.description.toLowerCase()))
+        return false;
+      if (!skip('dateRange') && filters.dateRange && !(dayjs(c.date).isSameOrAfter(filters.dateRange[0], "day") && dayjs(c.date).isSameOrBefore(filters.dateRange[1], "day")))
+        return false;
+        if (!skip('fixStartRange') && filters.fixStartRange && !(c.fix_start_date && dayjs(c.fix_start_date).isSameOrAfter(filters.fixStartRange[0], 'day') && dayjs(c.fix_start_date).isSameOrBefore(filters.fixStartRange[1], 'day')))
+        return false;
+      if (!skip('lawyerId') && filters.lawyerId && String(c.responsible_lawyer_id) !== filters.lawyerId)
+        return false;
+      if (!skip('hideClosed') && filters.hideClosed && closedStageId && c.status === closedStageId)
+        return false;
+      if (!skip('ids') && filters.ids && !filters.ids.includes(c.id))
+        return false;
+      return true;
+    },
+    [filters, closedStageId],
+  );
+
+  const filteredCases = useMemo(
+    () => cases.filter((c) => matchesFilters(c)),
+    [cases, matchesFilters],
+  );
+
+  const filterExcept = useCallback(
+    (keys: (keyof CourtCasesFiltersValues)[]) =>
+      cases.filter((c) => matchesFilters(c, keys)),
+    [cases, matchesFilters],
+  );
+
+  const projectOptions = useMemo(() => {
+    const list = Array.from(new Set(filterExcept(['projectId']).map((c) => c.project_id).filter(Boolean)));
+    return projects.filter((p) => list.includes(p.id));
+  }, [filterExcept, projects]);
+
+  const unitList = useMemo(() => {
+    const ids = Array.from(
+      new Set(
+        filterExcept(['objectId', 'building']).flatMap((c) => c.unit_ids ?? []).filter(Boolean),
+      ),
+    );
+    return units.filter((u) => ids.includes(u.id));
+  }, [filterExcept, units]);
+
+  const buildingOptions = useMemo(() => {
+    const set = new Set<string>();
+    unitList.forEach((u) => {
+      if (u.building) set.add(u.building);
+    });
+    return Array.from(set).sort(naturalCompare);
+  }, [unitList]);
+
+  const unitOptions = useMemo(() => unitList, [unitList]);
+
+  const statusOptions = useMemo(() => {
+    const list = Array.from(new Set(filterExcept(['status']).map((c) => c.status).filter(Boolean)));
+    return stages.filter((s) => list.includes(s.id));
+  }, [filterExcept, stages]);
+
+  const userOptions = useMemo(() => {
+    const list = Array.from(
+      new Set(filterExcept(['lawyerId']).map((c) => c.responsible_lawyer_id).filter(Boolean)),
+    );
+    return users.filter((u) => list.includes(u.id));
+  }, [filterExcept, users]);
+
+  const idOptions = useMemo(
+    () => filterExcept(['ids']).map((c) => ({ value: c.id, label: String(c.id) })),
+    [filterExcept],
+  );
+
+  return {
+    filteredCases,
+    projectOptions,
+    buildingOptions,
+    unitOptions,
+    statusOptions,
+    userOptions,
+    idOptions,
+  };
+}

--- a/src/pages/CourtCasesPage/CourtCasesPage.tsx
+++ b/src/pages/CourtCasesPage/CourtCasesPage.tsx
@@ -49,6 +49,7 @@ import AddCourtCaseFormAntd from "@/features/courtCase/AddCourtCaseFormAntd";
 import CourtCaseViewModal from "@/features/courtCase/CourtCaseViewModal";
 import CourtCasesFilters from "@/widgets/CourtCasesFilters";
 import type { CourtCasesFiltersValues } from "@/shared/types/courtCasesFilters";
+import { useCourtCasesFilterOptions } from "@/features/courtCase/model/useCourtCasesFilterOptions";
 const TableColumnsDrawer = React.lazy(
   () => import("@/widgets/TableColumnsDrawer"),
 );
@@ -257,73 +258,24 @@ export default function CourtCasesPage() {
     statusColor: stages.find((s) => s.id === c.status)?.color ?? null,
   }));
 
-  const idOptions = React.useMemo(
-    () =>
-      Array.from(new Set(cases.map((c) => c.id))).map((id) => ({
-        value: id,
-        label: String(id),
-      })),
-    [cases],
+  const {
+    filteredCases,
+    projectOptions,
+    buildingOptions,
+    unitOptions,
+    statusOptions,
+    userOptions,
+    idOptions,
+  } = useCourtCasesFilterOptions(
+    casesData,
+    projects,
+    caseUnits,
+    stages,
+    users,
+    filters,
+    closedStageId,
   );
 
-  const filteredCases = casesData.filter((c: any) => {
-    const matchesStatus = !filters.status || c.status === filters.status;
-    const matchesProject =
-      !filters.projectId || c.project_id === filters.projectId;
-    const matchesObject =
-      !filters.objectId || (c.unit_ids ?? []).includes(filters.objectId);
-    const matchesBuilding =
-      !filters.building || c.buildingNamesList?.includes(filters.building);
-    const matchesNumber =
-      !filters.number ||
-      c.number.toLowerCase().includes(filters.number.toLowerCase());
-    const matchesUid =
-      !filters.uid ||
-      (c.caseUid || '').toLowerCase().includes(filters.uid.toLowerCase());
-    const matchesParties =
-      !filters.parties ||
-      (c.plaintiffs + ' ' + c.defendants)
-        .toLowerCase()
-        .includes(filters.parties.toLowerCase());
-    const matchesDescription =
-      !filters.description ||
-      (c.description || '').toLowerCase().includes(filters.description.toLowerCase());
-    const matchesDate =
-      !filters.dateRange ||
-      (dayjs(c.date).isSameOrAfter(filters.dateRange[0], "day") &&
-        dayjs(c.date).isSameOrBefore(filters.dateRange[1], "day"));
-    const matchesFixStart =
-      !filters.fixStartRange ||
-      (c.fix_start_date &&
-        dayjs(c.fix_start_date).isSameOrAfter(
-          filters.fixStartRange[0],
-          "day",
-        ) &&
-        dayjs(c.fix_start_date).isSameOrBefore(
-          filters.fixStartRange[1],
-          "day",
-        ));
-    const matchesLawyer =
-      !filters.lawyerId || String(c.responsible_lawyer_id) === filters.lawyerId;
-    const matchesClosed =
-      !filters.hideClosed || !closedStageId || c.status !== closedStageId;
-    const matchesIds = !filters.ids || filters.ids.includes(c.id);
-    return (
-      matchesIds &&
-      matchesStatus &&
-      matchesProject &&
-      matchesObject &&
-      matchesBuilding &&
-      matchesNumber &&
-      matchesUid &&
-      matchesParties &&
-      matchesDescription &&
-      matchesDate &&
-      matchesFixStart &&
-      matchesLawyer &&
-      matchesClosed
-    );
-  });
 
   const treeData = React.useMemo(() => {
     const map = new Map<number, any>();
@@ -725,10 +677,10 @@ export default function CourtCasesPage() {
                 values={filters}
                 onChange={handleFiltersChange}
                 onReset={resetFilters}
-                projects={projects}
-                units={caseUnits}
-                stages={stages}
-                users={users}
+                projects={projectOptions}
+                units={unitOptions}
+                stages={statusOptions}
+                users={userOptions}
                 idOptions={idOptions}
               />
             </Card>


### PR DESCRIPTION
## Summary
- add hook to compute court case filter options linked to other filters
- use new hook in `CourtCasesPage` so filters update each other

## Testing
- `npm test`
- `npm run lint` *(fails: Module type warning but lint executed successfully)*

------
https://chatgpt.com/codex/tasks/task_e_686956d4e0e4832ebe063760416f806c