### PR TITLE
feat: link claims with court cases

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -1294,4 +1294,32 @@
     "is_nullable": "YES",
     "column_default": null
   }
+  ,{
+    "table_name": "court_case_claim_links",
+    "column_name": "id",
+    "data_type": "bigint",
+    "is_nullable": "NO",
+    "column_default": "nextval('court_case_claim_links_id_seq'::regclass)"
+  },
+  {
+    "table_name": "court_case_claim_links",
+    "column_name": "case_id",
+    "data_type": "bigint",
+    "is_nullable": "NO",
+    "column_default": null
+  },
+  {
+    "table_name": "court_case_claim_links",
+    "column_name": "claim_id",
+    "data_type": "bigint",
+    "is_nullable": "NO",
+    "column_default": null
+  },
+  {
+    "table_name": "court_case_claim_links",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "is_nullable": "YES",
+    "column_default": "now()"
+  }
 ]

--- a/db_indexes_summary.md
+++ b/db_indexes_summary.md
@@ -42,6 +42,11 @@
 ## court_case_claims
 - `court_case_claims_pkey` - `UNIQUE id`
 
+## court_case_claim_links
+- `court_case_claim_links_pkey` - `UNIQUE id`
+- `idx_court_case_claim_links_case` - `case_id`
+- `idx_court_case_claim_links_claim` - `claim_id`
+
 ## court_case_defects
 - `court_case_defects_pkey` - `UNIQUE case_id, defect_id`
 

--- a/src/entities/courtCaseClaimLink.ts
+++ b/src/entities/courtCaseClaimLink.ts
@@ -1,0 +1,63 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/shared/api/supabaseClient';
+import type { CourtCaseClaimLink } from '@/shared/types/courtCaseClaimLink';
+
+const TABLE = 'court_case_claim_links';
+
+export function useCaseClaimLinks(caseId?: number | null) {
+  return useQuery({
+    queryKey: [TABLE, caseId],
+    enabled: !!caseId,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select('id, case_id, claim_id, created_at')
+        .eq('case_id', caseId as number);
+      if (error) throw error;
+      return (data ?? []) as CourtCaseClaimLink[];
+    },
+    staleTime: 5 * 60_000,
+  });
+}
+
+export function useAddCaseClaimLinks() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (
+      rows: Omit<CourtCaseClaimLink, 'id' | 'created_at'>[],
+    ) => {
+      if (!rows.length) return [] as CourtCaseClaimLink[];
+      const { data, error } = await supabase
+        .from(TABLE)
+        .insert(rows)
+        .select('id, case_id, claim_id, created_at');
+      if (error) throw error;
+      return (data ?? []) as CourtCaseClaimLink[];
+    },
+    onSuccess: (rows) => {
+      if (rows.length) {
+        qc.invalidateQueries({ queryKey: [TABLE, rows[0].case_id] });
+      }
+    },
+  });
+}
+
+export function useDeleteCaseClaimLink() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: number) => {
+      const { data, error } = await supabase
+        .from(TABLE)
+        .select('case_id')
+        .eq('id', id)
+        .single();
+      if (error) throw error;
+      const caseId = data.case_id as number;
+      const { error: delErr } = await supabase.from(TABLE).delete().eq('id', id);
+      if (delErr) throw delErr;
+      return caseId;
+    },
+    onSuccess: (caseId) =>
+      qc.invalidateQueries({ queryKey: [TABLE, caseId] }),
+  });
+}

--- a/src/features/courtCase/AddCourtCaseFormAntd.tsx
+++ b/src/features/courtCase/AddCourtCaseFormAntd.tsx
@@ -27,7 +27,7 @@ import { useAddCaseClaims } from "@/entities/courtCaseClaim";
 import { useCaseUids, getOrCreateCaseUid } from "@/entities/courtCaseUid";
 import CourtCaseClaimsTable from "@/widgets/CourtCaseClaimsTable";
 import CourtCasePartiesTable from "@/widgets/CourtCasePartiesTable";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useProjectId } from "@/shared/hooks/useProjectId";
 import { useAuthStore } from "@/shared/store/authStore";
 import FileDropZone from "@/shared/ui/FileDropZone";
@@ -35,6 +35,8 @@ import { useNotify } from "@/shared/hooks/useNotify";
 import { useCaseFiles } from "./model/useCaseFiles";
 import { useAddCaseParties } from "@/entities/courtCaseParty";
 import type { CasePartyRole } from "@/shared/types/courtCaseParty";
+import { useAddCaseClaimLinks } from "@/entities/courtCaseClaimLink";
+import { supabase } from "@/shared/api/supabaseClient";
 
 /**
  * Props for {@link AddCourtCaseFormAntd} component.
@@ -63,6 +65,7 @@ export default function AddCourtCaseFormAntd({
   const projectId = projectIdStr != null ? Number(projectIdStr) : null;
   const buildingWatch = Form.useWatch("building", form) ?? null;
   const buildingDebounced = useDebounce(buildingWatch);
+  const unitIdsWatch: number[] = Form.useWatch("unit_ids", form) || [];
   const profileId = useAuthStore((s) => s.profile?.id);
   const prevProjectIdRef = useRef<number | null>(null);
 
@@ -119,8 +122,38 @@ export default function AddCourtCaseFormAntd({
   const updateCaseMutation = useUpdateCourtCase();
   const addClaimsMutation = useAddCaseClaims();
   const addPartiesMutation = useAddCaseParties();
+  const addClaimLinksMutation = useAddCaseClaimLinks();
   const notify = useNotify();
   const qc = useQueryClient();
+
+  const { data: relatedClaims = [], isPending: relatedClaimsLoading } = useQuery({
+    queryKey: ["claims-for-case", projectId, unitIdsWatch.join(",")],
+    enabled: !!projectId,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("claims")
+        .select("id, claim_no, claim_units(unit_id)")
+        .eq("project_id", projectId as number);
+      if (error) throw error;
+      return (data ?? []).map((r: any) => ({
+        id: r.id,
+        claim_no: r.claim_no,
+        unit_ids: (r.claim_units ?? []).map((u: any) => u.unit_id),
+      }));
+    },
+  });
+
+  const relatedClaimOptions = React.useMemo(
+    () =>
+      relatedClaims
+        .filter((c: any) =>
+          unitIdsWatch.length
+            ? c.unit_ids.some((u: number) => unitIdsWatch.includes(u))
+            : true,
+        )
+        .map((c: any) => ({ value: c.id, label: c.claim_no })),
+    [relatedClaims, unitIdsWatch],
+  );
 
   // Set default litigation stage when loaded
   useEffect(() => {
@@ -211,6 +244,13 @@ export default function AddCourtCaseFormAntd({
             paid_amount: c.paid_amount ? Number(c.paid_amount) : null,
             agreed_amount: c.agreed_amount ? Number(c.agreed_amount) : null,
           })),
+        );
+      }
+
+      const linked: number[] = values.related_claim_ids || [];
+      if (linked.length) {
+        await addClaimLinksMutation.mutateAsync(
+          linked.map((id: number) => ({ case_id: newCase.id, claim_id: id })),
         );
       }
 
@@ -403,6 +443,21 @@ export default function AddCourtCaseFormAntd({
             />
           )}
         </Form.List>
+        <Form.Item name="related_claim_ids" label="Связанные претензии">
+          <Select
+            mode="multiple"
+            allowClear
+            showSearch
+            loading={relatedClaimsLoading}
+            options={relatedClaimOptions}
+            filterOption={(i, o) =>
+              String(o?.label ?? '')
+                .toLowerCase()
+                .includes(i.toLowerCase())
+            }
+            disabled={!projectId}
+          />
+        </Form.Item>
         {/* Row 7 */}
         <Row gutter={16}>
           <Col span={24}>

--- a/src/shared/types/courtCaseClaimLink.ts
+++ b/src/shared/types/courtCaseClaimLink.ts
@@ -1,0 +1,10 @@
+export interface CourtCaseClaimLink {
+  /** Уникальный идентификатор связи */
+  id: number;
+  /** Идентификатор судебного дела */
+  case_id: number;
+  /** Идентификатор претензии */
+  claim_id: number;
+  /** Дата создания связи */
+  created_at?: string | null;
+}


### PR DESCRIPTION
## Summary
- support linking existing claims to a court case
- store case-claim relations in `court_case_claim_links`

## Testing
- `npm run lint`
- `npx tsc --noEmit` *(fails: GenericStringError, removeCaseFile, etc.)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68695d80bf5c832e86ca96d0509e5e41