### PR TITLE
Update related claims block width and defects table

### DIFF
--- a/src/features/courtCase/AddCourtCaseFormAntd.tsx
+++ b/src/features/courtCase/AddCourtCaseFormAntd.tsx
@@ -418,12 +418,16 @@ export default function AddCourtCaseFormAntd({
           )}
         </Form.List>
         <Form.Item label="Связанные претензии">
-          <RelatedClaimsList
-            projectId={projectId}
-            unitIds={unitIdsWatch}
-            value={relatedIdsWatch}
-            onChange={(ids) => form.setFieldValue('related_claim_ids', ids)}
-          />
+          <div style={{ maxWidth: 1040 }}>
+            <RelatedClaimsList
+              projectId={projectId}
+              unitIds={unitIdsWatch}
+              value={relatedIdsWatch}
+              onChange={(ids) =>
+                form.setFieldValue('related_claim_ids', ids)
+              }
+            />
+          </div>
         </Form.Item>
         {/* Row 7 */}
         <Row gutter={16}>

--- a/src/features/courtCase/RelatedClaimsList.tsx
+++ b/src/features/courtCase/RelatedClaimsList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import dayjs from 'dayjs';
-import { Table, Switch, Space, Typography, Button } from 'antd';
+import { Table, Typography, Button } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { DownOutlined, EyeOutlined } from '@ant-design/icons';
 import { useQuery } from '@tanstack/react-query';
@@ -51,7 +51,8 @@ export default function RelatedClaimsList({
         .select(
           `id, claim_no, claimed_on, claim_status_id, statuses(name), claim_units(unit_id), claim_defects(defect_id)`
         )
-        .eq('project_id', projectId as number);
+        .eq('project_id', projectId as number)
+        .eq('pre_trial_claim', true);
       if (error) throw error;
       return (data ?? []).map((r: any) => ({
         id: r.id,
@@ -64,15 +65,9 @@ export default function RelatedClaimsList({
     },
   });
 
-  const [onlyObject, setOnlyObject] = React.useState(false);
   const [viewId, setViewId] = React.useState<number | null>(null);
 
-  const filtered = React.useMemo(() => {
-    if (!onlyObject) return claims;
-    return claims.filter((c) =>
-      c.unit_ids.some((u) => unitIds.includes(u))
-    );
-  }, [claims, onlyObject, unitIds]);
+  const filtered = React.useMemo(() => claims, [claims]);
 
   const columns: ColumnsType<ClaimRow> = [
     { title: '№ претензии', dataIndex: 'claim_no', width: 120 },
@@ -105,10 +100,6 @@ export default function RelatedClaimsList({
 
   return (
     <>
-      <Space style={{ marginBottom: 8 }} align="center">
-        <Typography.Text>Только выбранный объект</Typography.Text>
-        <Switch checked={onlyObject} onChange={setOnlyObject} />
-      </Space>
       <Table<ClaimRow>
         rowKey="id"
         columns={columns}

--- a/src/widgets/DefectsCompactTable.tsx
+++ b/src/widgets/DefectsCompactTable.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { Table } from 'antd';
+import { Table, Button } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import type { DefectWithNames } from '@/shared/types/defectWithNames';
+import { EyeOutlined } from '@ant-design/icons';
+import DefectViewModal from '@/features/defect/DefectViewModal';
 
 interface Props {
   /** Список дефектов для отображения */
@@ -10,6 +12,7 @@ interface Props {
 
 /** Краткая таблица дефектов. Показывает только тип, описание и статус. */
 export default function DefectsCompactTable({ defects }: Props) {
+  const [viewId, setViewId] = React.useState<number | null>(null);
   const columns: ColumnsType<DefectWithNames> = [
     {
       title: 'Тип',
@@ -24,14 +27,34 @@ export default function DefectsCompactTable({ defects }: Props) {
       render: (v: string | null) => v || '—',
       width: 160,
     },
+    {
+      title: '',
+      dataIndex: 'actions',
+      width: 60,
+      render: (_: unknown, row) => (
+        <Button
+          size="small"
+          type="text"
+          icon={<EyeOutlined />}
+          onClick={() => setViewId(row.id)}
+        />
+      ),
+    },
   ];
   return (
-    <Table
-      rowKey="id"
-      columns={columns}
-      dataSource={defects}
-      pagination={false}
-      size="small"
-    />
+    <>
+      <Table
+        rowKey="id"
+        columns={columns}
+        dataSource={defects}
+        pagination={false}
+        size="small"
+      />
+      <DefectViewModal
+        open={viewId !== null}
+        defectId={viewId}
+        onClose={() => setViewId(null)}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- match the width of related claims block with the claims table
- show only pre-trial claims when linking court cases
- remove object filter switch in related claims list
- allow viewing defects from the expandable table

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Missing script)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686a112739ac832eb243b4e7a6c36539