### PR TITLE
Добавление поля engineer_id в дефекты

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -819,6 +819,13 @@
     "column_default": null
   },
   {
+    "table_name": "defects",
+    "column_name": "engineer_id",
+    "data_type": "uuid",
+    "is_nullable": "YES",
+    "column_default": null
+  },
+  {
     "table_name": "lawsuit_claim_types",
     "column_name": "id",
     "data_type": "bigint",

--- a/db_indexes_summary.md
+++ b/db_indexes_summary.md
@@ -76,6 +76,7 @@
 
 ## defects
 - `defects_pkey` - `UNIQUE id`
+- `idx_defects_engineer` - `engineer_id`
 
 ## lawsuit_claim_types
 - `lawsuit_claim_types_pkey` - `UNIQUE id`

--- a/sql/add_engineer_to_defects.sql
+++ b/sql/add_engineer_to_defects.sql
@@ -1,0 +1,9 @@
+-- Добавление колонки engineer_id в таблицу defects
+ALTER TABLE IF EXISTS defects
+  ADD COLUMN IF NOT EXISTS engineer_id uuid;
+
+ALTER TABLE IF EXISTS defects
+  ADD CONSTRAINT fk_defects_engineer
+  FOREIGN KEY (engineer_id) REFERENCES profiles(id);
+
+CREATE INDEX IF NOT EXISTS idx_defects_engineer ON defects(engineer_id);

--- a/src/entities/defect.ts
+++ b/src/entities/defect.ts
@@ -26,6 +26,7 @@ export interface NewDefect {
   fixed_by: string | null;
   /** Уникальный идентификатор судебного дела */
   case_uid_id?: number | null;
+  engineer_id: string | null;
 }
 
 const TABLE = 'defects';
@@ -41,10 +42,10 @@ export function useDefects() {
       const rows = await fetchPaged<DefectRecord>((from, to) =>
         supabase
           .from(TABLE)
-          .select(
-            'id, description, type_id, status_id, project_id, unit_id, created_by, updated_by, updated_at, brigade_id, contractor_id, is_warranty, received_at, fixed_at, fixed_by, created_at,' +
-              ' defect_type:defect_types!fk_defects_type(id,name), defect_status:statuses!fk_defects_status(id,name,color), fixed_by_user:profiles!fk_defects_fixed_by(id,name)'
-          )
+        .select(
+          'id, description, type_id, status_id, project_id, unit_id, created_by, updated_by, updated_at, brigade_id, contractor_id, is_warranty, received_at, fixed_at, fixed_by, engineer_id, created_at,' +
+            ' defect_type:defect_types!fk_defects_type(id,name), defect_status:statuses!fk_defects_status(id,name,color), fixed_by_user:profiles!fk_defects_fixed_by(id,name)'
+        )
           .order('id', { ascending: false })
           .range(from, to) as unknown as PromiseLike<PostgrestSingleResponse<DefectRecord[]>>,
       );
@@ -68,7 +69,7 @@ export function useDefect(id?: number) {
       const { data, error } = await supabase
         .from(TABLE)
         .select(
-          'id, description, type_id, status_id, project_id, unit_id, created_by, updated_by, updated_at, brigade_id, contractor_id, is_warranty, received_at, fixed_at, fixed_by, created_at,' +
+          'id, description, type_id, status_id, project_id, unit_id, created_by, updated_by, updated_at, brigade_id, contractor_id, is_warranty, received_at, fixed_at, fixed_by, engineer_id, created_at,' +
           ' defect_type:defect_types!fk_defects_type(id,name), defect_status:statuses!fk_defects_status(id,name,color), fixed_by_user:profiles!fk_defects_fixed_by(id,name)'
         )
         .eq('id', id as number)
@@ -82,7 +83,10 @@ export function useDefect(id?: number) {
         .eq('defect_id', id as number);
       if (attachErr) throw attachErr;
       const attachments = (attachRows ?? []).map((r: any) => r.attachments);
-      return { ...(data as any), attachments } as DefectWithFiles;
+      return {
+        ...(data as any),
+        attachments,
+      } as DefectWithFiles;
     },
     staleTime: 5 * 60_000,
   });
@@ -123,7 +127,7 @@ export function useDefectsWithNames(ids?: number[]) {
       const { data, error } = await supabase
         .from(TABLE)
         .select(
-          'id, description, type_id, status_id, project_id, unit_id, created_by, updated_by, updated_at, brigade_id, contractor_id, is_warranty, received_at, fixed_at, fixed_by, defect_type:defect_types!fk_defects_type(id,name), defect_status:statuses!fk_defects_status(id,name,color), fixed_by_user:profiles!fk_defects_fixed_by(id,name)'
+          'id, description, type_id, status_id, project_id, unit_id, created_by, updated_by, updated_at, brigade_id, contractor_id, is_warranty, received_at, fixed_at, fixed_by, engineer_id, defect_type:defect_types!fk_defects_type(id,name), defect_status:statuses!fk_defects_status(id,name,color), fixed_by_user:profiles!fk_defects_fixed_by(id,name)'
         )
         .in('id', ids as number[]);
       if (error) throw error;
@@ -143,6 +147,7 @@ export function useDefectsWithNames(ids?: number[]) {
         received_at: d.received_at,
         fixed_at: d.fixed_at,
         fixed_by: d.fixed_by,
+        engineer_id: d.engineer_id,
         defectTypeName: d.defect_type?.name ?? null,
         defectStatusName: d.defect_status?.name ?? null,
         defectStatusColor: d.defect_status?.color ?? null,
@@ -277,6 +282,7 @@ export function useFixDefect() {
       brigade_id,
       contractor_id,
       fixed_at,
+      engineer_id,
       attachments = [],
       removedAttachmentIds = [],
       updatedAttachments = [],
@@ -285,6 +291,7 @@ export function useFixDefect() {
       brigade_id: number | null;
       contractor_id: number | null;
       fixed_at: string | null;
+      engineer_id: string | null;
       attachments: { file: File; type_id: number | null }[];
       removedAttachmentIds?: number[];
       updatedAttachments?: { id: number; type_id: number | null }[];
@@ -345,6 +352,7 @@ export function useFixDefect() {
           brigade_id,
           contractor_id,
           fixed_at,
+          engineer_id,
           fixed_by: userId,
           status_id: checkingId,
           updated_by: userId ?? undefined,

--- a/src/features/claim/ClaimFormAntd.tsx
+++ b/src/features/claim/ClaimFormAntd.tsx
@@ -220,6 +220,7 @@ export default function ClaimFormAntd({ onCreated, initialValues = {}, showDefec
       fixed_at: d.fixed_at ? d.fixed_at.format('YYYY-MM-DD') : null,
       fixed_by: null,
       case_uid_id: values.case_uid_id ?? null,
+      engineer_id: values.engineer_id ?? null,
     }));
     const defectIds = await createDefects.mutateAsync(newDefs);
     if (defectIds.length !== newDefs.length) {

--- a/src/features/claim/ClaimViewModal.tsx
+++ b/src/features/claim/ClaimViewModal.tsx
@@ -218,6 +218,7 @@ export default function ClaimViewModal({ open, claimId, onClose }: Props) {
         ...d,
         unit_id: unitId,
         created_by: userId,
+        engineer_id: null,
         tmpId: tmpIdRef.current--,
       })),
     ]);

--- a/src/features/defect/DefectAddModal.tsx
+++ b/src/features/defect/DefectAddModal.tsx
@@ -36,6 +36,7 @@ export default function DefectAddModal({ open, projectId, defaultReceivedAt, onC
       received_at: d.received_at ? dayjs(d.received_at).format('YYYY-MM-DD') : null,
       fixed_at: d.fixed_at ? dayjs(d.fixed_at).format('YYYY-MM-DD') : null,
       fixed_by: null,
+      engineer_id: null,
     }));
     onSubmit(defs);
     form.resetFields();

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -161,6 +161,7 @@ export default function DefectsPage() {
         ),
         hasPretrialClaim: hasPretrial,
         createdByName: userMap.get(d.created_by as string) ?? null,
+        engineerName: userMap.get(d.engineer_id as string) ?? null,
         unitIds,
         unitNames,
         unitNamesList,
@@ -237,8 +238,9 @@ export default function DefectsPage() {
       statuses: uniqPairs(
         filtered('statusId').map((d) => [d.status_id, d.defectStatusName]),
       ),
-        fixBy: mapStrOptions(filtered('fixBy').map((d) => d.fixByName)),
-      };
+      fixBy: mapStrOptions(filtered('fixBy').map((d) => d.fixByName)),
+      engineers: mapStrOptions(filtered('engineer').map((d) => d.engineerName)),
+    };
   }, [filteredData, filters, units, projects]);
   const [viewId, setViewId] = useState<number | null>(null);
   const [fixId, setFixId] = useState<number | null>(null);
@@ -362,6 +364,13 @@ const LS_COLUMN_WIDTHS_KEY = "defectsColumnWidths";
         width: 180,
         sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
           (a.fixByName || "").localeCompare(b.fixByName || ""),
+      },
+      engineer: {
+        title: "Закрепленный инженер",
+        dataIndex: "engineerName",
+        width: 180,
+        sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
+          (a.engineerName || "").localeCompare(b.engineerName || ""),
       },
       received: {
         title: "Дата получения",
@@ -487,6 +496,7 @@ const LS_COLUMN_WIDTHS_KEY = "defectsColumnWidths";
     "received",
     "createdAt",
     "createdByName",
+    "engineer",
     "created",
     "actions",
   ] as const;

--- a/src/shared/types/defect.ts
+++ b/src/shared/types/defect.ts
@@ -34,6 +34,8 @@ export interface DefectRecord {
   created_at: string | null;
   /** Уникальный идентификатор судебного дела */
   case_uid_id?: number | null;
+  /** Закрепленный инженер */
+  engineer_id: string | null;
 }
 
 /** Дефект с дополнительной информацией для отображения */
@@ -58,6 +60,8 @@ export interface DefectWithInfo extends DefectRecord {
   defectStatusColor?: string | null;
   /** Название исполнителя */
   fixByName?: string;
+  /** Имя закрепленного инженера */
+  engineerName?: string | null;
   /** Пользователь, подтвердивший устранение */
   fixedByUserName?: string | null;
   /** Идентификаторы проектов, связанные с замечаниями */

--- a/src/shared/types/defectFilters.ts
+++ b/src/shared/types/defectFilters.ts
@@ -9,6 +9,7 @@ export interface DefectFilters {
   typeId?: number[];
   statusId?: number[];
   fixBy?: string[];
+  engineer?: string;
   /** Корпус */
   building?: string[];
   period?: [Dayjs, Dayjs];

--- a/src/shared/types/defectWithFiles.ts
+++ b/src/shared/types/defectWithFiles.ts
@@ -8,4 +8,6 @@ export interface DefectWithFiles extends DefectRecord {
   defect_type?: { id: number; name: string } | null;
   /** Статус дефекта */
   defect_status?: { id: number; name: string; color: string | null } | null;
+  /** Имя закрепленного инженера */
+  engineerName?: string | null;
 }

--- a/src/shared/types/defectWithNames.ts
+++ b/src/shared/types/defectWithNames.ts
@@ -9,8 +9,10 @@ export interface DefectWithNames {
   received_at: string | null;
   fixed_at: string | null;
   fixed_by: string | null;
+  engineer_id: string | null;
   defectTypeName: string | null;
   defectStatusName: string | null;
   defectStatusColor: string | null;
   fixedByUserName?: string | null;
+  engineerName?: string | null;
 }

--- a/src/shared/utils/defectFilter.ts
+++ b/src/shared/utils/defectFilter.ts
@@ -15,6 +15,7 @@ export function filterDefects<T extends {
   status_id: number | null;
   defectStatusName?: string;
   fixByName?: string;
+  engineerName?: string | null;
   buildingNamesList?: string[];
 }>(rows: T[], f: DefectFilters): T[] {
   return rows.filter((d) => {
@@ -61,6 +62,9 @@ export function filterDefects<T extends {
       f.fixBy.length > 0 &&
       (!d.fixByName || !f.fixBy.includes(d.fixByName))
     ) {
+      return false;
+    }
+    if (f.engineer && d.engineerName !== f.engineer) {
       return false;
     }
     if (f.period && f.period.length === 2) {

--- a/src/widgets/DefectsFilters.tsx
+++ b/src/widgets/DefectsFilters.tsx
@@ -14,6 +14,7 @@ interface Options {
   types: { label: string; value: number }[];
   statuses: { label: string; value: number }[];
   fixBy: { label: string; value: string }[];
+  engineers: { label: string; value: string }[];
   buildings: { label: string; value: string }[];
 }
 
@@ -98,6 +99,9 @@ export default function DefectsFilters({
       </Form.Item>
       <Form.Item name="fixBy" label="Кем устраняется">
         <Select mode="multiple" allowClear options={options.fixBy} showSearch optionFilterProp="label" />
+      </Form.Item>
+      <Form.Item name="engineer" label="Закрепленный инженер">
+        <Select allowClear options={options.engineers} showSearch optionFilterProp="label" />
       </Form.Item>
       <Form.Item name="hideClosed" label="Скрыть закрытые" valuePropName="checked">
         <Switch />


### PR DESCRIPTION
## Summary
- расширена структура таблицы `defects` добавлением `engineer_id`
- обновлены типы дефектов и фильтры
- реализовано сохранение закрепленного инженера при создании претензии и подтверждении устранения дефекта
- добавлена колонка и фильтр "Закрепленный инженер" на странице дефектов
- создан SQL-скрипт для миграции
- исправлена ошибка запроса из-за отсутствия отношения к профилям

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Missing script)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686a2714d778832eb0d67e3566e94aaf