### PR TITLE
feat: extend user stats on dashboard

### DIFF
--- a/src/shared/types/userStats.ts
+++ b/src/shared/types/userStats.ts
@@ -7,6 +7,13 @@ export interface StatusCount {
 export interface UserStats {
   claimCount: number;
   defectCount: number;
+  claimResponsibleCount: number;
+  defectResponsibleCount: number;
+  courtCaseCount: number;
+  courtCaseResponsibleCount: number;
   claimStatusCounts: StatusCount[];
+  claimResponsibleStatusCounts: StatusCount[];
   defectStatusCounts: StatusCount[];
+  defectResponsibleStatusCounts: StatusCount[];
+  courtCaseStatusCounts: StatusCount[];
 }

--- a/src/widgets/UserStatsBlock.tsx
+++ b/src/widgets/UserStatsBlock.tsx
@@ -113,10 +113,41 @@ export default function UserStatsBlock() {
                   <span>{s.count}</span>
                 </div>
               ))}
+              <Statistic title="Замечаний за инженером" value={data.claimResponsibleCount} style={{ marginTop: 8 }} />
+              {data.claimResponsibleStatusCounts.map((s) => (
+                <div
+                  key={`cr-${s.statusId}`}
+                  style={{ display: 'flex', justifyContent: 'space-between' }}
+                >
+                  <span>{s.statusName ?? 'Без статуса'}</span>
+                  <span>{s.count}</span>
+                </div>
+              ))}
               <Statistic title="Создано дефектов" value={data.defectCount} style={{ marginTop: 8 }} />
               {data.defectStatusCounts.map((s) => (
                 <div
                   key={`d-${s.statusId}`}
+                  style={{ display: 'flex', justifyContent: 'space-between' }}
+                >
+                  <span>{s.statusName ?? 'Без статуса'}</span>
+                  <span>{s.count}</span>
+                </div>
+              ))}
+              <Statistic title="Дефектов за инженером" value={data.defectResponsibleCount} style={{ marginTop: 8 }} />
+              {data.defectResponsibleStatusCounts.map((s) => (
+                <div
+                  key={`dr-${s.statusId}`}
+                  style={{ display: 'flex', justifyContent: 'space-between' }}
+                >
+                  <span>{s.statusName ?? 'Без статуса'}</span>
+                  <span>{s.count}</span>
+                </div>
+              ))}
+              <Statistic title="Создано судебных дел" value={data.courtCaseCount} style={{ marginTop: 8 }} />
+              <Statistic title="Судебных дел за юристом" value={data.courtCaseResponsibleCount} style={{ marginTop: 8 }} />
+              {data.courtCaseStatusCounts.map((s) => (
+                <div
+                  key={`cc-${s.statusId}`}
                   style={{ display: 'flex', justifyContent: 'space-between' }}
                 >
                   <span>{s.statusName ?? 'Без статуса'}</span>


### PR DESCRIPTION
## Summary
- support court case status fetching in user stats
- add responsible metrics for claims, defects and court cases
- display new metrics in the user statistics block

## Testing
- `npm run lint`
- `npm test`
- `npx tsc --noEmit` *(fails: conversion and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_686a4712ba3c832e90724988529370d6