### PR TITLE
feat: improved dashboard user stats

### DIFF
--- a/src/entities/user.ts
+++ b/src/entities/user.ts
@@ -21,10 +21,16 @@ export const useUsers = () => {
                 .select(FIELDS)
                 .order('id');
             if (error) throw error;
-            return (data ?? []).map((u: any) => ({
+            const users = (data ?? []).map((u: any) => ({
                 ...u,
                 project_ids: u.profiles_projects?.map((p: any) => p.project_id) ?? [],
             }));
+            users.sort((a: any, b: any) => {
+                const an = a.name ?? a.email ?? '';
+                const bn = b.name ?? b.email ?? '';
+                return an.localeCompare(bn);
+            });
+            return users;
         },
         staleTime: 5 * 60_000,
     });

--- a/src/pages/DashboardPage/DashboardPage.tsx
+++ b/src/pages/DashboardPage/DashboardPage.tsx
@@ -37,7 +37,7 @@ export default function DashboardPage() {
         <ProjectStatsCard key={id} projectId={id} />
       ))}
 
-      <UserStatsBlock />
+      <UserStatsBlock projectIds={selected} />
     </Space>
   );
 }

--- a/src/shared/hooks/useUserStats.ts
+++ b/src/shared/hooks/useUserStats.ts
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient, useQueries } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { supabase } from '@/shared/api/supabaseClient';
 import { fetchPaged } from '@/shared/api/fetchAll';
@@ -6,6 +6,174 @@ import { useClaimStatuses } from '@/entities/claimStatus';
 import { useDefectStatuses } from '@/entities/defectStatus';
 import { useCourtCaseStatuses } from '@/entities/courtCaseStatus';
 import type { UserStats, StatusCount } from '@/shared/types/userStats';
+
+export async function fetchUserStats(
+  userId: string,
+  from: string,
+  to: string,
+  claimStatuses: ReturnType<typeof useClaimStatuses>['data'],
+  defectStatuses: ReturnType<typeof useDefectStatuses>['data'],
+  caseStatuses: ReturnType<typeof useCourtCaseStatuses>['data'],
+) {
+  const [claimRows, defectRows, claimRespRows, defectRespRows, caseRows, caseRespRows] =
+    await Promise.all([
+      fetchPaged<any>((f, t) =>
+        supabase
+          .from('claims')
+          .select('id, claim_status_id, created_at')
+          .eq('created_by', userId)
+          .gte('created_at', from)
+          .lte('created_at', to)
+          .order('id')
+          .range(f, t),
+      ),
+      fetchPaged<any>((f, t) =>
+        supabase
+          .from('claims')
+          .select('id, claim_status_id, created_at')
+          .eq('engineer_id', userId)
+          .gte('created_at', from)
+          .lte('created_at', to)
+          .order('id')
+          .range(f, t),
+      ),
+      fetchPaged<any>((f, t) =>
+        supabase
+          .from('defects')
+          .select('id, status_id, created_at')
+          .eq('engineer_id', userId)
+          .gte('created_at', from)
+          .lte('created_at', to)
+          .order('id')
+          .range(f, t),
+      ),
+      fetchPaged<any>((f, t) =>
+        supabase
+          .from('court_cases')
+          .select('id, status, created_at')
+          .eq('created_by', userId)
+          .gte('created_at', from)
+          .lte('created_at', to)
+          .order('id')
+          .range(f, t),
+      ),
+      fetchPaged<any>((f, t) =>
+        supabase
+          .from('court_cases')
+          .select('id, status, created_at')
+          .eq('responsible_lawyer_id', userId)
+          .gte('created_at', from)
+          .lte('created_at', to)
+          .order('id')
+          .range(f, t),
+      ),
+      fetchPaged<any>((f, t) =>
+        supabase
+          .from('defects')
+          .select('id, status_id, created_at')
+          .eq('created_by', userId)
+          .gte('created_at', from)
+          .lte('created_at', to)
+          .order('id')
+          .range(f, t),
+      ),
+    ]);
+
+  const claimMap: Record<string, number> = {};
+  const claimRespMap: Record<string, number> = {};
+  claimRows.forEach((r: any) => {
+    const id = r.claim_status_id ?? 'null';
+    claimMap[id] = (claimMap[id] || 0) + 1;
+  });
+  claimRespRows.forEach((r: any) => {
+    const id = r.claim_status_id ?? 'null';
+    claimRespMap[id] = (claimRespMap[id] || 0) + 1;
+  });
+  const defectMap: Record<string, number> = {};
+  const defectRespMap: Record<string, number> = {};
+  defectRows.forEach((r: any) => {
+    const id = r.status_id ?? 'null';
+    defectMap[id] = (defectMap[id] || 0) + 1;
+  });
+  defectRespRows.forEach((r: any) => {
+    const id = r.status_id ?? 'null';
+    defectRespMap[id] = (defectRespMap[id] || 0) + 1;
+  });
+  const caseRespMap: Record<string, number> = {};
+  caseRespRows.forEach((r: any) => {
+    const id = r.status ?? 'null';
+    caseRespMap[id] = (caseRespMap[id] || 0) + 1;
+  });
+
+  const claimStatusCounts: StatusCount[] = Object.entries(claimMap).map(
+    ([id, count]) => ({
+      statusId: id === 'null' ? null : Number(id),
+      statusName:
+        id === 'null'
+          ? null
+          : claimStatuses?.find((s: any) => s.id === Number(id))?.name ?? null,
+      count,
+    }),
+  );
+
+  const defectStatusCounts: StatusCount[] = Object.entries(defectMap).map(
+    ([id, count]) => ({
+      statusId: id === 'null' ? null : Number(id),
+      statusName:
+        id === 'null'
+          ? null
+          : defectStatuses?.find((s: any) => s.id === Number(id))?.name ?? null,
+      count,
+    }),
+  );
+
+  const claimResponsibleStatusCounts: StatusCount[] = Object.entries(
+    claimRespMap,
+  ).map(([id, count]) => ({
+    statusId: id === 'null' ? null : Number(id),
+    statusName:
+      id === 'null'
+        ? null
+        : claimStatuses?.find((s: any) => s.id === Number(id))?.name ?? null,
+    count,
+  }));
+
+  const defectResponsibleStatusCounts: StatusCount[] = Object.entries(
+    defectRespMap,
+  ).map(([id, count]) => ({
+    statusId: id === 'null' ? null : Number(id),
+    statusName:
+      id === 'null'
+        ? null
+        : defectStatuses?.find((s: any) => s.id === Number(id))?.name ?? null,
+    count,
+  }));
+
+  const courtCaseStatusCounts: StatusCount[] = Object.entries(
+    caseRespMap,
+  ).map(([id, count]) => ({
+    statusId: id === 'null' ? null : Number(id),
+    statusName:
+      id === 'null'
+        ? null
+        : caseStatuses?.find((s: any) => s.id === Number(id))?.name ?? null,
+    count,
+  }));
+
+  return {
+    claimCount: claimRows.length,
+    defectCount: defectRows.length,
+    claimResponsibleCount: claimRespRows.length,
+    defectResponsibleCount: defectRespRows.length,
+    courtCaseCount: caseRows.length,
+    courtCaseResponsibleCount: caseRespRows.length,
+    claimStatusCounts,
+    claimResponsibleStatusCounts,
+    defectStatusCounts,
+    defectResponsibleStatusCounts,
+    courtCaseStatusCounts,
+  } as UserStats;
+}
 
 /**
  * Загружает статистику активности пользователя за выбранный период.
@@ -29,165 +197,15 @@ export function useUserStats(
   const query = useQuery<UserStats>({
     queryKey: ['user-stats', userId, from, to],
     enabled: !!userId && !!from && !!to,
-    queryFn: async () => {
-      const [claimRows, defectRows, claimRespRows, defectRespRows, caseRows, caseRespRows] = await Promise.all([
-        fetchPaged<any>((f, t) =>
-          supabase
-            .from('claims')
-            .select('id, claim_status_id, created_at')
-            .eq('created_by', userId as string)
-            .gte('created_at', from as string)
-            .lte('created_at', to as string)
-            .order('id')
-            .range(f, t),
-        ),
-        fetchPaged<any>((f, t) =>
-          supabase
-            .from('claims')
-            .select('id, claim_status_id, created_at')
-            .eq('engineer_id', userId as string)
-            .gte('created_at', from as string)
-            .lte('created_at', to as string)
-            .order('id')
-            .range(f, t),
-        ),
-        fetchPaged<any>((f, t) =>
-          supabase
-            .from('defects')
-            .select('id, status_id, created_at')
-            .eq('engineer_id', userId as string)
-            .gte('created_at', from as string)
-            .lte('created_at', to as string)
-            .order('id')
-            .range(f, t),
-        ),
-        fetchPaged<any>((f, t) =>
-          supabase
-            .from('court_cases')
-            .select('id, status, created_at')
-            .eq('created_by', userId as string)
-            .gte('created_at', from as string)
-            .lte('created_at', to as string)
-            .order('id')
-            .range(f, t),
-        ),
-        fetchPaged<any>((f, t) =>
-          supabase
-            .from('court_cases')
-            .select('id, status, created_at')
-            .eq('responsible_lawyer_id', userId as string)
-            .gte('created_at', from as string)
-            .lte('created_at', to as string)
-            .order('id')
-            .range(f, t),
-        ),
-        fetchPaged<any>((f, t) =>
-          supabase
-            .from('defects')
-            .select('id, status_id, created_at')
-            .eq('created_by', userId as string)
-            .gte('created_at', from as string)
-            .lte('created_at', to as string)
-            .order('id')
-            .range(f, t),
-        ),
-      ]);
-
-      const claimMap: Record<string, number> = {};
-      const claimRespMap: Record<string, number> = {};
-      claimRows.forEach((r: any) => {
-        const id = r.claim_status_id ?? 'null';
-        claimMap[id] = (claimMap[id] || 0) + 1;
-      });
-      claimRespRows.forEach((r: any) => {
-        const id = r.claim_status_id ?? 'null';
-        claimRespMap[id] = (claimRespMap[id] || 0) + 1;
-      });
-      const defectMap: Record<string, number> = {};
-      const defectRespMap: Record<string, number> = {};
-      defectRows.forEach((r: any) => {
-        const id = r.status_id ?? 'null';
-        defectMap[id] = (defectMap[id] || 0) + 1;
-      });
-      defectRespRows.forEach((r: any) => {
-        const id = r.status_id ?? 'null';
-        defectRespMap[id] = (defectRespMap[id] || 0) + 1;
-      });
-      const caseRespMap: Record<string, number> = {};
-      caseRespRows.forEach((r: any) => {
-        const id = r.status ?? 'null';
-        caseRespMap[id] = (caseRespMap[id] || 0) + 1;
-      });
-
-      const claimStatusCounts: StatusCount[] = Object.entries(claimMap).map(
-        ([id, count]) => ({
-          statusId: id === 'null' ? null : Number(id),
-          statusName:
-            id === 'null'
-              ? null
-              : claimStatuses.find((s) => s.id === Number(id))?.name ?? null,
-          count,
-        }),
-      );
-
-      const defectStatusCounts: StatusCount[] = Object.entries(defectMap).map(
-        ([id, count]) => ({
-          statusId: id === 'null' ? null : Number(id),
-          statusName:
-            id === 'null'
-              ? null
-              : defectStatuses.find((s) => s.id === Number(id))?.name ?? null,
-          count,
-        }),
-      );
-
-      const claimResponsibleStatusCounts: StatusCount[] = Object.entries(
-        claimRespMap,
-      ).map(([id, count]) => ({
-        statusId: id === 'null' ? null : Number(id),
-        statusName:
-          id === 'null'
-            ? null
-            : claimStatuses.find((s) => s.id === Number(id))?.name ?? null,
-        count,
-      }));
-
-      const defectResponsibleStatusCounts: StatusCount[] = Object.entries(
-        defectRespMap,
-      ).map(([id, count]) => ({
-        statusId: id === 'null' ? null : Number(id),
-        statusName:
-          id === 'null'
-            ? null
-            : defectStatuses.find((s) => s.id === Number(id))?.name ?? null,
-        count,
-      }));
-
-      const courtCaseStatusCounts: StatusCount[] = Object.entries(
-        caseRespMap,
-      ).map(([id, count]) => ({
-        statusId: id === 'null' ? null : Number(id),
-        statusName:
-          id === 'null'
-            ? null
-            : caseStatuses.find((s) => s.id === Number(id))?.name ?? null,
-        count,
-      }));
-
-      return {
-        claimCount: claimRows.length,
-        defectCount: defectRows.length,
-        claimResponsibleCount: claimRespRows.length,
-        defectResponsibleCount: defectRespRows.length,
-        courtCaseCount: caseRows.length,
-        courtCaseResponsibleCount: caseRespRows.length,
-        claimStatusCounts,
-        claimResponsibleStatusCounts,
-        defectStatusCounts,
-        defectResponsibleStatusCounts,
-        courtCaseStatusCounts,
-      } as UserStats;
-    },
+    queryFn: async () =>
+      fetchUserStats(
+        userId as string,
+        from as string,
+        to as string,
+        claimStatuses,
+        defectStatuses,
+        caseStatuses,
+      ),
     staleTime: 60_000,
   });
 
@@ -213,4 +231,38 @@ export function useUserStats(
   }, [userId, from, to, qc]);
 
   return query;
+}
+
+export function useMultipleUserStats(
+  userIds: string[],
+  period?: [string, string] | null,
+) {
+  const { data: claimStatuses = [] } = useClaimStatuses();
+  const { data: defectStatuses = [] } = useDefectStatuses();
+  const { data: caseStatuses = [] } = useCourtCaseStatuses();
+
+  const from = period?.[0] ?? null;
+  const to = period?.[1] ?? null;
+
+  const queries = useQueries({
+    queries: userIds.map((id) => ({
+      queryKey: ['user-stats', id, from, to],
+      enabled: !!from && !!to,
+      queryFn: () =>
+        fetchUserStats(
+          id,
+          from as string,
+          to as string,
+          claimStatuses,
+          defectStatuses,
+          caseStatuses,
+        ),
+      staleTime: 60_000,
+    })),
+  });
+
+  const isPending = queries.some((q) => q.isPending);
+  const data = queries.map((q) => q.data as UserStats | undefined);
+
+  return { data, isPending } as { data: (UserStats | undefined)[]; isPending: boolean };
 }


### PR DESCRIPTION
## Summary
- sort users alphabetically
- filter stats by selected projects
- support multiple users stats table on dashboard
- reuse multi user stats hook

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Missing script)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686a5522a278832eac59da677614d06f