### PR TITLE
Enhance user stats on dashboard

### DIFF
--- a/src/pages/DashboardPage/DashboardPage.tsx
+++ b/src/pages/DashboardPage/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Card, Typography, Skeleton, Space } from 'antd';
+import { Card, Typography, Skeleton, Space, Button } from 'antd';
 import { useSnackbar } from 'notistack';
 import { useVisibleProjects } from '@/entities/project';
 import { useAuthStore } from '@/shared/store/authStore';
@@ -13,6 +13,7 @@ export default function DashboardPage() {
   const { data: projects = [], isPending, error } = useVisibleProjects();
   const profile = useAuthStore((s) => s.profile);
   const [selected, setSelected] = React.useState<number[]>([]);
+  const [resetCounter, setResetCounter] = React.useState(0);
 
   useEffect(() => {
     if (error) enqueueSnackbar('Ошибка загрузки проектов.', { variant: 'error' });
@@ -20,8 +21,16 @@ export default function DashboardPage() {
 
   if (isPending) return <Skeleton active />;
 
+  const handleReset = () => {
+    setSelected([]);
+    setResetCounter((c) => c + 1);
+  };
+
   return (
     <Space direction="vertical" size="large" style={{ width: '100%' }}>
+      <Button onClick={handleReset} style={{ alignSelf: 'flex-start' }}>
+        Сбросить фильтры
+      </Button>
       <Card>
         <Typography.Title level={5} style={{ margin: 0 }}>
           Добро пожаловать, {profile?.name ?? profile?.email ?? 'гость'}!
@@ -37,7 +46,7 @@ export default function DashboardPage() {
         <ProjectStatsCard key={id} projectId={id} />
       ))}
 
-      <UserStatsBlock projectIds={selected} />
+      <UserStatsBlock projectIds={selected} resetSignal={resetCounter} />
     </Space>
   );
 }

--- a/src/widgets/UserStatsBlock.tsx
+++ b/src/widgets/UserStatsBlock.tsx
@@ -6,12 +6,15 @@ import {
   Select,
   DatePicker,
   Space,
+  Table,
   Skeleton,
   Statistic,
   Segmented,
 } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
 import ruRU from 'antd/locale/ru_RU';
 import { useUsers } from '@/entities/user';
+import { useRoles } from '@/entities/role';
 import { useMultipleUserStats } from '@/shared/hooks/useUserStats';
 import { Dayjs } from 'dayjs';
 
@@ -24,11 +27,15 @@ dayjs.locale('ru');
 
 export default function UserStatsBlock({
   projectIds,
+  resetSignal = 0,
 }: {
   projectIds?: number[];
+  resetSignal?: number;
 }) {
   const { data: users = [], isPending } = useUsers();
+  const { data: roles = [] } = useRoles();
   const [userIds, setUserIds] = React.useState<string[]>([]);
+  const [role, setRole] = React.useState<string | null>(null);
   const [range, setRange] = React.useState<[Dayjs, Dayjs] | null>(null);
   /** Выбранный предустановленный период. */
   const [preset, setPreset] = React.useState<'all' | 'month' | 'week' | null>(
@@ -59,11 +66,14 @@ export default function UserStatsBlock({
   }, [range]);
 
   const filteredUsers = React.useMemo(() => {
-    if (!projectIds?.length) return users;
-    return users.filter((u) =>
-      u.project_ids.some((pid) => projectIds.includes(pid)),
-    );
-  }, [users, projectIds]);
+    return users.filter((u) => {
+      const byProject =
+        !projectIds?.length ||
+        u.project_ids.some((pid) => projectIds.includes(pid));
+      const byRole = !role || u.role === role;
+      return byProject && byRole;
+    });
+  }, [users, projectIds, role]);
 
   const { data, isPending: loadingStats } = useMultipleUserStats(
     userIds,
@@ -75,14 +85,92 @@ export default function UserStatsBlock({
     label: u.name ?? u.email,
   }));
 
+  const roleOptions = roles.map((r) => ({ value: r.name, label: r.name }));
+
   React.useEffect(() => {
     setUserIds((ids) => ids.filter((id) => filteredUsers.some((u) => u.id === id)));
   }, [filteredUsers]);
 
+  React.useEffect(() => {
+    setUserIds([]);
+    setRange(null);
+    setPreset(null);
+    setRole(null);
+  }, [resetSignal]);
+
+  const tableData = React.useMemo(() =>
+    userIds.map((id, idx) => {
+      const stats = data?.[idx];
+      const u = filteredUsers.find((f) => f.id === id);
+      return {
+        key: id,
+        name: u?.name ?? u?.email ?? id,
+        claim: stats?.claimCount ?? 0,
+        claimResp: stats?.claimResponsibleCount ?? 0,
+        defect: stats?.defectCount ?? 0,
+        defectResp: stats?.defectResponsibleCount ?? 0,
+        caseCount: stats?.courtCaseCount ?? 0,
+        caseResp: stats?.courtCaseResponsibleCount ?? 0,
+      };
+    }),
+  [userIds, data, filteredUsers]);
+
+  const columns: ColumnsType<(typeof tableData)[number]> = [
+    {
+      title: 'Пользователь',
+      dataIndex: 'name',
+      sorter: (a, b) => String(a.name).localeCompare(String(b.name)),
+    },
+    {
+      title: 'Создано претензий',
+      dataIndex: 'claim',
+      align: 'right',
+      sorter: (a, b) => a.claim - b.claim,
+    },
+    {
+      title: 'Претензий за ним',
+      dataIndex: 'claimResp',
+      align: 'right',
+      sorter: (a, b) => a.claimResp - b.claimResp,
+    },
+    {
+      title: 'Создано дефектов',
+      dataIndex: 'defect',
+      align: 'right',
+      sorter: (a, b) => a.defect - b.defect,
+    },
+    {
+      title: 'Дефектов за ним',
+      dataIndex: 'defectResp',
+      align: 'right',
+      sorter: (a, b) => a.defectResp - b.defectResp,
+    },
+    {
+      title: 'Создано дел',
+      dataIndex: 'caseCount',
+      align: 'right',
+      sorter: (a, b) => a.caseCount - b.caseCount,
+    },
+    {
+      title: 'Дел за ним',
+      dataIndex: 'caseResp',
+      align: 'right',
+      sorter: (a, b) => a.caseResp - b.caseResp,
+    },
+  ];
+
   return (
     <ConfigProvider locale={ruRU}>
-      <Card title="Статистика пользователя" style={{ width: '100%' }}>
+      <Card title="Статистика пользователя" style={{ width: 1024 }}>
         <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+          <Select
+            allowClear
+            placeholder="Роль"
+            options={roleOptions}
+            value={role ?? undefined}
+            onChange={(val) => setRole(val)}
+            style={{ width: '100%' }}
+          />
           <Select
             mode="multiple"
             showSearch
@@ -103,7 +191,7 @@ export default function UserStatsBlock({
             ]}
             onChange={(val) => {
               setPreset(val as 'all' | 'month' | 'week');
-              setRange(presets[val as 'all' | 'month' | 'week']);
+              setRange(presets[val as 'all' | 'month' | 'week'] as [Dayjs, Dayjs]);
             }}
             value={preset ?? undefined}
             style={{ width: '100%' }}
@@ -121,36 +209,12 @@ export default function UserStatsBlock({
             <Skeleton active paragraph={{ rows: 2 }} />
           ) : null}
           {data && userIds.length && !loadingStats ? (
-            <table className="ant-table" style={{ width: '100%' }}>
-              <thead>
-                <tr>
-                  <th>Пользователь</th>
-                  <th>Создано претензий</th>
-                  <th>Претензий за ним</th>
-                  <th>Создано дефектов</th>
-                  <th>Дефектов за ним</th>
-                  <th>Создано дел</th>
-                  <th>Дел за ним</th>
-                </tr>
-              </thead>
-              <tbody>
-                {userIds.map((id, idx) => {
-                  const stats = data[idx];
-                  const u = filteredUsers.find((f) => f.id === id);
-                  return (
-                    <tr key={id}>
-                      <td>{u?.name ?? u?.email ?? id}</td>
-                      <td>{stats?.claimCount ?? 0}</td>
-                      <td>{stats?.claimResponsibleCount ?? 0}</td>
-                      <td>{stats?.defectCount ?? 0}</td>
-                      <td>{stats?.defectResponsibleCount ?? 0}</td>
-                      <td>{stats?.courtCaseCount ?? 0}</td>
-                      <td>{stats?.courtCaseResponsibleCount ?? 0}</td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
+            <Table
+              columns={columns}
+              dataSource={tableData}
+              pagination={false}
+              size="small"
+            />
           ) : null}
         </Space>
       </Card>


### PR DESCRIPTION
## Summary
- add Reset button on dashboard page
- include role filter and sort table in UserStatsBlock
- align stats table columns to the right and set card width
- allow resetting dashboard filters

## Testing
- `npm run lint`
- `npm test`
- `npx tsc -p tsconfig.json` *(fails: Conversion type errors)*

------
https://chatgpt.com/codex/tasks/task_e_686a59662540832e83a1c8e241664b9f