### PR TITLE
Enhance defects filters and Excel export

### DIFF
--- a/src/features/defect/ExportDefectsButton.tsx
+++ b/src/features/defect/ExportDefectsButton.tsx
@@ -48,17 +48,19 @@ export default function ExportDefectsButton({
       const rows = filtered.map((d) => ({
         'ID дефекта': d.id,
         'ID претензии': d.claimIds.join(', '),
+        'Прошло дней с даты получения': d.days ?? '',
         Проект: d.projectNames ?? '',
+        Корпус: d.buildingNames ?? '',
         Объекты: d.unitNames ?? '',
         Описание: d.description,
         Тип: d.defectTypeName ?? '',
         Статус: d.defectStatusName ?? '',
         'Кем устраняется': d.fixByName ?? '',
+        'Закрепленный инженер': d.engineerName ?? '',
         'Дата получения': d.received_at ? dayjs(d.received_at).format('DD.MM.YYYY') : '',
-        'Прошло дней с Даты получения': d.received_at
-          ? today.diff(dayjs(d.received_at), 'day') + 1
-          : '',
-        'Дата создания': d.created_at ? dayjs(d.created_at).format('DD.MM.YYYY') : '',
+        Добавлено: d.created_at ? dayjs(d.created_at).format('DD.MM.YYYY HH:mm') : '',
+        Автор: d.createdByName ?? '',
+        'Дата устранения': d.fixed_at ? dayjs(d.fixed_at).format('DD.MM.YYYY') : '',
         'Ссылки на файлы': (filesMap[d.id] ?? []).join('\n'),
       }));
       const wb = new ExcelJS.Workbook();

--- a/src/index.css
+++ b/src/index.css
@@ -18,6 +18,21 @@ body {
   gap: 16px;
 }
 
+.defects-filter-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(220px, 1fr));
+  grid-auto-flow: column;
+  gap: 16px;
+}
+
+.defects-filter-grid .MuiTextField-root,
+.defects-filter-grid .MuiFormControl-root,
+.defects-filter-grid .ant-input,
+.defects-filter-grid .ant-select,
+.defects-filter-grid button {
+  width: 100%;
+}
+
 .filter-grid .MuiTextField-root,
 .filter-grid .MuiFormControl-root,
 .filter-grid .ant-input,

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -219,15 +219,14 @@ export default function DefectsPage() {
     const unitMap = new Map(units.map((u) => [u.id, u.name]));
     const projectMap = new Map(projects.map((p) => [p.id, p.name]));
 
-      return {
-        ids: mapNumOptions(filtered('id').map((d) => d.id)),
-      units: Array.from(
-        new Set(filtered('units').flatMap((d) => d.unitIds)),
-      )
+    return {
+      ids: mapNumOptions(filtered('id').map((d) => d.id)),
+      claimIds: mapNumOptions(filtered('claimId').flatMap((d) => d.claimIds)),
+      units: Array.from(new Set(filtered('units').flatMap((d) => d.unitIds)))
         .map((id) => ({ label: unitMap.get(id) ?? String(id), value: id }))
         .sort((a, b) => naturalCompare(a.label, b.label)),
-        buildings: mapStrOptions(
-          filtered('building').flatMap((d) => d.buildingNamesList || []),
+      buildings: mapStrOptions(
+        filtered('building').flatMap((d) => d.buildingNamesList || []),
       ),
       projects: Array.from(
         new Set(filtered('projectId').flatMap((d) => d.projectIds || [])),
@@ -240,6 +239,7 @@ export default function DefectsPage() {
       ),
       fixBy: mapStrOptions(filtered('fixBy').map((d) => d.fixByName)),
       engineers: mapStrOptions(filtered('engineer').map((d) => d.engineerName)),
+      authors: mapStrOptions(filtered('author').map((d) => d.createdByName)),
     };
   }, [filteredData, filters, units, projects]);
   const [viewId, setViewId] = useState<number | null>(null);

--- a/src/shared/types/defectFilters.ts
+++ b/src/shared/types/defectFilters.ts
@@ -3,15 +3,25 @@ import { Dayjs } from 'dayjs';
 /** Набор фильтров для списка дефектов */
 export interface DefectFilters {
   id?: number[];
-  ticketId?: number[];
+  /** ID претензии */
+  claimId?: number[];
   units?: number[];
   projectId?: number[];
   typeId?: number[];
   statusId?: number[];
   fixBy?: string[];
   engineer?: string;
+  /** Автор дефекта */
+  author?: string[];
   /** Корпус */
   building?: string[];
+  /** Дата получения */
   period?: [Dayjs, Dayjs];
+  /** Дата создания */
+  createdPeriod?: [Dayjs, Dayjs];
+  /** Дата устранения */
+  fixedPeriod?: [Dayjs, Dayjs];
+  /** Поиск по описанию */
+  description?: string;
   hideClosed?: boolean;
 }

--- a/src/shared/utils/defectFilter.ts
+++ b/src/shared/utils/defectFilter.ts
@@ -10,32 +10,43 @@ export function filterDefects<T extends {
   unitIds: number[];
   created_at: string | null;
   received_at: string | null;
+  fixed_at: string | null;
   projectIds?: number[];
   type_id: number | null;
   status_id: number | null;
+  claimIds: number[];
   defectStatusName?: string;
   fixByName?: string;
   engineerName?: string | null;
+  createdByName?: string | null;
   buildingNamesList?: string[];
+  description: string;
 }>(rows: T[], f: DefectFilters): T[] {
   return rows.filter((d) => {
     if (Array.isArray(f.id) && f.id.length > 0 && !f.id.includes(d.id)) {
       return false;
     }
+  if (
+    Array.isArray(f.units) &&
+    f.units.length > 0 &&
+    !d.unitIds.some((u) => f.units!.includes(u))
+  ) {
+    return false;
+  }
     if (
-      Array.isArray(f.units) &&
-      f.units.length > 0 &&
-      !d.unitIds.some((u) => f.units!.includes(u))
+      Array.isArray(f.claimId) &&
+      f.claimId.length > 0 &&
+      !d.claimIds.some((c) => f.claimId!.includes(c))
     ) {
       return false;
     }
-    if (
-      Array.isArray(f.building) &&
-      f.building.length > 0 &&
-      (!d.buildingNamesList || !d.buildingNamesList.some((b) => f.building!.includes(b)))
-    ) {
-      return false;
-    }
+  if (
+    Array.isArray(f.building) &&
+    f.building.length > 0 &&
+    (!d.buildingNamesList || !d.buildingNamesList.some((b) => f.building!.includes(b)))
+  ) {
+    return false;
+  }
     if (
       Array.isArray(f.projectId) &&
       f.projectId.length > 0 &&
@@ -58,25 +69,49 @@ export function filterDefects<T extends {
       return false;
     }
     if (
-      Array.isArray(f.fixBy) &&
-      f.fixBy.length > 0 &&
-      (!d.fixByName || !f.fixBy.includes(d.fixByName))
+    Array.isArray(f.fixBy) &&
+    f.fixBy.length > 0 &&
+    (!d.fixByName || !f.fixBy.includes(d.fixByName))
+  ) {
+    return false;
+  }
+    if (
+      Array.isArray(f.author) &&
+      f.author.length > 0 &&
+      (!d.createdByName || !f.author.includes(d.createdByName))
     ) {
       return false;
     }
-    if (f.engineer && d.engineerName !== f.engineer) {
+  if (f.engineer && d.engineerName !== f.engineer) {
+    return false;
+  }
+  if (f.period && f.period.length === 2) {
+    const [from, to] = f.period;
+    const rec = dayjs(d.received_at);
+    if (!rec.isSameOrAfter(from, 'day') || !rec.isSameOrBefore(to, 'day')) {
       return false;
     }
-    if (f.period && f.period.length === 2) {
-      const [from, to] = f.period;
-      const rec = dayjs(d.received_at);
-      if (!rec.isSameOrAfter(from, 'day') || !rec.isSameOrBefore(to, 'day')) {
-        return false;
-      }
-    }
-    if (f.hideClosed && d.defectStatusName?.toLowerCase().includes('закры')) {
+  }
+  if (f.createdPeriod && f.createdPeriod.length === 2) {
+    const [from, to] = f.createdPeriod;
+    const c = dayjs(d.created_at);
+    if (!c.isSameOrAfter(from, 'day') || !c.isSameOrBefore(to, 'day')) {
       return false;
     }
-    return true;
+  }
+  if (f.fixedPeriod && f.fixedPeriod.length === 2) {
+    const [from, to] = f.fixedPeriod;
+    const fx = dayjs(d.fixed_at);
+    if (!fx.isSameOrAfter(from, 'day') || !fx.isSameOrBefore(to, 'day')) {
+      return false;
+    }
+  }
+  if (f.description && !d.description.toLowerCase().includes(f.description.toLowerCase())) {
+    return false;
+  }
+  if (f.hideClosed && d.defectStatusName?.toLowerCase().includes('закры')) {
+    return false;
+  }
+  return true;
   });
 }

--- a/src/widgets/DefectsFilters.tsx
+++ b/src/widgets/DefectsFilters.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Form, Select, Button, DatePicker, Switch } from 'antd';
+import { Form, Select, Button, DatePicker, Switch, Input } from 'antd';
 import type { DefectFilters } from '@/shared/types/defectFilters';
 
 const { RangePicker } = DatePicker;
@@ -9,12 +9,14 @@ const LS_HIDE_CLOSED_KEY = 'defectsHideClosed';
 
 interface Options {
   ids: { label: string; value: number }[];
+  claimIds: { label: string; value: number }[];
   units: { label: string; value: number }[];
   projects: { label: string; value: number }[];
   types: { label: string; value: number }[];
   statuses: { label: string; value: number }[];
   fixBy: { label: string; value: string }[];
   engineers: { label: string; value: string }[];
+  authors: { label: string; value: string }[];
   buildings: { label: string; value: string }[];
 }
 
@@ -75,11 +77,38 @@ export default function DefectsFilters({
   };
 
   return (
-    <Form form={form} layout="vertical" onValuesChange={handleValuesChange} className="filter-grid">
+    <Form form={form} layout="vertical" onValuesChange={handleValuesChange} className="defects-filter-grid">
       <Form.Item name="id" label="ID дефекта">
         <Select mode="multiple" allowClear options={options.ids} showSearch optionFilterProp="label" />
       </Form.Item>
-      <Form.Item name="projectId" label="Проекты">
+      <Form.Item name="claimId" label="ID претензии">
+        <Select mode="multiple" allowClear options={options.claimIds} showSearch optionFilterProp="label" />
+      </Form.Item>
+      <Form.Item name="statusId" label="Статус">
+        <Select mode="multiple" allowClear options={options.statuses} showSearch optionFilterProp="label" />
+      </Form.Item>
+
+      <Form.Item name="author" label="Автор">
+        <Select mode="multiple" allowClear options={options.authors} showSearch optionFilterProp="label" />
+      </Form.Item>
+      <Form.Item name="engineer" label="Закрепленный инженер">
+        <Select allowClear options={options.engineers} showSearch optionFilterProp="label" />
+      </Form.Item>
+      <Form.Item name="fixBy" label="Кем устраняется">
+        <Select mode="multiple" allowClear options={options.fixBy} showSearch optionFilterProp="label" />
+      </Form.Item>
+
+      <Form.Item name="createdPeriod" label="Добавлено">
+        <RangePicker style={{ width: '100%' }} format="DD.MM.YYYY" />
+      </Form.Item>
+      <Form.Item name="period" label="Дата получения">
+        <RangePicker style={{ width: '100%' }} format="DD.MM.YYYY" />
+      </Form.Item>
+      <Form.Item name="fixedPeriod" label="Дата устранения">
+        <RangePicker style={{ width: '100%' }} format="DD.MM.YYYY" />
+      </Form.Item>
+
+      <Form.Item name="projectId" label="Проект">
         <Select mode="multiple" allowClear options={options.projects} showSearch optionFilterProp="label" />
       </Form.Item>
       <Form.Item name="building" label="Корпус">
@@ -88,21 +117,14 @@ export default function DefectsFilters({
       <Form.Item name="units" label="Объекты">
         <Select mode="multiple" allowClear options={options.units} showSearch optionFilterProp="label" />
       </Form.Item>
-      <Form.Item name="statusId" label="Статус">
-        <Select mode="multiple" allowClear options={options.statuses} showSearch optionFilterProp="label" />
-      </Form.Item>
+
       <Form.Item name="typeId" label="Тип">
         <Select mode="multiple" allowClear options={options.types} showSearch optionFilterProp="label" />
       </Form.Item>
-      <Form.Item name="period" label="Дата получения">
-        <RangePicker style={{ width: '100%' }} format="DD.MM.YYYY" />
+      <Form.Item name="description" label="Описание">
+        <Input />
       </Form.Item>
-      <Form.Item name="fixBy" label="Кем устраняется">
-        <Select mode="multiple" allowClear options={options.fixBy} showSearch optionFilterProp="label" />
-      </Form.Item>
-      <Form.Item name="engineer" label="Закрепленный инженер">
-        <Select allowClear options={options.engineers} showSearch optionFilterProp="label" />
-      </Form.Item>
+
       <Form.Item name="hideClosed" label="Скрыть закрытые" valuePropName="checked">
         <Switch />
       </Form.Item>


### PR DESCRIPTION
## Summary
- add `defects-filter-grid` layout for /defects page
- extend `DefectFilters` with author, claim, and date ranges
- support new filters in `filterDefects`
- implement extended filter form layout
- export all table columns to Excel

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a74dfb5b4832e8b194af2151ed74a