### PR TITLE
Add defect filters and full export

### DIFF
--- a/src/features/defect/ExportDefectsButton.tsx
+++ b/src/features/defect/ExportDefectsButton.tsx
@@ -49,16 +49,20 @@ export default function ExportDefectsButton({
         'ID дефекта': d.id,
         'ID претензии': d.claimIds.join(', '),
         Проект: d.projectNames ?? '',
+        Корпус: d.buildingNames ?? '',
         Объекты: d.unitNames ?? '',
         Описание: d.description,
         Тип: d.defectTypeName ?? '',
         Статус: d.defectStatusName ?? '',
         'Кем устраняется': d.fixByName ?? '',
+        'Закрепленный инженер': d.engineerName ?? '',
+        Автор: d.createdByName ?? '',
         'Дата получения': d.received_at ? dayjs(d.received_at).format('DD.MM.YYYY') : '',
+        'Добавлено': d.created_at ? dayjs(d.created_at).format('DD.MM.YYYY HH:mm') : '',
+        'Дата устранения': d.fixed_at ? dayjs(d.fixed_at).format('DD.MM.YYYY') : '',
         'Прошло дней с Даты получения': d.received_at
           ? today.diff(dayjs(d.received_at), 'day') + 1
           : '',
-        'Дата создания': d.created_at ? dayjs(d.created_at).format('DD.MM.YYYY') : '',
         'Ссылки на файлы': (filesMap[d.id] ?? []).join('\n'),
       }));
       const wb = new ExcelJS.Workbook();

--- a/src/index.css
+++ b/src/index.css
@@ -26,6 +26,25 @@ body {
   width: 100%;
 }
 
+.defects-filter-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 16px;
+}
+.defects-filter-col {
+  display: grid;
+  gap: 16px;
+}
+.defects-filter-footer {
+  margin-top: 16px;
+}
+.defects-filter-grid .ant-input,
+.defects-filter-grid .ant-select,
+.defects-filter-grid .ant-picker,
+.defects-filter-grid button {
+  width: 100%;
+}
+
 /* === ТАБЛИЦА ================================================================= */
 .MuiTable-root {
   width: 100%;

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -221,11 +221,12 @@ export default function DefectsPage() {
 
       return {
         ids: mapNumOptions(filtered('id').map((d) => d.id)),
-      units: Array.from(
-        new Set(filtered('units').flatMap((d) => d.unitIds)),
-      )
-        .map((id) => ({ label: unitMap.get(id) ?? String(id), value: id }))
-        .sort((a, b) => naturalCompare(a.label, b.label)),
+        claimIds: mapNumOptions(filtered('claimId').flatMap((d) => d.claimIds)),
+        units: Array.from(
+          new Set(filtered('units').flatMap((d) => d.unitIds)),
+        )
+          .map((id) => ({ label: unitMap.get(id) ?? String(id), value: id }))
+          .sort((a, b) => naturalCompare(a.label, b.label)),
         buildings: mapStrOptions(
           filtered('building').flatMap((d) => d.buildingNamesList || []),
       ),
@@ -240,6 +241,7 @@ export default function DefectsPage() {
       ),
       fixBy: mapStrOptions(filtered('fixBy').map((d) => d.fixByName)),
       engineers: mapStrOptions(filtered('engineer').map((d) => d.engineerName)),
+      authors: mapStrOptions(filtered('author').map((d) => d.createdByName)),
     };
   }, [filteredData, filters, units, projects]);
   const [viewId, setViewId] = useState<number | null>(null);

--- a/src/shared/types/defectFilters.ts
+++ b/src/shared/types/defectFilters.ts
@@ -4,14 +4,23 @@ import { Dayjs } from 'dayjs';
 export interface DefectFilters {
   id?: number[];
   ticketId?: number[];
+  /** Связанные претензии */
+  claimId?: number[];
   units?: number[];
   projectId?: number[];
   typeId?: number[];
   statusId?: number[];
+  /** Автор создания */
+  author?: string;
   fixBy?: string[];
   engineer?: string;
   /** Корпус */
   building?: string[];
+  /** Период получения */
   period?: [Dayjs, Dayjs];
+  /** Период создания */
+  createdPeriod?: [Dayjs, Dayjs];
+  /** Период устранения */
+  fixedPeriod?: [Dayjs, Dayjs];
   hideClosed?: boolean;
 }

--- a/src/shared/utils/defectFilter.ts
+++ b/src/shared/utils/defectFilter.ts
@@ -10,6 +10,7 @@ export function filterDefects<T extends {
   unitIds: number[];
   created_at: string | null;
   received_at: string | null;
+  fixed_at: string | null;
   projectIds?: number[];
   type_id: number | null;
   status_id: number | null;
@@ -17,6 +18,8 @@ export function filterDefects<T extends {
   fixByName?: string;
   engineerName?: string | null;
   buildingNamesList?: string[];
+  claimIds: number[];
+  createdByName?: string | null;
 }>(rows: T[], f: DefectFilters): T[] {
   return rows.filter((d) => {
     if (Array.isArray(f.id) && f.id.length > 0 && !f.id.includes(d.id)) {
@@ -58,10 +61,20 @@ export function filterDefects<T extends {
       return false;
     }
     if (
+      Array.isArray(f.claimId) &&
+      f.claimId.length > 0 &&
+      !d.claimIds.some((c) => f.claimId!.includes(c))
+    ) {
+      return false;
+    }
+    if (
       Array.isArray(f.fixBy) &&
       f.fixBy.length > 0 &&
       (!d.fixByName || !f.fixBy.includes(d.fixByName))
     ) {
+      return false;
+    }
+    if (f.author && d.createdByName !== f.author) {
       return false;
     }
     if (f.engineer && d.engineerName !== f.engineer) {
@@ -71,6 +84,20 @@ export function filterDefects<T extends {
       const [from, to] = f.period;
       const rec = dayjs(d.received_at);
       if (!rec.isSameOrAfter(from, 'day') || !rec.isSameOrBefore(to, 'day')) {
+        return false;
+      }
+    }
+    if (f.createdPeriod && f.createdPeriod.length === 2) {
+      const [from, to] = f.createdPeriod;
+      const created = dayjs(d.created_at);
+      if (!created.isSameOrAfter(from, 'day') || !created.isSameOrBefore(to, 'day')) {
+        return false;
+      }
+    }
+    if (f.fixedPeriod && f.fixedPeriod.length === 2) {
+      const [from, to] = f.fixedPeriod;
+      const fixed = dayjs(d.fixed_at);
+      if (!fixed.isSameOrAfter(from, 'day') || !fixed.isSameOrBefore(to, 'day')) {
         return false;
       }
     }

--- a/src/widgets/DefectsFilters.tsx
+++ b/src/widgets/DefectsFilters.tsx
@@ -9,12 +9,14 @@ const LS_HIDE_CLOSED_KEY = 'defectsHideClosed';
 
 interface Options {
   ids: { label: string; value: number }[];
+  claimIds: { label: string; value: number }[];
   units: { label: string; value: number }[];
   projects: { label: string; value: number }[];
   types: { label: string; value: number }[];
   statuses: { label: string; value: number }[];
   fixBy: { label: string; value: string }[];
   engineers: { label: string; value: string }[];
+  authors: { label: string; value: string }[];
   buildings: { label: string; value: string }[];
 }
 
@@ -75,42 +77,71 @@ export default function DefectsFilters({
   };
 
   return (
-    <Form form={form} layout="vertical" onValuesChange={handleValuesChange} className="filter-grid">
-      <Form.Item name="id" label="ID дефекта">
-        <Select mode="multiple" allowClear options={options.ids} showSearch optionFilterProp="label" />
-      </Form.Item>
-      <Form.Item name="projectId" label="Проекты">
-        <Select mode="multiple" allowClear options={options.projects} showSearch optionFilterProp="label" />
-      </Form.Item>
-      <Form.Item name="building" label="Корпус">
-        <Select mode="multiple" allowClear options={options.buildings} showSearch optionFilterProp="label" />
-      </Form.Item>
-      <Form.Item name="units" label="Объекты">
-        <Select mode="multiple" allowClear options={options.units} showSearch optionFilterProp="label" />
-      </Form.Item>
-      <Form.Item name="statusId" label="Статус">
-        <Select mode="multiple" allowClear options={options.statuses} showSearch optionFilterProp="label" />
-      </Form.Item>
-      <Form.Item name="typeId" label="Тип">
-        <Select mode="multiple" allowClear options={options.types} showSearch optionFilterProp="label" />
-      </Form.Item>
-      <Form.Item name="period" label="Дата получения">
-        <RangePicker style={{ width: '100%' }} format="DD.MM.YYYY" />
-      </Form.Item>
-      <Form.Item name="fixBy" label="Кем устраняется">
-        <Select mode="multiple" allowClear options={options.fixBy} showSearch optionFilterProp="label" />
-      </Form.Item>
-      <Form.Item name="engineer" label="Закрепленный инженер">
-        <Select allowClear options={options.engineers} showSearch optionFilterProp="label" />
-      </Form.Item>
-      <Form.Item name="hideClosed" label="Скрыть закрытые" valuePropName="checked">
-        <Switch />
-      </Form.Item>
-      <Form.Item>
-        <Button onClick={reset} block>
-          Сброс
-        </Button>
-      </Form.Item>
+    <Form form={form} layout="vertical" onValuesChange={handleValuesChange}>
+      <div className="defects-filter-grid">
+        <div className="defects-filter-col">
+          <Form.Item name="id" label="ID дефекта">
+            <Select mode="multiple" allowClear options={options.ids} showSearch optionFilterProp="label" />
+          </Form.Item>
+          <Form.Item name="claimId" label="ID претензии">
+            <Select mode="multiple" allowClear options={options.claimIds} showSearch optionFilterProp="label" />
+          </Form.Item>
+          <Form.Item name="statusId" label="Статус">
+            <Select mode="multiple" allowClear options={options.statuses} showSearch optionFilterProp="label" />
+          </Form.Item>
+        </div>
+        <div className="defects-filter-col">
+          <Form.Item name="author" label="Автор">
+            <Select allowClear options={options.authors} showSearch optionFilterProp="label" />
+          </Form.Item>
+          <Form.Item name="engineer" label="Закрепленный инженер">
+            <Select allowClear options={options.engineers} showSearch optionFilterProp="label" />
+          </Form.Item>
+          <Form.Item name="fixBy" label="Кем устраняется">
+            <Select mode="multiple" allowClear options={options.fixBy} showSearch optionFilterProp="label" />
+          </Form.Item>
+        </div>
+        <div className="defects-filter-col">
+          <Form.Item name="createdPeriod" label="Добавлено">
+            <RangePicker style={{ width: '100%' }} format="DD.MM.YYYY" />
+          </Form.Item>
+          <Form.Item name="period" label="Дата получения">
+            <RangePicker style={{ width: '100%' }} format="DD.MM.YYYY" />
+          </Form.Item>
+          <Form.Item name="fixedPeriod" label="Дата устранения">
+            <RangePicker style={{ width: '100%' }} format="DD.MM.YYYY" />
+          </Form.Item>
+        </div>
+        <div className="defects-filter-col">
+          <Form.Item name="projectId" label="Проект">
+            <Select mode="multiple" allowClear options={options.projects} showSearch optionFilterProp="label" />
+          </Form.Item>
+          <Form.Item name="building" label="Корпус">
+            <Select mode="multiple" allowClear options={options.buildings} showSearch optionFilterProp="label" />
+          </Form.Item>
+          <Form.Item name="units" label="Объекты">
+            <Select mode="multiple" allowClear options={options.units} showSearch optionFilterProp="label" />
+          </Form.Item>
+        </div>
+        <div className="defects-filter-col">
+          <Form.Item name="typeId" label="Тип">
+            <Select mode="multiple" allowClear options={options.types} showSearch optionFilterProp="label" />
+          </Form.Item>
+          <Form.Item name="description" label="Описание">
+            <Select disabled />
+          </Form.Item>
+          <Form.Item name="hideClosed" label="Скрыть закрытые" valuePropName="checked">
+            <Switch />
+          </Form.Item>
+        </div>
+      </div>
+      <div className="defects-filter-footer">
+        <Form.Item>
+          <Button onClick={reset} block>
+            Сброс
+          </Button>
+        </Form.Item>
+      </div>
     </Form>
   );
 }


### PR DESCRIPTION
## Summary
- extend `DefectFilters` with author, claim, and date ranges
- update defect filter utils to handle new fields
- layout filters in a five-column grid
- show new controls in `DefectsFilters`
- include new columns in Excel export
- expose options for authors and claim ids

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Missing script)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a74dfb5b4832e8b194af2151ed74a