### PR TITLE
Add object lock feature

### DIFF
--- a/database_structure.json
+++ b/database_structure.json
@@ -1197,6 +1197,13 @@
     "column_default": "false"
   },
   {
+    "table_name": "role_permissions",
+    "column_name": "can_lock_units",
+    "data_type": "boolean",
+    "is_nullable": "NO",
+    "column_default": "false"
+  },
+  {
     "table_name": "roles",
     "column_name": "id",
     "data_type": "integer",
@@ -1328,5 +1335,12 @@
     "data_type": "uuid",
     "is_nullable": "YES",
     "column_default": null
+  },
+  {
+    "table_name": "units",
+    "column_name": "locked",
+    "data_type": "boolean",
+    "is_nullable": "NO",
+    "column_default": "false"
   }
 ]

--- a/sql/lock_units.sql
+++ b/sql/lock_units.sql
@@ -1,0 +1,5 @@
+-- Добавление признака блокировки объектов
+ALTER TABLE units ADD COLUMN locked boolean NOT NULL DEFAULT false;
+
+-- Право блокировки объектов для ролей
+ALTER TABLE role_permissions ADD COLUMN can_lock_units boolean NOT NULL DEFAULT false;

--- a/src/entities/claim.ts
+++ b/src/entities/claim.ts
@@ -444,6 +444,17 @@ export function useCreateClaim() {
     ) => {
       const { unit_ids = [], defect_ids = [], attachments = [], ...rest } = payload as any;
 
+      if (unit_ids.length) {
+        const { data: locked } = await supabase
+          .from('units')
+          .select('id')
+          .in('id', unit_ids)
+          .eq('locked', true);
+        if (locked && locked.length) {
+          throw new Error('Объект заблокирован. Обратитесь в юридический отдел');
+        }
+      }
+
       const insertData: any = {
         ...rest,
         project_id: rest.project_id ?? projectId,

--- a/src/entities/rolePermission.ts
+++ b/src/entities/rolePermission.ts
@@ -5,7 +5,7 @@ import { DEFAULT_ROLE_PERMISSIONS } from '@/shared/types/rolePermission';
 
 const TABLE = 'role_permissions';
 const FIELDS =
-  'role_name, pages, edit_tables, delete_tables, only_assigned_project';
+  'role_name, pages, edit_tables, delete_tables, only_assigned_project, can_lock_units';
 
 /** Получить настройки ролей */
 export const useRolePermissions = () =>

--- a/src/entities/unit.ts
+++ b/src/entities/unit.ts
@@ -18,7 +18,8 @@ const SELECT = `
   id, name, building, floor,
   project_id,
   project:projects ( id, name ),
-  person_id
+  person_id,
+  locked
 `;
 
 // sanitize теперь включает person_id!
@@ -278,3 +279,37 @@ export const useRenameBuilding = () => {
 };
 
 /** Удалить все квартиры в секции корпуса */
+
+export const useLockedUnitIds = () =>
+    useQuery<number[]>({
+        queryKey: ['locked-units'],
+        queryFn: async () => {
+            const { data, error } = await supabase
+                .from('units')
+                .select('id')
+                .eq('locked', true);
+            if (error) throw error;
+            return (data ?? []).map((r: any) => r.id as number);
+        },
+        staleTime: 5 * 60_000,
+    });
+
+export const useSetUnitLock = () => {
+    const qc = useQueryClient();
+    const notify = useNotify();
+    return useMutation<void, Error, { id: number; locked: boolean }>({
+        mutationFn: async ({ id, locked }) => {
+            const { error } = await supabase
+                .from('units')
+                .update({ locked })
+                .eq('id', id);
+            if (error) throw error;
+        },
+        onSuccess: (_d, vars) => {
+            qc.invalidateQueries({ queryKey: ['units'] });
+            qc.invalidateQueries({ queryKey: ['locked-units'] });
+            notify.success(vars.locked ? 'Объект заблокирован' : 'Блокировка снята');
+        },
+        onError: (e) => notify.error(e.message),
+    });
+};

--- a/src/index.css
+++ b/src/index.css
@@ -143,6 +143,9 @@ body {
   color: #aaa;
   background: inherit !important;
 }
+.locked-object-row {
+  background: #ffccc7 !important;
+}
 
 /* Подсветка новых элементов */
 .new-row {

--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -20,7 +20,7 @@ import {
   useUnlinkClaim,
 } from '@/entities/claim';
 import { useUsers } from '@/entities/user';
-import { useUnitsByIds } from '@/entities/unit';
+import { useUnitsByIds, useLockedUnitIds } from '@/entities/unit';
 import { useRolePermission } from '@/entities/rolePermission';
 import { useAuthStore } from '@/shared/store/authStore';
 import type { RoleName } from '@/shared/types/rolePermission';
@@ -70,6 +70,7 @@ export default function ClaimsPage() {
     [claims],
   );
   const { data: units = [] } = useUnitsByIds(unitIds);
+  const { data: lockedUnitIds = [] } = useLockedUnitIds();
   const checkingDefectMap = useMemo(() => new Map<number, boolean>(), []);
   const [searchParams] = useSearchParams();
   const initialValues = {
@@ -424,6 +425,7 @@ export default function ClaimsPage() {
               filters={filters}
               loading={isLoading}
               columns={columns}
+              lockedUnitIds={lockedUnitIds}
               onView={(id) => setViewId(id)}
               onAddChild={setLinkFor}
               onUnlink={(id) => unlinkClaim.mutate(id)}

--- a/src/pages/CorrespondencePage/CorrespondencePage.tsx
+++ b/src/pages/CorrespondencePage/CorrespondencePage.tsx
@@ -44,7 +44,7 @@ import { useAuthStore } from '@/shared/store/authStore';
 import { useUsers } from '@/entities/user';
 import { useLetterTypes } from '@/entities/letterType';
 import { useVisibleProjects } from '@/entities/project';
-import { useUnitsByProject, useUnitsByIds } from '@/entities/unit';
+import { useUnitsByProject, useUnitsByIds, useLockedUnitIds } from '@/entities/unit';
 import { useNotify } from '@/shared/hooks/useNotify';
 import { useLetterStatuses } from '@/entities/letterStatus';
 import { useContractors } from '@/entities/contractor';
@@ -202,6 +202,7 @@ export default function CorrespondencePage() {
       [letters],
   );
   const { data: allUnits = [] } = useUnitsByIds(unitIds);
+  const { data: lockedUnitIds = [] } = useLockedUnitIds();
 
   const contactOptions = React.useMemo(
     () => [
@@ -688,10 +689,11 @@ export default function CorrespondencePage() {
             users={users}
             letterTypes={letterTypes}
             projects={projects}
-            units={allUnits}
-            statuses={statuses}
-            columns={columns}
-          />
+          units={allUnits}
+          statuses={statuses}
+          columns={columns}
+          lockedUnitIds={lockedUnitIds}
+        />
           <Typography.Text style={{ display: 'block', marginTop: 8 }}>
             Всего писем: {total}, из них закрытых: {closedCount} и не закрытых: {openCount}
           </Typography.Text>

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -19,7 +19,7 @@ import {
 
 import ruRU from "antd/locale/ru_RU";
 import { useDefects, useDeleteDefect } from "@/entities/defect";
-import { useUnitsByIds } from "@/entities/unit";
+import { useUnitsByIds, useLockedUnitIds } from "@/entities/unit";
 import { useVisibleProjects } from "@/entities/project";
 import { useBrigades } from "@/entities/brigade";
 import { useContractors } from "@/entities/contractor";
@@ -76,6 +76,7 @@ export default function DefectsPage() {
     [claims, defectUnitIds],
   );
   const { data: units = [] } = useUnitsByIds(unitIds);
+  const { data: lockedUnitIds = [] } = useLockedUnitIds();
   const { data: projects = [] } = useVisibleProjects();
   const { data: brigades = [] } = useBrigades();
   const { data: contractors = [] } = useContractors();
@@ -615,6 +616,7 @@ const LS_COLUMN_WIDTHS_KEY = "defectsColumnWidths";
           loading={isPending}
           onView={setViewId}
           columns={columns}
+          lockedUnitIds={lockedUnitIds}
         />
         <React.Suspense fallback={null}>
           <TableColumnsDrawer

--- a/src/shared/hooks/useUnitsMatrix.ts
+++ b/src/shared/hooks/useUnitsMatrix.ts
@@ -40,7 +40,7 @@ export default function useUnitsMatrix(projectId: number | null, building?: stri
 
       let query = supabase
         .from('units')
-        .select('id, name, building, floor, project_id')
+        .select('id, name, building, floor, project_id, locked')
         .eq('project_id', projectId);
       if (building) query = query.eq('building', building);
       const { data: unitsData } = await query;

--- a/src/shared/types/rolePermission.ts
+++ b/src/shared/types/rolePermission.ts
@@ -5,6 +5,8 @@ export interface RolePermission {
   delete_tables: string[];
   /** Ограничить видимость только назначенным проектом */
   only_assigned_project: boolean;
+  /** Разрешено ли блокировать объекты */
+  can_lock_units: boolean;
 }
 
 /** Специальная отметка в массиве pages для разрешения досудебных претензий */
@@ -29,6 +31,7 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<RoleName, RolePermission> = {
     edit_tables: ['defects', 'court_cases', 'letters', 'claims'],
     delete_tables: ['defects', 'court_cases', 'letters', 'claims'],
     only_assigned_project: false,
+    can_lock_units: true,
   },
   ENGINEER: {
     role_name: 'ENGINEER',
@@ -45,6 +48,7 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<RoleName, RolePermission> = {
     edit_tables: ['defects', 'letters', 'claims'],
     delete_tables: ['defects', 'letters', 'claims'],
     only_assigned_project: false,
+    can_lock_units: false,
   },
   LAWYER: {
     role_name: 'LAWYER',
@@ -60,6 +64,7 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<RoleName, RolePermission> = {
     edit_tables: ['court_cases', 'letters'],
     delete_tables: ['court_cases', 'letters'],
     only_assigned_project: false,
+    can_lock_units: true,
   },
   CONTRACTOR: {
     role_name: 'CONTRACTOR',
@@ -67,5 +72,6 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<RoleName, RolePermission> = {
     edit_tables: [],
     delete_tables: [],
     only_assigned_project: false,
+    can_lock_units: false,
   },
 };

--- a/src/shared/types/unit.ts
+++ b/src/shared/types/unit.ts
@@ -5,4 +5,5 @@ export interface Unit {
   building?: string | null;
   floor?: number | null;
   person_id?: string | null;
+  locked?: boolean | null;
 }

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -29,6 +29,7 @@ interface Props {
   onView?: (id: number) => void;
   onAddChild?: (parent: ClaimWithNames) => void;
   onUnlink?: (id: number) => void;
+  lockedUnitIds?: number[];
 }
 
 export default function ClaimsTable({
@@ -39,6 +40,7 @@ export default function ClaimsTable({
   onView,
   onAddChild,
   onUnlink,
+  lockedUnitIds = [],
 }: Props) {
   const { mutateAsync: remove, isPending } = useDeleteClaim();
   const defaultColumns: ColumnsType<any> = useMemo(
@@ -180,9 +182,11 @@ export default function ClaimsTable({
     const closed = row.statusName?.toLowerCase().includes('закры');
     const preTrial = row.pre_trial_claim ||
       row.statusName?.toLowerCase().includes('досудеб');
+    const locked = row.unit_ids?.some((id) => lockedUnitIds.includes(id));
     if (checking || row.hasCheckingDefect) return 'claim-checking-row';
     if (preTrial) return 'claim-pretrial-row';
     if (closed) return 'claim-closed-row';
+    if (locked) return 'locked-object-row';
     return '';
   };
 

--- a/src/widgets/CorrespondenceTable.tsx
+++ b/src/widgets/CorrespondenceTable.tsx
@@ -22,6 +22,7 @@ interface CorrespondenceTableProps {
   projects: Option[];
   units: Option[];
   statuses: Option[];
+  lockedUnitIds?: number[];
 }
 
 /** Ключ в localStorage для хранения раскрывшихся строк */
@@ -40,6 +41,7 @@ export default function CorrespondenceTable({
                                               projects,
                                               units,
                                               statuses,
+                                              lockedUnitIds = [],
                                             }: CorrespondenceTableProps) {
   const maps = useMemo(() => {
     const m = {
@@ -301,8 +303,9 @@ export default function CorrespondenceTable({
   const resizableColumns = columnsProp ?? defaultColumns;
 
   const rowClassName = (record: any) => {
-    if (!record.parent_id) return 'main-letter-row';
-    return 'child-letter-row';
+    const base = record.parent_id ? 'child-letter-row' : 'main-letter-row';
+    const locked = record.unit_ids?.some((id: number) => lockedUnitIds.includes(id));
+    return locked ? `${base} locked-object-row` : base;
   };
 
   return (

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -29,6 +29,7 @@ interface Props {
   /** Колонки таблицы. Если не переданы, используется набор по умолчанию */
   columns?: ColumnsType<DefectWithInfo>;
   onView?: (id: number) => void;
+  lockedUnitIds?: number[];
 }
 
 /**
@@ -41,6 +42,7 @@ export default function DefectsTable({
   loading,
   columns: columnsProp,
   onView,
+  lockedUnitIds = [],
 }: Props) {
   const { mutateAsync: remove, isPending } = useDeleteDefect();
   const filtered = useMemo(
@@ -218,9 +220,11 @@ export default function DefectsTable({
     const checking = row.defectStatusName?.toLowerCase().includes("провер");
     const closed = row.defectStatusName?.toLowerCase().includes("закры");
     const preTrial = row.hasPretrialClaim;
+    const locked = row.unit_id != null && lockedUnitIds.includes(row.unit_id);
     if (checking) classes.push("defect-confirmed-row");
     if (preTrial) classes.push("defect-pretrial-row");
     if (closed) classes.push("defect-closed-row");
+    if (locked) classes.push("locked-object-row");
     return classes.join(" ");
   };
 

--- a/src/widgets/UnitsMatrix/UnitsMatrix.tsx
+++ b/src/widgets/UnitsMatrix/UnitsMatrix.tsx
@@ -19,6 +19,9 @@ import useUnitsMatrix from "@/shared/hooks/useUnitsMatrix";
 import { supabase } from "@/shared/api/supabaseClient";
 import { useNavigate, createSearchParams } from 'react-router-dom';
 import { useAuthStore } from '@/shared/store/authStore';
+import { useRolePermission } from '@/entities/rolePermission';
+import type { RoleName } from '@/shared/types/rolePermission';
+import { useSetUnitLock } from '@/entities/unit';
 import { getUnitNameComparator } from '@/shared/utils/unitNumberSort';
 import type { SortDirection } from '@/shared/types/sortDirection';
 import { useUnitSortOrders, useUpsertUnitSortOrder } from '@/entities/unitSortOrder';
@@ -53,6 +56,9 @@ export default function UnitsMatrix({
   } = useUnitsMatrix(numericProjectId, building);
   const navigate = useNavigate();
   const profileId = useAuthStore((s) => s.profile?.id);
+  const role = useAuthStore((s) => s.profile?.role as RoleName | undefined);
+  const { data: perm } = useRolePermission(role);
+  const setLock = useSetUnitLock();
 
   // Диалоги редактирования/удаления
   const [editDialog, setEditDialog] = useState({
@@ -430,6 +436,20 @@ export default function UnitsMatrix({
               >
                 Посмотреть архив
               </AntButton>
+              {perm?.can_lock_units && (
+                <AntButton
+                  danger={actionDialog.unit?.locked}
+                  onClick={async () => {
+                    const id = actionDialog.unit?.id;
+                    if (!id) return;
+                    await setLock.mutateAsync({ id, locked: !actionDialog.unit?.locked });
+                    await fetchUnits();
+                    setActionDialog({ open: false, unit: null, action: '' });
+                  }}
+                >
+                  {actionDialog.unit?.locked ? 'Снять блокировку' : 'Заблокировать объект'}
+                </AntButton>
+              )}
             </div>
           )}
         </Modal>


### PR DESCRIPTION
## Summary
- add SQL for object lock
- support new `locked` column in units and `can_lock_units` in role permissions
- enable unit lock/unlock via menu on structure page
- prevent claim creation for locked units
- highlight locked records in tables
- manage lock rights in admin roles

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a829d1178832e9fafcb8e16e56234