### PR TITLE
Fix locked object handling

### DIFF
--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useImperativeHandle } from 'react';
-import type { Dayjs } from 'dayjs';
+import React, { useEffect, useImperativeHandle } from "react";
+import type { Dayjs } from "dayjs";
 import {
   Form,
   Input,
@@ -13,7 +13,8 @@ import {
   Tooltip,
   Space,
   Popconfirm,
-} from 'antd';
+  Modal,
+} from "antd";
 import {
   useClaim,
   useClaimAll,
@@ -22,28 +23,31 @@ import {
   removeClaimAttachmentsBulk,
   signedUrl,
   markClaimDefectsPreTrial,
-} from '@/entities/claim';
-import { updateAttachmentDescription } from '@/entities/attachment';
-import { supabase } from '@/shared/api/supabaseClient';
-import { useVisibleProjects } from '@/entities/project';
-import { useUnitsByProject, useUnitsByIds } from '@/entities/unit';
-import { useUsers } from '@/entities/user';
-import { useClaimStatuses } from '@/entities/claimStatus';
+} from "@/entities/claim";
+import { updateAttachmentDescription } from "@/entities/attachment";
+import { supabase } from "@/shared/api/supabaseClient";
+import { useVisibleProjects } from "@/entities/project";
+import {
+  useUnitsByProject,
+  useUnitsByIds,
+  useLockedUnitIds,
+} from "@/entities/unit";
+import { useUsers } from "@/entities/user";
+import { useClaimStatuses } from "@/entities/claimStatus";
 
-import { useCaseUids } from '@/entities/courtCaseUid';
-import { useNotify } from '@/shared/hooks/useNotify';
-import { useProjectId } from '@/shared/hooks/useProjectId';
-import { useAuthStore } from '@/shared/store/authStore';
-import { useRolePermission } from '@/entities/rolePermission';
-import type { RoleName } from '@/shared/types/rolePermission';
-import { PRETRIAL_FLAG } from '@/shared/types/rolePermission';
-import { useChangedFields } from '@/shared/hooks/useChangedFields';
-import AttachmentEditorTable from '@/shared/ui/AttachmentEditorTable';
-import FileDropZone from '@/shared/ui/FileDropZone';
-import { useClaimAttachments } from './model/useClaimAttachments';
-import type { RemoteClaimFile } from '@/shared/types/claimFile';
-import type { ClaimFormAntdEditRef } from '@/shared/types/claimFormAntdEditRef';
-
+import { useCaseUids } from "@/entities/courtCaseUid";
+import { useNotify } from "@/shared/hooks/useNotify";
+import { useProjectId } from "@/shared/hooks/useProjectId";
+import { useAuthStore } from "@/shared/store/authStore";
+import { useRolePermission } from "@/entities/rolePermission";
+import type { RoleName } from "@/shared/types/rolePermission";
+import { PRETRIAL_FLAG } from "@/shared/types/rolePermission";
+import { useChangedFields } from "@/shared/hooks/useChangedFields";
+import AttachmentEditorTable from "@/shared/ui/AttachmentEditorTable";
+import FileDropZone from "@/shared/ui/FileDropZone";
+import { useClaimAttachments } from "./model/useClaimAttachments";
+import type { RemoteClaimFile } from "@/shared/types/claimFile";
+import type { ClaimFormAntdEditRef } from "@/shared/types/claimFormAntdEditRef";
 
 export interface ClaimFormAntdEditProps {
   claimId: string | number;
@@ -95,11 +99,14 @@ const ClaimFormAntdEdit = React.forwardRef<
   const allowPretrial = perm?.pages.includes(PRETRIAL_FLAG);
   const claimAssigned = useClaim(claimId);
   const claimAll = useClaimAll(claimId);
-  const claim = perm?.only_assigned_project ? claimAssigned.data : claimAll.data;
+  const claim = perm?.only_assigned_project
+    ? claimAssigned.data
+    : claimAll.data;
   const { data: projects = [] } = useVisibleProjects();
   const globalProjectId = useProjectId();
-  const projectIdWatch = Form.useWatch('project_id', form);
-  const projectId = projectIdWatch != null ? Number(projectIdWatch) : globalProjectId;
+  const projectIdWatch = Form.useWatch("project_id", form);
+  const projectId =
+    projectIdWatch != null ? Number(projectIdWatch) : globalProjectId;
   const { data: units = [] } = useUnitsByProject(projectId);
   const { data: users = [] } = useUsers();
   const { data: statuses = [] } = useClaimStatuses();
@@ -111,16 +118,17 @@ const ClaimFormAntdEdit = React.forwardRef<
   const attachments =
     attachmentsState ?? useClaimAttachments({ claim: claim as any });
   const { changedFields, handleValuesChange } = useChangedFields(form, [claim]);
-  const preTrialWatch = Form.useWatch('pre_trial_claim', form);
-  const unitIdsWatch = Form.useWatch('unit_ids', form) ?? [];
+  const preTrialWatch = Form.useWatch("pre_trial_claim", form);
+  const unitIdsWatch = Form.useWatch("unit_ids", form) ?? [];
   const { data: selectedUnits = [] } = useUnitsByIds(
     Array.isArray(unitIdsWatch) ? unitIdsWatch : [],
   );
+  const { data: lockedUnitIds = [] } = useLockedUnitIds();
   const buildingsText = React.useMemo(
     () =>
       Array.from(
         new Set(selectedUnits.map((u) => u.building).filter(Boolean)),
-      ).join(', '),
+      ).join(", "),
     [selectedUnits],
   );
 
@@ -131,7 +139,7 @@ const ClaimFormAntdEdit = React.forwardRef<
 
   const highlight = (name: keyof ClaimFormAntdEditValues) =>
     changedFields[name as string]
-      ? { background: '#fffbe6', padding: 4, borderRadius: 2 }
+      ? { background: "#fffbe6", padding: 4, borderRadius: 2 }
       : {};
 
   useEffect(() => {
@@ -148,12 +156,19 @@ const ClaimFormAntdEdit = React.forwardRef<
       owner: claim.owner ?? null,
       case_uid_id: claim.case_uid_id ?? null,
       pre_trial_claim: claim.pre_trial_claim ?? false,
-      description: claim.description ?? '',
+      description: claim.description ?? "",
     });
   }, [claim, form]);
 
   const onFinish = async (values: ClaimFormAntdEditValues) => {
     if (!claim) return;
+    if (values.unit_ids?.some((id) => lockedUnitIds.includes(id))) {
+      Modal.warning({
+        title: "Объект заблокирован",
+        content: "Работы по устранению замечаний запрещено выполнять.",
+      });
+      return;
+    }
     try {
       await update.mutateAsync({
         id: claim.id,
@@ -163,19 +178,19 @@ const ClaimFormAntdEdit = React.forwardRef<
           claim_status_id: values.claim_status_id,
           claim_no: values.claim_no,
           claimed_on: values.claimed_on
-            ? values.claimed_on.format('YYYY-MM-DD')
+            ? values.claimed_on.format("YYYY-MM-DD")
             : null,
           accepted_on: values.accepted_on
-            ? values.accepted_on.format('YYYY-MM-DD')
+            ? values.accepted_on.format("YYYY-MM-DD")
             : null,
           registered_on: values.registered_on
-            ? values.registered_on.format('YYYY-MM-DD')
+            ? values.registered_on.format("YYYY-MM-DD")
             : null,
           engineer_id: values.engineer_id ?? null,
           owner: values.owner ?? null,
           case_uid_id: values.case_uid_id ?? null,
           pre_trial_claim: values.pre_trial_claim ?? false,
-          description: values.description ?? '',
+          description: values.description ?? "",
           updated_by: userId ?? undefined,
         } as any,
       });
@@ -198,13 +213,13 @@ const ClaimFormAntdEdit = React.forwardRef<
         });
         uploaded = res.map((u) => ({
           id: u.id,
-          name: u.original_name ?? u.storage_path.split('/').pop() ?? 'file',
+          name: u.original_name ?? u.storage_path.split("/").pop() ?? "file",
           original_name: u.original_name ?? null,
           path: u.storage_path,
           url: u.file_url,
           mime_type: u.file_type,
         }));
-      attachments.appendRemote(uploaded);
+        attachments.appendRemote(uploaded);
       }
       if (Object.keys(attachments.changedDesc).length) {
         await Promise.all(
@@ -214,7 +229,7 @@ const ClaimFormAntdEdit = React.forwardRef<
         );
       }
       attachments.markPersisted();
-      notify.success('Претензия обновлена');
+      notify.success("Претензия обновлена");
       onSaved?.();
     } catch (e: any) {
       notify.error(e.message);
@@ -225,185 +240,211 @@ const ClaimFormAntdEdit = React.forwardRef<
 
   return (
     <>
-    <Form
-      form={form}
-      layout="vertical"
-      onFinish={onFinish}
-      onValuesChange={handleValuesChange}
-      style={{ maxWidth: embedded ? 'none' : 640 }}
-      autoComplete="off"
-    >
-      <Row gutter={16}>
-        <Col span={8} hidden={!allowPretrial}>
+      <Form
+        form={form}
+        layout="vertical"
+        onFinish={onFinish}
+        onValuesChange={handleValuesChange}
+        style={{ maxWidth: embedded ? "none" : 640 }}
+        autoComplete="off"
+      >
+        <Row gutter={16}>
+          <Col span={8} hidden={!allowPretrial}>
+            <Form.Item
+              name="pre_trial_claim"
+              label="Досудебная претензия"
+              valuePropName="checked"
+              style={highlight("pre_trial_claim")}
+            >
+              <Switch disabled={!allowPretrial} />
+            </Form.Item>
+          </Col>
+          <Col span={8} hidden={!allowPretrial}>
+            <Form.Item
+              name="case_uid_id"
+              label="Уникальный идентификатор дела"
+              hidden={!preTrialWatch}
+              style={highlight("case_uid_id")}
+            >
+              <Select
+                showSearch
+                allowClear
+                disabled={!preTrialWatch || !allowPretrial}
+                options={caseUids.map((c) => ({ value: c.id, label: c.uid }))}
+              />
+            </Form.Item>
+          </Col>
+        </Row>
+        <Row gutter={16}>
+          <Col span={8}>
+            <Form.Item
+              name="project_id"
+              label="Проект"
+              rules={[{ required: true }]}
+              style={highlight("project_id")}
+            >
+              <Select
+                allowClear
+                options={projects.map((p) => ({ value: p.id, label: p.name }))}
+              />
+            </Form.Item>
+          </Col>
+          <Col span={8}>
+            <Form.Item label="Корпус">
+              <Input value={buildingsText} disabled />
+            </Form.Item>
+          </Col>
+          <Col span={8}>
+            <Form.Item
+              name="unit_ids"
+              label="Объекты"
+              rules={[{ required: true }]}
+              style={highlight("unit_ids")}
+            >
+              <Select
+                mode="multiple"
+                options={units.map((u) => ({ value: u.id, label: u.name }))}
+                disabled={!projectId}
+              />
+            </Form.Item>
+          </Col>
+          <Col span={8}>
+            <Form.Item
+              label="Собственник объекта"
+              name="owner"
+              style={highlight("owner")}
+            >
+              <Input />
+            </Form.Item>
+          </Col>
+          <Col span={8}>
+            <Form.Item
+              name="engineer_id"
+              label="Закрепленный инженер"
+              rules={[{ required: true }]}
+              style={highlight("engineer_id")}
+            >
+              <Select
+                allowClear
+                showSearch
+                options={users.map((u) => ({ value: u.id, label: u.name }))}
+              />
+            </Form.Item>
+          </Col>
+        </Row>
+        <Row gutter={16}>
+          <Col span={8}>
+            <Form.Item
+              name="claim_no"
+              label="№ претензии"
+              rules={[{ required: true }]}
+              style={highlight("claim_no")}
+            >
+              <Input />
+            </Form.Item>
+          </Col>
+          <Col span={8}>
+            <Form.Item
+              name="claimed_on"
+              label="Дата претензии"
+              style={highlight("claimed_on")}
+            >
+              <DatePicker format="DD.MM.YYYY" style={{ width: "100%" }} />
+            </Form.Item>
+          </Col>
+          <Col span={8}>
+            <Form.Item
+              name="accepted_on"
+              label="Дата получения претензии Застройщиком"
+              style={highlight("accepted_on")}
+            >
+              <DatePicker format="DD.MM.YYYY" style={{ width: "100%" }} />
+            </Form.Item>
+          </Col>
+        </Row>
+        <Row gutter={16}>
+          <Col span={8}>
+            <Form.Item
+              name="registered_on"
+              label="Дата регистрации претензии GARANTHUB"
+              style={highlight("registered_on")}
+            >
+              <DatePicker format="DD.MM.YYYY" style={{ width: "100%" }} />
+            </Form.Item>
+          </Col>
+          <Col span={8}>
+            <Form.Item
+              name="claim_status_id"
+              label="Статус"
+              rules={[{ required: true }]}
+              style={highlight("claim_status_id")}
+            >
+              <Select
+                showSearch
+                options={statuses.map((s) => ({ value: s.id, label: s.name }))}
+              />
+            </Form.Item>
+          </Col>
+        </Row>
+        <Row gutter={16}>
+          <Col span={24}>
+            <Form.Item
+              name="description"
+              label="Дополнительная информация"
+              style={highlight("description")}
+            >
+              <Input.TextArea rows={2} />
+            </Form.Item>
+          </Col>
+        </Row>
+        {showAttachments && (
           <Form.Item
-            name="pre_trial_claim"
-            label="Досудебная претензия"
-            valuePropName="checked"
-            style={highlight('pre_trial_claim')}
+            label="Файлы"
+            style={
+              attachments.attachmentsChanged
+                ? { background: "#fffbe6", padding: 4, borderRadius: 2 }
+                : {}
+            }
           >
-            <Switch disabled={!allowPretrial} />
-          </Form.Item>
-        </Col>
-        <Col span={8} hidden={!allowPretrial}>
-          <Form.Item
-            name="case_uid_id"
-            label="Уникальный идентификатор дела"
-            hidden={!preTrialWatch}
-            style={highlight('case_uid_id')}
-          >
-            <Select
-              showSearch
-              allowClear
-              disabled={!preTrialWatch || !allowPretrial}
-              options={caseUids.map((c) => ({ value: c.id, label: c.uid }))}
+            <FileDropZone onFiles={attachments.addFiles} />
+            <AttachmentEditorTable
+              remoteFiles={attachments.remoteFiles.map((f) => ({
+                id: String(f.id),
+                name: f.name,
+                path: f.path,
+                mime: f.mime_type,
+                description: f.description ?? "",
+              }))}
+              newFiles={attachments.newFiles.map((f) => ({
+                file: f.file,
+                mime: f.file.type,
+                description: f.description,
+              }))}
+              showDetails
+              onDescNew={(idx, d) => attachments.setDescription(idx, d)}
+              onRemoveRemote={(id) => attachments.removeRemote(id)}
+              onRemoveNew={(idx) => attachments.removeNew(idx)}
+              getSignedUrl={(path, name) => signedUrl(path, name)}
             />
           </Form.Item>
-        </Col>
-      </Row>
-      <Row gutter={16}>
-        <Col span={8}>
-          <Form.Item
-            name="project_id"
-            label="Проект"
-            rules={[{ required: true }]}
-            style={highlight('project_id')}
-          >
-            <Select allowClear options={projects.map((p) => ({ value: p.id, label: p.name }))} />
-          </Form.Item>
-        </Col>
-        <Col span={8}>
-          <Form.Item label="Корпус">
-            <Input value={buildingsText} disabled />
-          </Form.Item>
-        </Col>
-        <Col span={8}>
-          <Form.Item
-            name="unit_ids"
-            label="Объекты"
-            rules={[{ required: true }]}
-            style={highlight('unit_ids')}
-          >
-            <Select
-              mode="multiple"
-              options={units.map((u) => ({ value: u.id, label: u.name }))}
-              disabled={!projectId}
-            />
-          </Form.Item>
-        </Col>
-        <Col span={8}>
-          <Form.Item label="Собственник объекта" name="owner" style={highlight('owner')}>
-            <Input />
-          </Form.Item>
-        </Col>
-        <Col span={8}>
-          <Form.Item
-            name="engineer_id"
-            label="Закрепленный инженер"
-            rules={[{ required: true }]}
-            style={highlight('engineer_id')}
-          >
-            <Select allowClear showSearch options={users.map((u) => ({ value: u.id, label: u.name }))} />
-          </Form.Item>
-        </Col>
-      </Row>
-      <Row gutter={16}>
-        <Col span={8}>
-          <Form.Item
-            name="claim_no"
-            label="№ претензии"
-            rules={[{ required: true }]}
-            style={highlight('claim_no')}
-          >
-            <Input />
-          </Form.Item>
-        </Col>
-        <Col span={8}>
-          <Form.Item name="claimed_on" label="Дата претензии" style={highlight('claimed_on')}>
-            <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
-          </Form.Item>
-        </Col>
-        <Col span={8}>
-          <Form.Item
-            name="accepted_on"
-            label="Дата получения претензии Застройщиком"
-            style={highlight('accepted_on')}
-          >
-            <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
-          </Form.Item>
-        </Col>
-      </Row>
-      <Row gutter={16}>
-        <Col span={8}>
-          <Form.Item
-            name="registered_on"
-            label="Дата регистрации претензии GARANTHUB"
-            style={highlight('registered_on')}
-          >
-            <DatePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
-          </Form.Item>
-        </Col>
-        <Col span={8}>
-          <Form.Item
-            name="claim_status_id"
-            label="Статус"
-            rules={[{ required: true }]}
-            style={highlight('claim_status_id')}
-          >
-            <Select showSearch options={statuses.map((s) => ({ value: s.id, label: s.name }))} />
-          </Form.Item>
-        </Col>
-      </Row>
-      <Row gutter={16}>
-        <Col span={24}>
-          <Form.Item name="description" label="Дополнительная информация" style={highlight('description')}>
-            <Input.TextArea rows={2} />
-          </Form.Item>
-        </Col>
-      </Row>
-      {showAttachments && (
-        <Form.Item
-          label="Файлы"
-          style={
-            attachments.attachmentsChanged
-              ? { background: '#fffbe6', padding: 4, borderRadius: 2 }
-              : {}
-          }
-        >
-          <FileDropZone onFiles={attachments.addFiles} />
-          <AttachmentEditorTable
-            remoteFiles={attachments.remoteFiles.map((f) => ({
-              id: String(f.id),
-              name: f.name,
-              path: f.path,
-              mime: f.mime_type,
-              description: f.description ?? '',
-            }))}
-            newFiles={attachments.newFiles.map((f) => ({
-              file: f.file,
-              mime: f.file.type,
-              description: f.description,
-            }))}
-            showDetails
-            onDescNew={(idx, d) => attachments.setDescription(idx, d)}
-            onRemoveRemote={(id) => attachments.removeRemote(id)}
-            onRemoveNew={(idx) => attachments.removeNew(idx)}
-            getSignedUrl={(path, name) => signedUrl(path, name)}
-          />
-        </Form.Item>
-      )}
-      {!hideActions && (
-        <Form.Item style={{ textAlign: 'right' }}>
-          {onCancel && (
-            <Button style={{ marginRight: 8 }} onClick={onCancel} disabled={update.isPending}>
-              Отмена
+        )}
+        {!hideActions && (
+          <Form.Item style={{ textAlign: "right" }}>
+            {onCancel && (
+              <Button
+                style={{ marginRight: 8 }}
+                onClick={onCancel}
+                disabled={update.isPending}
+              >
+                Отмена
+              </Button>
+            )}
+            <Button type="primary" htmlType="submit" loading={update.isPending}>
+              Сохранить
             </Button>
-          )}
-          <Button type="primary" htmlType="submit" loading={update.isPending}>
-            Сохранить
-          </Button>
-        </Form.Item>
-      )}
-    </Form>
+          </Form.Item>
+        )}
+      </Form>
     </>
   );
 });

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -1,7 +1,7 @@
-import React, { useMemo } from 'react';
-import dayjs from 'dayjs';
-import { Table, Tooltip, Space, Button, Popconfirm, message } from 'antd';
-import type { ColumnsType } from 'antd/es/table';
+import React, { useMemo } from "react";
+import dayjs from "dayjs";
+import { Table, Tooltip, Space, Button, Popconfirm, message } from "antd";
+import type { ColumnsType } from "antd/es/table";
 import {
   EyeOutlined,
   DeleteOutlined,
@@ -9,17 +9,16 @@ import {
   BranchesOutlined,
   FileTextOutlined,
   LinkOutlined,
-} from '@ant-design/icons';
-import { useDeleteClaim } from '@/entities/claim';
-import type { ClaimFilters } from '@/shared/types/claimFilters';
-import type { ClaimWithNames } from '@/shared/types/claimWithNames';
-import ClaimStatusSelect from '@/features/claim/ClaimStatusSelect';
+} from "@ant-design/icons";
+import { useDeleteClaim } from "@/entities/claim";
+import type { ClaimFilters } from "@/shared/types/claimFilters";
+import type { ClaimWithNames } from "@/shared/types/claimWithNames";
+import ClaimStatusSelect from "@/features/claim/ClaimStatusSelect";
 
 const fmt = (d: any) =>
-  d && dayjs.isDayjs(d) && d.isValid() ? d.format('DD.MM.YYYY') : '—';
+  d && dayjs.isDayjs(d) && d.isValid() ? d.format("DD.MM.YYYY") : "—";
 const fmtDateTime = (d: any) =>
-  d && dayjs.isDayjs(d) && d.isValid() ? d.format('DD.MM.YYYY HH:mm') : '—';
-
+  d && dayjs.isDayjs(d) && d.isValid() ? d.format("DD.MM.YYYY HH:mm") : "—";
 
 interface Props {
   claims: ClaimWithNames[];
@@ -46,61 +45,163 @@ export default function ClaimsTable({
   const defaultColumns: ColumnsType<any> = useMemo(
     () => [
       {
-        title: '',
-        dataIndex: 'treeIcon',
+        title: "",
+        dataIndex: "treeIcon",
         width: 40,
         render: (_: any, record: any) => {
           if (!record.parent_id) {
             return (
               <Tooltip title="Основная претензия">
-                <FileTextOutlined style={{ color: '#1890ff', fontSize: 17 }} />
+                <FileTextOutlined style={{ color: "#1890ff", fontSize: 17 }} />
               </Tooltip>
             );
           }
           return (
             <Tooltip title="Связанная претензия">
-              <BranchesOutlined style={{ color: '#52c41a', fontSize: 16 }} />
+              <BranchesOutlined style={{ color: "#52c41a", fontSize: 16 }} />
             </Tooltip>
           );
         },
       },
-      { title: 'ID', dataIndex: 'id', width: 80, sorter: (a, b) => a.id - b.id },
-      { title: 'Проект', dataIndex: 'projectName', width: 180, sorter: (a, b) => a.projectName.localeCompare(b.projectName) },
-      { title: 'Корпус', dataIndex: 'buildings', width: 120, sorter: (a, b) => (a.buildings || '').localeCompare(b.buildings || '') },
-      { title: 'Объекты', dataIndex: 'unitNames', width: 160, sorter: (a, b) => a.unitNames.localeCompare(b.unitNames) },
-      { title: 'Статус', dataIndex: 'claim_status_id', width: 160, sorter: (a, b) => a.statusName.localeCompare(b.statusName), render: (_: any, row: any) => <ClaimStatusSelect claimId={row.id} statusId={row.claim_status_id} statusColor={row.statusColor} statusName={row.statusName} /> },
-      { title: '№ претензии', dataIndex: 'claim_no', width: 160, sorter: (a, b) => a.claim_no.localeCompare(b.claim_no) },
-      { title: 'Дата претензии', dataIndex: 'claimedOn', width: 120, sorter: (a, b) => (a.claimedOn ? a.claimedOn.valueOf() : 0) - (b.claimedOn ? b.claimedOn.valueOf() : 0), render: (v) => fmt(v) },
-      { title: 'Дата получения Застройщиком', dataIndex: 'acceptedOn', width: 120, sorter: (a, b) => (a.acceptedOn ? a.acceptedOn.valueOf() : 0) - (b.acceptedOn ? b.acceptedOn.valueOf() : 0), render: (v) => fmt(v) },
-      { title: 'Дата регистрации претензии', dataIndex: 'registeredOn', width: 120, sorter: (a, b) => (a.registeredOn ? a.registeredOn.valueOf() : 0) - (b.registeredOn ? b.registeredOn.valueOf() : 0), render: (v) => fmt(v) },
-      { title: 'Дата устранения', dataIndex: 'resolvedOn', width: 120, sorter: (a, b) => (a.resolvedOn ? a.resolvedOn.valueOf() : 0) - (b.resolvedOn ? b.resolvedOn.valueOf() : 0), render: (v) => fmt(v) },
-      { title: 'Закрепленный инженер', dataIndex: 'responsibleEngineerName', width: 180, sorter: (a, b) => (a.responsibleEngineerName || '').localeCompare(b.responsibleEngineerName || '') },
       {
-        title: 'Добавлено',
-        dataIndex: 'createdAt',
+        title: "ID",
+        dataIndex: "id",
+        width: 80,
+        sorter: (a, b) => a.id - b.id,
+      },
+      {
+        title: "Проект",
+        dataIndex: "projectName",
+        width: 180,
+        sorter: (a, b) => a.projectName.localeCompare(b.projectName),
+      },
+      {
+        title: "Корпус",
+        dataIndex: "buildings",
+        width: 120,
+        sorter: (a, b) => (a.buildings || "").localeCompare(b.buildings || ""),
+      },
+      {
+        title: "Объекты",
+        dataIndex: "unitNames",
+        width: 160,
+        sorter: (a, b) => a.unitNames.localeCompare(b.unitNames),
+      },
+      {
+        title: "Статус",
+        dataIndex: "claim_status_id",
+        width: 160,
+        sorter: (a, b) => a.statusName.localeCompare(b.statusName),
+        render: (_: any, row: any) => (
+          <ClaimStatusSelect
+            claimId={row.id}
+            statusId={row.claim_status_id}
+            statusColor={row.statusColor}
+            statusName={row.statusName}
+          />
+        ),
+      },
+      {
+        title: "№ претензии",
+        dataIndex: "claim_no",
+        width: 160,
+        sorter: (a, b) => a.claim_no.localeCompare(b.claim_no),
+      },
+      {
+        title: "Дата претензии",
+        dataIndex: "claimedOn",
+        width: 120,
+        sorter: (a, b) =>
+          (a.claimedOn ? a.claimedOn.valueOf() : 0) -
+          (b.claimedOn ? b.claimedOn.valueOf() : 0),
+        render: (v) => fmt(v),
+      },
+      {
+        title: "Дата получения Застройщиком",
+        dataIndex: "acceptedOn",
+        width: 120,
+        sorter: (a, b) =>
+          (a.acceptedOn ? a.acceptedOn.valueOf() : 0) -
+          (b.acceptedOn ? b.acceptedOn.valueOf() : 0),
+        render: (v) => fmt(v),
+      },
+      {
+        title: "Дата регистрации претензии",
+        dataIndex: "registeredOn",
+        width: 120,
+        sorter: (a, b) =>
+          (a.registeredOn ? a.registeredOn.valueOf() : 0) -
+          (b.registeredOn ? b.registeredOn.valueOf() : 0),
+        render: (v) => fmt(v),
+      },
+      {
+        title: "Дата устранения",
+        dataIndex: "resolvedOn",
+        width: 120,
+        sorter: (a, b) =>
+          (a.resolvedOn ? a.resolvedOn.valueOf() : 0) -
+          (b.resolvedOn ? b.resolvedOn.valueOf() : 0),
+        render: (v) => fmt(v),
+      },
+      {
+        title: "Закрепленный инженер",
+        dataIndex: "responsibleEngineerName",
+        width: 180,
+        sorter: (a, b) =>
+          (a.responsibleEngineerName || "").localeCompare(
+            b.responsibleEngineerName || "",
+          ),
+      },
+      {
+        title: "Добавлено",
+        dataIndex: "createdAt",
         width: 160,
         sorter: (a, b) =>
           (a.createdAt ? a.createdAt.valueOf() : 0) -
           (b.createdAt ? b.createdAt.valueOf() : 0),
         render: (v) => fmtDateTime(v),
       },
-      { title: 'Автор', dataIndex: 'createdByName', width: 160, sorter: (a, b) => (a.createdByName || '').localeCompare(b.createdByName || '') },
       {
-        title: 'Действия',
-        key: 'actions',
+        title: "Автор",
+        dataIndex: "createdByName",
+        width: 160,
+        sorter: (a, b) =>
+          (a.createdByName || "").localeCompare(b.createdByName || ""),
+      },
+      {
+        title: "Действия",
+        key: "actions",
         width: 140,
         render: (_: any, record) => (
           <Space size="middle">
             <Tooltip title="Просмотр">
-              <Button size="small" type="text" icon={<EyeOutlined />} onClick={() => onView && onView(record.id)} />
+              <Button
+                size="small"
+                type="text"
+                icon={<EyeOutlined />}
+                onClick={() => onView && onView(record.id)}
+              />
             </Tooltip>
-            <Button size="small" type="text" icon={<PlusOutlined />} onClick={() => onAddChild && onAddChild(record)} />
+            <Button
+              size="small"
+              type="text"
+              icon={<PlusOutlined />}
+              onClick={() => onAddChild && onAddChild(record)}
+            />
             {record.parent_id && (
               <Tooltip title="Исключить из связи">
                 <Button
                   size="small"
                   type="text"
-                  icon={<LinkOutlined style={{ color: '#c41d7f', textDecoration: 'line-through', fontWeight: 700 }} />}
+                  icon={
+                    <LinkOutlined
+                      style={{
+                        color: "#c41d7f",
+                        textDecoration: "line-through",
+                        fontWeight: 700,
+                      }}
+                    />
+                  }
                   onClick={() => onUnlink && onUnlink(record.id)}
                 />
               </Tooltip>
@@ -111,11 +212,17 @@ export default function ClaimsTable({
               cancelText="Нет"
               onConfirm={async () => {
                 await remove({ id: record.id });
-                message.success('Удалено');
+                message.success("Удалено");
               }}
               disabled={isPending}
             >
-              <Button size="small" type="text" danger icon={<DeleteOutlined />} loading={isPending} />
+              <Button
+                size="small"
+                type="text"
+                danger
+                icon={<DeleteOutlined />}
+                loading={isPending}
+              />
             </Popconfirm>
           </Space>
         ),
@@ -128,23 +235,54 @@ export default function ClaimsTable({
 
   const filtered = useMemo(() => {
     return claims.filter((c) => {
-      const matchesProject = !filters.project || c.projectName === filters.project;
-      const matchesUnits = !filters.units || (() => {
-        const units = c.unitNumbers ? c.unitNumbers.split(',').map((n) => n.trim()) : [];
-        return filters.units.every((u) => units.includes(u));
-      })();
-      const matchesBuilding = !filters.building || (() => {
-        const blds = c.buildings ? c.buildings.split(',').map((n) => n.trim()) : [];
-        return blds.includes(filters.building!);
-      })();
+      const matchesProject =
+        !filters.project || c.projectName === filters.project;
+      const matchesUnits =
+        !filters.units ||
+        (() => {
+          const units = c.unitNumbers
+            ? c.unitNumbers.split(",").map((n) => n.trim())
+            : [];
+          return filters.units.every((u) => units.includes(u));
+        })();
+      const matchesBuilding =
+        !filters.building ||
+        (() => {
+          const blds = c.buildings
+            ? c.buildings.split(",").map((n) => n.trim())
+            : [];
+          return blds.includes(filters.building!);
+        })();
       const matchesStatus = !filters.status || c.statusName === filters.status;
-      const matchesResponsible = !filters.responsible || c.responsibleEngineerName === filters.responsible;
-      const matchesNumber = !filters.claim_no || c.claim_no.includes(filters.claim_no);
+      const matchesResponsible =
+        !filters.responsible ||
+        c.responsibleEngineerName === filters.responsible;
+      const matchesNumber =
+        !filters.claim_no || c.claim_no.includes(filters.claim_no);
       const matchesIds = !filters.id || filters.id.includes(c.id);
-      const matchesDescription = !filters.description || (c.description ?? '').includes(filters.description);
-      const matchesHideClosed = !(filters.hideClosed && /закры/i.test(c.statusName));
-      const matchesPeriod = !filters.period || (c.registeredOn && c.registeredOn.isSameOrAfter(filters.period[0], 'day') && c.registeredOn.isSameOrBefore(filters.period[1], 'day'));
-      return matchesProject && matchesUnits && matchesBuilding && matchesStatus && matchesResponsible && matchesNumber && matchesIds && matchesDescription && matchesHideClosed && matchesPeriod;
+      const matchesDescription =
+        !filters.description ||
+        (c.description ?? "").includes(filters.description);
+      const matchesHideClosed = !(
+        filters.hideClosed && /закры/i.test(c.statusName)
+      );
+      const matchesPeriod =
+        !filters.period ||
+        (c.registeredOn &&
+          c.registeredOn.isSameOrAfter(filters.period[0], "day") &&
+          c.registeredOn.isSameOrBefore(filters.period[1], "day"));
+      return (
+        matchesProject &&
+        matchesUnits &&
+        matchesBuilding &&
+        matchesStatus &&
+        matchesResponsible &&
+        matchesNumber &&
+        matchesIds &&
+        matchesDescription &&
+        matchesHideClosed &&
+        matchesPeriod
+      );
     });
   }, [claims, filters]);
 
@@ -178,16 +316,16 @@ export default function ClaimsTable({
   }, [filtered]);
 
   const rowClassName = (row: ClaimWithNames) => {
-    const checking = row.statusName?.toLowerCase().includes('провер');
-    const closed = row.statusName?.toLowerCase().includes('закры');
-    const preTrial = row.pre_trial_claim ||
-      row.statusName?.toLowerCase().includes('досудеб');
+    const checking = row.statusName?.toLowerCase().includes("провер");
+    const closed = row.statusName?.toLowerCase().includes("закры");
+    const preTrial =
+      row.pre_trial_claim || row.statusName?.toLowerCase().includes("досудеб");
     const locked = row.unit_ids?.some((id) => lockedUnitIds.includes(id));
-    if (checking || row.hasCheckingDefect) return 'claim-checking-row';
-    if (preTrial) return 'claim-pretrial-row';
-    if (closed) return 'claim-closed-row';
-    if (locked) return 'locked-object-row';
-    return '';
+    if (locked) return "locked-object-row";
+    if (checking || row.hasCheckingDefect) return "claim-checking-row";
+    if (preTrial) return "claim-pretrial-row";
+    if (closed) return "claim-closed-row";
+    return "";
   };
 
   return (
@@ -221,9 +359,11 @@ export default function ClaimsTable({
       }}
       rowClassName={(row: any) => {
         const base = rowClassName(row);
-        return row.parent_id ? `child-claim-row ${base}` : `main-claim-row ${base}`;
+        return row.parent_id
+          ? `child-claim-row ${base}`
+          : `main-claim-row ${base}`;
       }}
-      style={{ background: '#fff' }}
+      style={{ background: "#fff" }}
     />
   );
 }


### PR DESCRIPTION
## Summary
- block claim edits on locked objects and highlight locked rows first
- show warning when trying to fix defects for locked objects

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a9e7532cc832e9ab0a3603822e4b8