### PR TITLE
Add lock check for claim status and unit selection

### DIFF
--- a/src/features/claim/ClaimFormAntdEdit.tsx
+++ b/src/features/claim/ClaimFormAntdEdit.tsx
@@ -124,6 +124,26 @@ const ClaimFormAntdEdit = React.forwardRef<
     Array.isArray(unitIdsWatch) ? unitIdsWatch : [],
   );
   const { data: lockedUnitIds = [] } = useLockedUnitIds();
+  const prevUnitIds = React.useRef<number[]>([]);
+  const didMountUnits = React.useRef(false);
+
+  React.useEffect(() => {
+    if (!didMountUnits.current) {
+      prevUnitIds.current = Array.isArray(unitIdsWatch) ? unitIdsWatch : [];
+      didMountUnits.current = true;
+      return;
+    }
+    const added = (Array.isArray(unitIdsWatch) ? unitIdsWatch : []).filter(
+      (id) => !prevUnitIds.current.includes(id),
+    );
+    if (added.some((id) => lockedUnitIds.includes(id))) {
+      Modal.warning({
+        title: 'Объект заблокирован',
+        content: 'Работы по устранению замечаний запрещено выполнять.',
+      });
+    }
+    prevUnitIds.current = Array.isArray(unitIdsWatch) ? unitIdsWatch : [];
+  }, [unitIdsWatch, lockedUnitIds]);
   const buildingsText = React.useMemo(
     () =>
       Array.from(

--- a/src/features/claim/ClaimStatusSelect.tsx
+++ b/src/features/claim/ClaimStatusSelect.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Select, Tag } from 'antd';
+import { Select, Tag, Modal } from 'antd';
 import { useClaimStatuses } from '@/entities/claimStatus';
 import { useUpdateClaim } from '@/entities/claim';
 
@@ -8,6 +8,8 @@ interface ClaimStatusSelectProps {
   statusId: number | null;
   statusColor?: string | null;
   statusName?: string | null;
+  /** Признак, что претензия содержит заблокированные объекты */
+  locked?: boolean;
 }
 
 export default function ClaimStatusSelect({
@@ -15,6 +17,7 @@ export default function ClaimStatusSelect({
   statusId,
   statusColor,
   statusName,
+  locked,
 }: ClaimStatusSelectProps) {
   const { data: statuses = [], isLoading } = useClaimStatuses();
   const update = useUpdateClaim();
@@ -33,13 +36,34 @@ export default function ClaimStatusSelect({
   );
 
   const handleChange = (value: number) => {
+    if (locked) {
+      Modal.warning({
+        title: 'Объект заблокирован',
+        content: 'Работы по устранению замечаний запрещено выполнять.',
+      });
+      setEditing(false);
+      return;
+    }
     update.mutate({ id: claimId, updates: { claim_status_id: value } });
     setEditing(false);
   };
 
   if (!editing) {
     return (
-      <Tag color={current?.color} onClick={() => setEditing(true)} style={{ cursor: 'pointer' }}>
+      <Tag
+        color={current?.color}
+        onClick={() => {
+          if (locked) {
+            Modal.warning({
+              title: 'Объект заблокирован',
+              content: 'Работы по устранению замечаний запрещено выполнять.',
+            });
+          } else {
+            setEditing(true);
+          }
+        }}
+        style={{ cursor: 'pointer' }}
+      >
         {current?.name ?? '—'}
       </Tag>
     );

--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -277,7 +277,21 @@ export default function ClaimsPage() {
       projectName: { title: 'Проект', dataIndex: 'projectName', width: 180, sorter: (a: any, b: any) => a.projectName.localeCompare(b.projectName) },
       buildings: { title: 'Корпус', dataIndex: 'buildings', width: 120, sorter: (a: any, b: any) => (a.buildings || '').localeCompare(b.buildings || '') },
       unitNames: { title: 'Объекты', dataIndex: 'unitNames', width: 160, sorter: (a: any, b: any) => a.unitNames.localeCompare(b.unitNames) },
-      statusId: { title: 'Статус', dataIndex: 'claim_status_id', width: 160, sorter: (a: any, b: any) => a.statusName.localeCompare(b.statusName), render: (_: any, row: any) => <ClaimStatusSelect claimId={row.id} statusId={row.claim_status_id} statusColor={row.statusColor} statusName={row.statusName} /> },
+      statusId: {
+        title: 'Статус',
+        dataIndex: 'claim_status_id',
+        width: 160,
+        sorter: (a: any, b: any) => a.statusName.localeCompare(b.statusName),
+        render: (_: any, row: any) => (
+          <ClaimStatusSelect
+            claimId={row.id}
+            statusId={row.claim_status_id}
+            statusColor={row.statusColor}
+            statusName={row.statusName}
+            locked={row.unit_ids?.some((id: number) => lockedUnitIds.includes(id))}
+          />
+        ),
+      },
       claim_no: { title: '№ претензии', dataIndex: 'claim_no', width: 160, sorter: (a: any, b: any) => a.claim_no.localeCompare(b.claim_no) },
       claimedOn: { title: 'Дата претензии', dataIndex: 'claimedOn', width: 120, sorter: (a: any, b: any) => (a.claimedOn ? a.claimedOn.valueOf() : 0) - (b.claimedOn ? b.claimedOn.valueOf() : 0), render: (v: any) => fmt(v) },
       acceptedOn: { title: 'Дата получения Застройщиком', dataIndex: 'acceptedOn', width: 120, sorter: (a: any, b: any) => (a.acceptedOn ? a.acceptedOn.valueOf() : 0) - (b.acceptedOn ? b.acceptedOn.valueOf() : 0), render: (v: any) => fmt(v) },

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -98,6 +98,7 @@ export default function ClaimsTable({
             statusId={row.claim_status_id}
             statusColor={row.statusColor}
             statusName={row.statusName}
+            locked={row.unit_ids?.some((id: number) => lockedUnitIds.includes(id))}
           />
         ),
       },


### PR DESCRIPTION
## Summary
- warn and block status change if claim has locked objects
- show warning if user selects locked objects in claim forms

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Missing script)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686aa5424134832eb0acc0bd9e4f01d0