### PR TITLE
Implement locked object restrictions

### DIFF
--- a/src/features/defect/DefectStatusSelect.tsx
+++ b/src/features/defect/DefectStatusSelect.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Select, Tag } from 'antd';
+import { Select, Tag, Modal } from 'antd';
 import { useDefectStatuses } from '@/entities/defectStatus';
 import { useUpdateDefectStatus } from '@/entities/defect';
 
@@ -8,6 +8,8 @@ interface Props {
   statusId: number | null;
   statusName?: string | null;
   statusColor?: string | null;
+  /** Признак, что дефект содержит заблокированные объекты */
+  locked?: boolean;
 }
 
 /** Выпадающий список для смены статуса дефекта в таблице */
@@ -16,6 +18,7 @@ export default function DefectStatusSelect({
   statusId,
   statusName,
   statusColor,
+  locked,
 }: Props) {
   const { data: statuses = [], isLoading } = useDefectStatuses();
   const update = useUpdateDefectStatus();
@@ -44,6 +47,14 @@ export default function DefectStatusSelect({
   );
 
   const handleChange = (value: number) => {
+    if (locked) {
+      Modal.warning({
+        title: 'Объект заблокирован',
+        content: 'Работы по устранению замечаний запрещено выполнять.',
+      });
+      setEditing(false);
+      return;
+    }
     (update as any).mutate({ id: defectId, statusId: value });
     setEditing(false);
   };
@@ -52,7 +63,16 @@ export default function DefectStatusSelect({
     return (
       <Tag
         color={current?.color}
-        onClick={() => setEditing(true)}
+        onClick={() => {
+          if (locked) {
+            Modal.warning({
+              title: 'Объект заблокирован',
+              content: 'Работы по устранению замечаний запрещено выполнять.',
+            });
+          } else {
+            setEditing(true);
+          }
+        }}
         style={{ cursor: 'pointer' }}
       >
         {current?.name ?? '—'}

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -8,6 +8,7 @@ import {
   Tooltip,
   Popconfirm,
   message,
+  Modal,
 } from "antd";
 import {
   SettingOutlined,
@@ -358,6 +359,7 @@ const LS_COLUMN_WIDTHS_KEY = "defectsColumnWidths";
             statusId={row.status_id}
             statusName={row.defectStatusName}
             statusColor={row.defectStatusColor}
+            locked={row.unit_id != null && lockedUnitIds.includes(row.unit_id)}
           />
         ),
       },
@@ -451,7 +453,20 @@ const LS_COLUMN_WIDTHS_KEY = "defectsColumnWidths";
                   icon={
                     <CheckOutlined style={{ color: "#52c41a", fontSize: 16 }} />
                   }
-                  onClick={() => setFixId(row.id)}
+                  onClick={() => {
+                    if (
+                      row.unit_id != null &&
+                      lockedUnitIds.includes(row.unit_id)
+                    ) {
+                      Modal.warning({
+                        title: "Объект заблокирован",
+                        content:
+                          "Работы по устранению замечаний запрещено выполнять.",
+                      });
+                      return;
+                    }
+                    setFixId(row.id);
+                  }}
                 />
               </Tooltip>
             )}

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -130,6 +130,7 @@ export default function DefectsTable({
           statusId={row.status_id}
           statusName={row.defectStatusName}
           statusColor={row.defectStatusColor}
+          locked={row.unit_id != null && lockedUnitIds.includes(row.unit_id)}
         />
       ),
     },


### PR DESCRIPTION
## Summary
- warn about blocked defects in status selector
- display warning when trying to fix locked defects
- disable status change for locked objects in tables

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Missing script)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686aaa970344832e86d423deb0d6f6eb