### PR TITLE
feat: enhance claims filters

### DIFF
--- a/src/features/claim/ExportClaimsButton.tsx
+++ b/src/features/claim/ExportClaimsButton.tsx
@@ -18,16 +18,21 @@ export default function ExportClaimsButton({ claims, filters }: ExportClaimsButt
     const rows = filterClaims(claims, filters).map((c) => ({
       ID: c.id,
       Проект: c.projectName,
+      Корпус: c.buildings ?? '',
       Объекты: c.unitNames,
+      Статус: c.statusName,
       '№ претензии': c.claim_no,
       'Дата претензии': c.claimedOn ? c.claimedOn.format('DD.MM.YYYY') : '',
       'Дата получения Застройщиком': c.acceptedOn
         ? c.acceptedOn.format('DD.MM.YYYY')
         : '',
-      'Дата регистрации претензии': c.registeredOn ? c.registeredOn.format('DD.MM.YYYY') : '',
-      'Дата устранения претензии': c.resolvedOn ? c.resolvedOn.format('DD.MM.YYYY') : '',
-      Статус: c.statusName,
-      'Ответственный инженер': c.responsibleEngineerName ?? '',
+      'Дата регистрации претензии': c.registeredOn
+        ? c.registeredOn.format('DD.MM.YYYY')
+        : '',
+      'Дата устранения': c.resolvedOn ? c.resolvedOn.format('DD.MM.YYYY') : '',
+      'Закрепленный инженер': c.responsibleEngineerName ?? '',
+      Добавлено: c.createdAt ? c.createdAt.format('DD.MM.YYYY HH:mm') : '',
+      Автор: c.createdByName ?? '',
     }));
     const wb = new ExcelJS.Workbook();
     const ws = wb.addWorksheet('Claims');

--- a/src/index.css
+++ b/src/index.css
@@ -45,6 +45,25 @@ body {
   width: 100%;
 }
 
+.claims-filter-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+.claims-filter-col {
+  display: grid;
+  gap: 16px;
+}
+.claims-filter-footer {
+  margin-top: 16px;
+}
+.claims-filter-grid .ant-input,
+.claims-filter-grid .ant-select,
+.claims-filter-grid .ant-picker,
+.claims-filter-grid button {
+  width: 100%;
+}
+
 /* === ТАБЛИЦА ================================================================= */
 .MuiTable-root {
   width: 100%;

--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -249,6 +249,7 @@ export default function ClaimsPage() {
         filtered('responsible').map((c) => c.responsibleEngineerName),
       ),
       ids: mapOptions(filtered('id').map((c) => c.id)),
+      authors: mapOptions(filtered('author').map((c) => c.createdByName)),
     };
   }, [claimsWithNames, filters]);
 

--- a/src/shared/types/claimFilters.ts
+++ b/src/shared/types/claimFilters.ts
@@ -8,10 +8,18 @@ export interface ClaimFilters {
   building?: string;
   status?: string;
   responsible?: string;
+  /** Автор создания */
+  author?: string;
   claim_no?: string;
   /** Поиск в поле дополнительной информации */
   description?: string;
   /** Скрывать записи со статусом "Закрыто" */
   hideClosed?: boolean;
   period?: [Dayjs, Dayjs];
+  /** Период дат претензии */
+  claimedPeriod?: [Dayjs, Dayjs];
+  /** Период получения застройщиком */
+  acceptedPeriod?: [Dayjs, Dayjs];
+  /** Период устранения дефекта */
+  resolvedPeriod?: [Dayjs, Dayjs];
 }

--- a/src/shared/utils/claimFilter.ts
+++ b/src/shared/utils/claimFilter.ts
@@ -8,8 +8,12 @@ export function filterClaims<T extends {
   unitNumbers?: string;
   statusName?: string;
   responsibleEngineerName?: string | null;
+  createdByName?: string | null;
   claim_no?: string;
   registeredOn?: Dayjs | null;
+  claimedOn?: Dayjs | null;
+  acceptedOn?: Dayjs | null;
+  resolvedOn?: Dayjs | null;
   description?: string;
 }>(rows: T[], f: ClaimFilters): T[] {
   return rows.filter((r) => {
@@ -22,6 +26,7 @@ export function filterClaims<T extends {
     }
     if (f.status && r.statusName !== f.status) return false;
     if (f.responsible && r.responsibleEngineerName !== f.responsible) return false;
+    if (f.author && r.createdByName !== f.author) return false;
     if (f.claim_no && (!r.claim_no || !r.claim_no.includes(f.claim_no))) return false;
     if (f.description && (!r.description || !r.description.includes(f.description))) return false;
     if (f.hideClosed && /закры/i.test(r.statusName || '')) return false;
@@ -29,6 +34,21 @@ export function filterClaims<T extends {
       const [from, to] = f.period;
       if (!r.registeredOn) return false;
       if (r.registeredOn.isBefore(from, 'day') || r.registeredOn.isAfter(to, 'day')) return false;
+    }
+    if (f.claimedPeriod && f.claimedPeriod.length === 2) {
+      const [from, to] = f.claimedPeriod;
+      if (!r.claimedOn) return false;
+      if (r.claimedOn.isBefore(from, 'day') || r.claimedOn.isAfter(to, 'day')) return false;
+    }
+    if (f.acceptedPeriod && f.acceptedPeriod.length === 2) {
+      const [from, to] = f.acceptedPeriod;
+      if (!r.acceptedOn) return false;
+      if (r.acceptedOn.isBefore(from, 'day') || r.acceptedOn.isAfter(to, 'day')) return false;
+    }
+    if (f.resolvedPeriod && f.resolvedPeriod.length === 2) {
+      const [from, to] = f.resolvedPeriod;
+      if (!r.resolvedOn) return false;
+      if (r.resolvedOn.isBefore(from, 'day') || r.resolvedOn.isAfter(to, 'day')) return false;
     }
     return true;
   });

--- a/src/widgets/ClaimsFilters.tsx
+++ b/src/widgets/ClaimsFilters.tsx
@@ -34,42 +34,66 @@ export default function ClaimsFilters({ options, onChange, initialValues = {} }:
   };
 
   return (
-    <Form form={form} layout="vertical" onValuesChange={handleValuesChange} className="filter-grid" style={{ marginBottom: 20 }}>
-      <Form.Item name="period" label="Период регистрации претензий">
-        <RangePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
-      </Form.Item>
-      <Form.Item name="project" label="Проект">
-        <Select allowClear options={options.projects} />
-      </Form.Item>
-      <Form.Item name="building" label="Корпус">
-        <Select allowClear options={options.buildings} />
-      </Form.Item>
-      <Form.Item name="units" label="Объекты">
-        <Select mode="multiple" allowClear options={options.units} />
-      </Form.Item>
-      <Form.Item name="id" label="ID">
-        <Select mode="multiple" allowClear options={options.ids} />
-      </Form.Item>
-      <Form.Item name="status" label="Статусы">
-        <Select allowClear options={options.statuses} />
-      </Form.Item>
-      <Form.Item name="claim_no" label="№ претензии">
-        <Input />
-      </Form.Item>
-      <Form.Item name="responsible" label="Закрепленный инженер">
-        <Select allowClear options={options.responsibleEngineers} />
-      </Form.Item>
-      <Form.Item name="description" label="Дополнительная информация">
-        <Input />
-      </Form.Item>
-      <Form.Item name="hideClosed" label="Скрыть закрытые" valuePropName="checked">
-        <Switch />
-      </Form.Item>
-      <Form.Item>
-        <Button onClick={reset} block>
-          Сброс
-        </Button>
-      </Form.Item>
+    <Form form={form} layout="vertical" onValuesChange={handleValuesChange}>
+      <div className="claims-filter-grid">
+        <div className="claims-filter-col">
+          <Form.Item name="id" label="ID претензии">
+            <Select mode="multiple" allowClear options={options.ids} />
+          </Form.Item>
+          <Form.Item name="claim_no" label="№ претензии">
+            <Input />
+          </Form.Item>
+          <Form.Item name="status" label="Статус">
+            <Select allowClear options={options.statuses} />
+          </Form.Item>
+        </div>
+        <div className="claims-filter-col">
+          <Form.Item name="author" label="Автор">
+            <Select allowClear options={options.authors} />
+          </Form.Item>
+          <Form.Item name="responsible" label="Закрепленный инженер">
+            <Select allowClear options={options.responsibleEngineers} />
+          </Form.Item>
+          <Form.Item name="period" label="Дата регистрации претензии">
+            <RangePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+          </Form.Item>
+        </div>
+        <div className="claims-filter-col">
+          <Form.Item name="claimedPeriod" label="Дата претензии">
+            <RangePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+          </Form.Item>
+          <Form.Item name="acceptedPeriod" label="Дата получения Застройщиком">
+            <RangePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+          </Form.Item>
+          <Form.Item name="resolvedPeriod" label="Дата устранения">
+            <RangePicker format="DD.MM.YYYY" style={{ width: '100%' }} />
+          </Form.Item>
+        </div>
+        <div className="claims-filter-col">
+          <Form.Item name="project" label="Проект">
+            <Select allowClear options={options.projects} />
+          </Form.Item>
+          <Form.Item name="building" label="Корпус">
+            <Select allowClear options={options.buildings} />
+          </Form.Item>
+          <Form.Item name="units" label="Объекты">
+            <Select mode="multiple" allowClear options={options.units} />
+          </Form.Item>
+        </div>
+      </div>
+      <div className="claims-filter-footer">
+        <Form.Item name="description" label="Дополнительная информация">
+          <Input />
+        </Form.Item>
+        <Form.Item name="hideClosed" label="Скрыть закрытые" valuePropName="checked">
+          <Switch />
+        </Form.Item>
+        <Form.Item>
+          <Button onClick={reset} block>
+            Сброс
+          </Button>
+        </Form.Item>
+      </div>
     </Form>
   );
 }

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -258,6 +258,7 @@ export default function ClaimsTable({
       const matchesResponsible =
         !filters.responsible ||
         c.responsibleEngineerName === filters.responsible;
+      const matchesAuthor = !filters.author || c.createdByName === filters.author;
       const matchesNumber =
         !filters.claim_no || c.claim_no.includes(filters.claim_no);
       const matchesIds = !filters.id || filters.id.includes(c.id);
@@ -272,17 +273,36 @@ export default function ClaimsTable({
         (c.registeredOn &&
           c.registeredOn.isSameOrAfter(filters.period[0], "day") &&
           c.registeredOn.isSameOrBefore(filters.period[1], "day"));
+      const matchesClaimedPeriod =
+        !filters.claimedPeriod ||
+        (c.claimedOn &&
+          c.claimedOn.isSameOrAfter(filters.claimedPeriod[0], "day") &&
+          c.claimedOn.isSameOrBefore(filters.claimedPeriod[1], "day"));
+      const matchesAcceptedPeriod =
+        !filters.acceptedPeriod ||
+        (c.acceptedOn &&
+          c.acceptedOn.isSameOrAfter(filters.acceptedPeriod[0], "day") &&
+          c.acceptedOn.isSameOrBefore(filters.acceptedPeriod[1], "day"));
+      const matchesResolvedPeriod =
+        !filters.resolvedPeriod ||
+        (c.resolvedOn &&
+          c.resolvedOn.isSameOrAfter(filters.resolvedPeriod[0], "day") &&
+          c.resolvedOn.isSameOrBefore(filters.resolvedPeriod[1], "day"));
       return (
         matchesProject &&
         matchesUnits &&
         matchesBuilding &&
         matchesStatus &&
         matchesResponsible &&
+        matchesAuthor &&
         matchesNumber &&
         matchesIds &&
         matchesDescription &&
         matchesHideClosed &&
-        matchesPeriod
+        matchesPeriod &&
+        matchesClaimedPeriod &&
+        matchesAcceptedPeriod &&
+        matchesResolvedPeriod
       );
     });
   }, [claims, filters]);


### PR DESCRIPTION
## Summary
- organize `/claims` filters in grouped columns
- enable filtering by author and claim dates
- export all claim columns to Excel
- style claims filter grid

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Missing script)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686aac43de5c832eadcdcb93cef1060d