### PR TITLE
feat: redesign claims filters

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -45,24 +45,6 @@ body {
   width: 100%;
 }
 
-.claims-filter-grid {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 16px;
-}
-.claims-filter-col {
-  display: grid;
-  gap: 16px;
-}
-.claims-filter-footer {
-  margin-top: 16px;
-}
-.claims-filter-grid .ant-input,
-.claims-filter-grid .ant-select,
-.claims-filter-grid .ant-picker,
-.claims-filter-grid button {
-  width: 100%;
-}
 
 /* === ТАБЛИЦА ================================================================= */
 .MuiTable-root {

--- a/src/pages/ClaimsPage/ClaimsPage.tsx
+++ b/src/pages/ClaimsPage/ClaimsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { ConfigProvider, Alert, Card, Button, Tooltip, Popconfirm, message, Space, Typography } from 'antd';
+import { ConfigProvider, Alert, Button, Tooltip, Popconfirm, message, Space, Typography } from 'antd';
 import ruRU from 'antd/locale/ru_RU';
 import {
   SettingOutlined,
@@ -64,13 +64,14 @@ export default function ClaimsPage() {
   const isLoading = perm?.only_assigned_project ? loadingAssigned : loadingAll;
   const error = errorAssigned || errorAll;
   const deleteClaimMutation = useDeleteClaim();
-  const { data: users = [] } = useUsers();
+  const { data: users = [], isPending: usersLoading } = useUsers();
   const unitIds = useMemo(
     () => Array.from(new Set(claims.flatMap((t) => t.unit_ids))),
     [claims],
   );
-  const { data: units = [] } = useUnitsByIds(unitIds);
+  const { data: units = [], isPending: unitsLoading } = useUnitsByIds(unitIds);
   const { data: lockedUnitIds = [] } = useLockedUnitIds();
+  const filtersLoading = usersLoading || unitsLoading;
   const checkingDefectMap = useMemo(() => new Map<number, boolean>(), []);
   const [searchParams] = useSearchParams();
   const initialValues = {
@@ -371,6 +372,17 @@ export default function ClaimsPage() {
     [claimsWithNames, filters],
   );
 
+  const applyFilters = (vals: ClaimFilters) => {
+    setFilters(vals);
+    const count = filterClaims(claimsWithNames, vals).length;
+    message.success(`Фильтры применены (${count} результатов)`);
+  };
+
+  const resetFilters = () => {
+    setFilters({});
+    message.info('Фильтры сброшены');
+  };
+
   return (
     <ConfigProvider locale={ruRU}>
       <>
@@ -428,9 +440,14 @@ export default function ClaimsPage() {
         </React.Suspense>
         <div style={{ marginTop: 24 }}>
           {showFilters && (
-            <Card style={{ marginBottom: 24 }}>
-              <ClaimsFilters options={options} onChange={setFilters} />
-            </Card>
+            <div style={{ marginBottom: 24 }}>
+              <ClaimsFilters
+                options={options}
+                loading={filtersLoading}
+                onSubmit={applyFilters}
+                onReset={resetFilters}
+              />
+            </div>
           )}
           {error ? (
             <Alert type="error" message={error.message} />


### PR DESCRIPTION
## Summary
- redesign filters on /claims page
- break filters into base and extra sections
- show badge count and skeleton
- add messages on search and reset

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Missing script)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ab26de4a0832e90f2e5ace4b72600