### PR TITLE
Add duplicate check for defect types

### DIFF
--- a/src/entities/defectType.js
+++ b/src/entities/defectType.js
@@ -19,10 +19,22 @@ export const useDefectTypes = () => {
 };
 
 // ---------------- insert ----------------
+/**
+ * Creates a new defect type.
+ * Throws an error if a type with the same name exists.
+ */
 export const useAddDefectType = () => {
     const qc = useQueryClient();
     return useMutation({
         mutationFn: async (name) => {
+            const { data: exists, error: selectErr } = await supabase
+                .from('defect_types')
+                .select('id')
+                .eq('name', name)
+                .maybeSingle();
+            if (selectErr) throw selectErr;
+            if (exists) throw new Error('Такой тип дефекта уже существует');
+
             const { data, error } = await supabase
                 .from('defect_types')
                 .insert({ name })

--- a/src/widgets/DefectTypesAdmin.tsx
+++ b/src/widgets/DefectTypesAdmin.tsx
@@ -11,6 +11,7 @@ import AdminDataGrid from '@/shared/ui/AdminDataGrid';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import DefectTypeForm from '@/features/defectType/DefectTypeForm';
+import { useNotify } from '@/shared/hooks/useNotify';
 
 interface DefectTypesAdminProps {
     pageSize?: number;
@@ -21,6 +22,7 @@ export default function DefectTypesAdmin({
     rowsPerPageOptions = [10, 25, 50, 100],
 }: DefectTypesAdminProps) {
     const { data = [], isLoading } = useDefectTypes();
+    const notify = useNotify();
     const addMutation = useAddDefectType();
     const updateMutation = useUpdateDefectType();
     const deleteMutation = useDeleteDefectType();
@@ -45,12 +47,16 @@ export default function DefectTypesAdmin({
     };
 
     const handleSubmit = async (values) => {
-        if (editRow) {
-            await (updateMutation.mutateAsync as any)({ id: editRow.id, name: values.name });
-        } else {
-            await (addMutation.mutateAsync as any)(values.name);
+        try {
+            if (editRow) {
+                await (updateMutation.mutateAsync as any)({ id: editRow.id, name: values.name });
+            } else {
+                await (addMutation.mutateAsync as any)(values.name);
+            }
+            setOpen(false);
+        } catch (e) {
+            notify.error(e.message);
         }
-        setOpen(false);
     };
 
     const columns = [


### PR DESCRIPTION
## Summary
- prevent duplicate names when adding defect types
- show notification on mutation errors

## Testing
- `npm run lint` *(fails: Unexpected token 'export')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686adb311188832e875effe16ef438e6