### PR TITLE
Fix claim view modal opening

### DIFF
--- a/src/pages/ClaimsPage/hooks/useClaimsPageState.ts
+++ b/src/pages/ClaimsPage/hooks/useClaimsPageState.ts
@@ -43,9 +43,7 @@ export function useClaimsPageState() {
   // URL sync for view modal
   useEffect(() => {
     const claimId = searchParams.get('claim_id');
-    if (claimId) {
-      setViewId(claimId);
-    }
+    setViewId(claimId);
   }, [searchParams]);
 
   // URL sync for add form


### PR DESCRIPTION
## Summary
- open claim view modal correctly when navigating with `claim_id` query parameter

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68787fb18e84832eaa6597e69389a308