### PR TITLE
Добавлена колонка гарантии в таблицу дефектов

### DIFF
--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -389,6 +389,14 @@ const LS_COLUMN_WIDTHS_KEY = "defectsColumnWidths";
           />
         ),
       },
+      warranty: {
+        title: "Гарантия",
+        dataIndex: "is_warranty",
+        width: 100,
+        sorter: (a: DefectWithInfo, b: DefectWithInfo) =>
+          Number(a.is_warranty) - Number(b.is_warranty),
+        render: (v: boolean) => (v ? "Да" : "Нет"),
+      },
       fixBy: {
         title: "Кем устраняется",
         dataIndex: "fixByName",
@@ -544,6 +552,7 @@ const LS_COLUMN_WIDTHS_KEY = "defectsColumnWidths";
     "description",
     "type",
     "status",
+    "warranty",
     "fixBy",
     "received",
     "createdAt",

--- a/src/widgets/DefectsTable.tsx
+++ b/src/widgets/DefectsTable.tsx
@@ -135,6 +135,13 @@ const DefectsTable = React.memo<Props>(({
       ),
     },
     {
+      title: "Гарантия",
+      dataIndex: "is_warranty",
+      width: 100,
+      sorter: (a, b) => Number(a.is_warranty) - Number(b.is_warranty),
+      render: (v: boolean) => (v ? "Да" : "Нет"),
+    },
+    {
       title: "Кем устраняется",
       dataIndex: "fixByName",
       width: 180,


### PR DESCRIPTION
## Summary
- в таблице `DefectsTable` добавлен столбец "Гарантия"
- в настройках страницы дефектов добавлены соответствующие колонки и порядок по умолчанию

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_687bb03b4310832e87728007911ac37a