### PR TITLE
Enable linked defect filters and archive file preview

### DIFF
--- a/src/entities/attachment/attachment.ts
+++ b/src/entities/attachment/attachment.ts
@@ -318,6 +318,14 @@ export async function signedUrl(path: string, filename = ''): Promise<string> {
     return data.signedUrl;
 }
 
+export async function signedUrlForPreview(path: string): Promise<string> {
+    const { data, error } = await supabase.storage
+        .from(ATTACH_BUCKET)
+        .createSignedUrl(path, 60);
+    if (error) throw error;
+    return data.signedUrl;
+}
+
 export async function getFileSize(path: string): Promise<number | null> {
     try {
         const { data, error } = await supabase.storage

--- a/src/pages/DefectsPage/DefectsPage.tsx
+++ b/src/pages/DefectsPage/DefectsPage.tsx
@@ -219,6 +219,11 @@ export default function DefectsPage() {
 
   const [filters, setFilters] = useState<DefectFilters>({});
 
+  const filteredDefects = useMemo(
+    () => filterDefects(filteredData, filters),
+    [filteredData, filters],
+  );
+
   // Базовые опции, не зависящие от фильтров
   const baseOptions = useMemo(() => {
     const uniq = (values: (string | number | null | undefined)[]) =>
@@ -242,30 +247,30 @@ export default function DefectsPage() {
     const projectOptionsMap = new Map(projects.map((p) => [p.id, p.name]));
 
     return {
-      ids: mapNumOptions(filteredData.map((d) => d.id)),
-      claimIds: mapNumOptions(filteredData.flatMap((d) => d.claimIds)),
+      ids: mapNumOptions(filteredDefects.map((d) => d.id)),
+      claimIds: mapNumOptions(filteredDefects.flatMap((d) => d.claimIds)),
       units: Array.from(
-        new Set(filteredData.flatMap((d) => d.unitIds)),
+        new Set(filteredDefects.flatMap((d) => d.unitIds)),
       )
         .map((id) => ({ label: unitOptionsMap.get(id) ?? String(id), value: id }))
         .sort((a, b) => naturalCompare(a.label, b.label)),
       buildings: mapStrOptions(
-        filteredData.flatMap((d) => d.buildingNamesList || []),
+        filteredDefects.flatMap((d) => d.buildingNamesList || []),
       ),
       projects: Array.from(
-        new Set(filteredData.flatMap((d) => d.projectIds || [])),
+        new Set(filteredDefects.flatMap((d) => d.projectIds || [])),
       )
         .map((id) => ({ label: projectOptionsMap.get(id) ?? String(id), value: id }))
         .sort((a, b) => naturalCompare(a.label, b.label)),
-      types: uniqPairs(filteredData.map((d) => [d.type_id, d.defectTypeName])),
+      types: uniqPairs(filteredDefects.map((d) => [d.type_id, d.defectTypeName])),
       statuses: uniqPairs(
-        filteredData.map((d) => [d.status_id, d.defectStatusName]),
+        filteredDefects.map((d) => [d.status_id, d.defectStatusName]),
       ),
-      fixBy: mapStrOptions(filteredData.map((d) => d.fixByName)),
-      engineers: mapStrOptions(filteredData.map((d) => d.engineerName)),
-      authors: mapStrOptions(filteredData.map((d) => d.createdByName)),
+      fixBy: mapStrOptions(filteredDefects.map((d) => d.fixByName)),
+      engineers: mapStrOptions(filteredDefects.map((d) => d.engineerName)),
+      authors: mapStrOptions(filteredDefects.map((d) => d.createdByName)),
     };
-  }, [filteredData, units, projects]);
+  }, [filteredDefects, units, projects]);
 
   // Динамические опции для фильтров (если нужно)
   const options = useMemo(() => {
@@ -650,8 +655,8 @@ const LS_COLUMN_WIDTHS_KEY = "defectsColumnWidths";
   );
   const openCount = total - closedCount;
   const readyToExport = useMemo(
-    () => filterDefects(filteredData, filters).length,
-    [filteredData, filters],
+    () => filteredDefects.length,
+    [filteredDefects],
   );
 
   return (

--- a/src/pages/ObjectArchivePage/ObjectArchivePage.tsx
+++ b/src/pages/ObjectArchivePage/ObjectArchivePage.tsx
@@ -9,11 +9,14 @@ import ClaimViewModal from '@/features/claim/ClaimViewModal';
 import DefectViewModal from '@/features/defect/DefectViewModal';
 import CourtCaseViewModal from '@/features/courtCase/CourtCaseViewModal';
 import LetterViewModal from '@/features/correspondence/LetterViewModal';
-import {
+import { 
   signedUrl,
+  signedUrlForPreview,
   updateAttachmentDescription,
   addUnitAttachments,
 } from '@/entities/attachment';
+import FilePreviewModal from '@/shared/ui/FilePreviewModal';
+import type { PreviewFile } from '@/shared/types/previewFile';
 import { downloadZip } from '@/shared/utils/downloadZip';
 import type { ArchiveFile } from '@/shared/types/archiveFile';
 import { useUsers } from '@/entities/user';
@@ -48,6 +51,7 @@ export default function ObjectArchivePage() {
   const [viewDefectId, setViewDefectId] = React.useState<number | null>(null);
   const [viewCourtId, setViewCourtId] = React.useState<number | null>(null);
   const [viewLetterId, setViewLetterId] = React.useState<number | null>(null);
+  const [previewFile, setPreviewFile] = React.useState<PreviewFile | null>(null);
 
   const changedFlags = React.useMemo(() => {
     const map: Record<string, boolean> = {};
@@ -190,9 +194,11 @@ export default function ObjectArchivePage() {
             showLink
             showCreatedAt
             showCreatedBy
-            changedMap={changedFlags}
-            getSignedUrl={(p, n) => signedUrl(p, n)}
-          />
+          changedMap={changedFlags}
+          getSignedUrl={(p, n) => signedUrl(p, n)}
+          getSignedUrlForPreview={(p) => signedUrlForPreview(p)}
+          onPreview={setPreviewFile}
+        />
           <Divider />
           <Typography.Title level={4}>Документы по замечаниям</Typography.Title>
           <AttachmentEditorTable
@@ -205,11 +211,13 @@ export default function ObjectArchivePage() {
             showLink
             showCreatedAt
             showCreatedBy
-            changedMap={changedFlags}
-            getSignedUrl={(p, n) => signedUrl(p, n)}
-            onOpenLink={(f) => setViewClaimId(Number(f.entityId))}
-            getLinkLabel={() => 'Замечание'}
-          />
+          changedMap={changedFlags}
+          getSignedUrl={(p, n) => signedUrl(p, n)}
+          getSignedUrlForPreview={(p) => signedUrlForPreview(p)}
+          onPreview={setPreviewFile}
+          onOpenLink={(f) => setViewClaimId(Number(f.entityId))}
+          getLinkLabel={() => 'Замечание'}
+        />
           <Divider />
           <Typography.Title level={4}>Документы по дефектам</Typography.Title>
           <AttachmentEditorTable
@@ -222,11 +230,13 @@ export default function ObjectArchivePage() {
             showLink
             showCreatedAt
             showCreatedBy
-            changedMap={changedFlags}
-            getSignedUrl={(p, n) => signedUrl(p, n)}
-            onOpenLink={(f) => setViewDefectId(Number(f.entityId))}
-            getLinkLabel={() => 'Дефект'}
-          />
+          changedMap={changedFlags}
+          getSignedUrl={(p, n) => signedUrl(p, n)}
+          getSignedUrlForPreview={(p) => signedUrlForPreview(p)}
+          onPreview={setPreviewFile}
+          onOpenLink={(f) => setViewDefectId(Number(f.entityId))}
+          getLinkLabel={() => 'Дефект'}
+        />
           <Divider />
           <Typography.Title level={4}>Документы по судебным делам</Typography.Title>
           <AttachmentEditorTable
@@ -239,11 +249,13 @@ export default function ObjectArchivePage() {
             showLink
             showCreatedAt
             showCreatedBy
-            changedMap={changedFlags}
-            getSignedUrl={(p, n) => signedUrl(p, n)}
-            onOpenLink={(f) => setViewCourtId(Number(f.entityId))}
-            getLinkLabel={() => 'Судебное дело'}
-          />
+          changedMap={changedFlags}
+          getSignedUrl={(p, n) => signedUrl(p, n)}
+          getSignedUrlForPreview={(p) => signedUrlForPreview(p)}
+          onPreview={setPreviewFile}
+          onOpenLink={(f) => setViewCourtId(Number(f.entityId))}
+          getLinkLabel={() => 'Судебное дело'}
+        />
           <Divider />
           <Typography.Title level={4}>Файлы из писем</Typography.Title>
           <AttachmentEditorTable
@@ -256,11 +268,13 @@ export default function ObjectArchivePage() {
             showLink
             showCreatedAt
             showCreatedBy
-            changedMap={changedFlags}
-            getSignedUrl={(p, n) => signedUrl(p, n)}
-            onOpenLink={(f) => setViewLetterId(Number(f.entityId))}
-            getLinkLabel={(f) => `Письмо №${f.entityId}`}
-          />
+          changedMap={changedFlags}
+          getSignedUrl={(p, n) => signedUrl(p, n)}
+          getSignedUrlForPreview={(p) => signedUrlForPreview(p)}
+          onPreview={setPreviewFile}
+          onOpenLink={(f) => setViewLetterId(Number(f.entityId))}
+          getLinkLabel={(f) => `Письмо №${f.entityId}`}
+        />
           <Divider />
           <Button type="primary" disabled={!newObjectFiles.length && !Object.keys(changed).length} onClick={handleSave}>
             Сохранить изменения
@@ -269,6 +283,11 @@ export default function ObjectArchivePage() {
           <DefectViewModal open={viewDefectId !== null} defectId={viewDefectId} onClose={() => setViewDefectId(null)} />
           <CourtCaseViewModal open={viewCourtId !== null} caseId={viewCourtId} onClose={() => setViewCourtId(null)} />
           <LetterViewModal open={viewLetterId !== null} letterId={viewLetterId} onClose={() => setViewLetterId(null)} />
+          <FilePreviewModal
+            open={previewFile !== null}
+            file={previewFile}
+            onClose={() => setPreviewFile(null)}
+          />
         </>
       )}
     </ConfigProvider>


### PR DESCRIPTION
## Summary
- link defect filters so options depend on current selections
- add `signedUrlForPreview` helper
- allow previewing archive files via the eye icon

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d3e14a250832e831d39b4df2390de