### PR TITLE
Fix claim amount display for zero values

### DIFF
--- a/src/entities/courtCase/index.ts
+++ b/src/entities/courtCase/index.ts
@@ -164,7 +164,10 @@ export function useCourtCases() {
         ...row,
         unit_ids: unitMap.get(row.id) || [],
         parent_id: linkMap.get(row.id) ?? null,
-        total_claim_amount: claimMap.get(row.id) ?? null,
+        total_claim_amount:
+          row.total_claim_amount != null && Number(row.total_claim_amount) > 0
+            ? Number(row.total_claim_amount)
+            : claimMap.get(row.id) ?? null,
         caseUid: row.court_cases_uids?.uid ?? null,
       })) as CourtCase[];
     },


### PR DESCRIPTION
## Summary
- compute `total_claim_amount` from related claims when the stored value is zero

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688653e7db28832eb420d98ff10d32a0