### PR TITLE
Fix claim filter options for buildings and units

### DIFF
--- a/src/pages/ClaimsPage/hooks/useClaimsDataPaginated.ts
+++ b/src/pages/ClaimsPage/hooks/useClaimsDataPaginated.ts
@@ -186,15 +186,19 @@ export function useClaimsDataPaginated(filters: ClaimFilters, perm: RolePermissi
     const mapOptions = (vals: (string | number | undefined | null)[]) =>
       uniq(vals).map((v) => ({ label: String(v), value: v }));
 
+    const projectFiltered = filters.project
+      ? filterClaims(claimsWithNames, { project: filters.project })
+      : claimsWithNames;
+
     return {
       projects: mapOptions(projects.map((p) => p.name)),
       units: mapOptions(
-        filtered("units").flatMap((c) =>
+        projectFiltered.flatMap((c) =>
           c.unitNumbers ? c.unitNumbers.split(",").map((n) => n.trim()) : [],
         ),
       ),
       buildings: mapOptions(
-        filtered("building").flatMap((c) =>
+        projectFiltered.flatMap((c) =>
           c.buildings ? c.buildings.split(",").map((n) => n.trim()) : [],
         ),
       ),


### PR DESCRIPTION
## Summary
- show all units and buildings with claims when filtering by project on the Claims page

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688655540158832eb0e939b655efee47