### PR TITLE
Fix claims pagination when filtering

### DIFF
--- a/src/entities/claim/claim.ts
+++ b/src/entities/claim/claim.ts
@@ -503,9 +503,10 @@ export function useClaimsAll(page = 0, pageSize = 50) {
 /**
  * Получить все претензии без пагинации (для обратной совместимости).
  */
-export function useClaimsAllLegacy() {
+export function useClaimsAllLegacy(enabled = true) {
   return useQuery({
     queryKey: ['claims-all-legacy'],
+    enabled,
     queryFn: async () => {
       const rows = await fetchPaged<any>((from, to) =>
         supabase

--- a/src/pages/ClaimsPage/hooks/useClaimsDataPaginated.ts
+++ b/src/pages/ClaimsPage/hooks/useClaimsDataPaginated.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useEffect } from 'react';
 import {
   useClaims,
   useClaimsAllSummary,
@@ -36,21 +36,46 @@ export function useClaimsDataPaginated(filters: ClaimFilters, perm: RolePermissi
 
   // Data queries
   const claimsAssigned = useClaims(); // For assigned projects (non-paginated)
-  const claimsAllPaginated = useClaimsAllSummary(pagination.page, pagination.pageSize); // For all projects (paginated)
+  const claimsAllPaginated = useClaimsAllSummary(
+    pagination.page,
+    pagination.pageSize,
+  ); // For all projects (paginated)
+  const claimsAll = useClaimsAllLegacy(!perm?.only_assigned_project && disablePagination); // Full dataset when pagination off
   
-  // Choose between assigned or all claims based on permissions
-  const usesPagination = !perm?.only_assigned_project;
-  const claims = usesPagination 
-    ? claimsAllPaginated.data?.data 
-    : claimsAssigned.data;
-  
-  const isLoading = usesPagination 
-    ? claimsAllPaginated.isLoading 
-    : claimsAssigned.isLoading;
-  
-  const error = usesPagination 
-    ? claimsAllPaginated.error 
-    : claimsAssigned.error;
+  // Disable pagination when filtering by project or unit/building
+  const disablePagination = Boolean(
+    filters.project ||
+      (filters.units && filters.units.length > 0) ||
+      filters.building,
+  );
+
+  // Choose between assigned or all claims based on permissions and filters
+  const usesPagination = !perm?.only_assigned_project && !disablePagination;
+
+  // Reset to first page when pagination is disabled
+  useEffect(() => {
+    if (!usesPagination) {
+      setPagination(prev => ({ ...prev, page: 0 }));
+    }
+  }, [usesPagination]);
+
+  const claims = perm?.only_assigned_project
+    ? claimsAssigned.data
+    : usesPagination
+      ? claimsAllPaginated.data?.data
+      : claimsAll.data;
+
+  const isLoading = perm?.only_assigned_project
+    ? claimsAssigned.isLoading
+    : usesPagination
+      ? claimsAllPaginated.isLoading
+      : claimsAll.isLoading;
+
+  const error = perm?.only_assigned_project
+    ? claimsAssigned.error
+    : usesPagination
+      ? claimsAllPaginated.error
+      : claimsAll.error;
 
   // Update pagination state when data changes
   useMemo(() => {
@@ -172,7 +197,9 @@ export function useClaimsDataPaginated(filters: ClaimFilters, perm: RolePermissi
   }, [claimsWithNames, filters]);
 
   // Get statistics from server
-  const statsQuery = usesPagination ? useClaimsAllStats() : useClaimsStats();
+  const allStatsQuery = useClaimsAllStats();
+  const assignedStatsQuery = useClaimsStats();
+  const statsQuery = usesPagination ? allStatsQuery : assignedStatsQuery;
   
   // Statistics
   const totalClaims = statsQuery.data?.total || 0;


### PR DESCRIPTION
## Summary
- fetch all claims only when pagination is disabled
- call stats hooks unconditionally to keep hook order stable

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68865a414250832e85514590601a6434