### PR TITLE
fix horizontal shift on reload

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,7 @@ body {
   background-color: #f5f7ff;
   margin: 0;
   font-size: 14px;
+  overflow-x: hidden;
 }
 
 /* === ФИЛЬТРЫ ================================================================= */


### PR DESCRIPTION
## Summary
- prevent horizontal scroll after reload by hiding extra width on body

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688679596820832e8fe560ebef6398e9