### PR TITLE
Fix /claims header

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -233,3 +233,13 @@ body {
 .ant-table-tbody > tr > td {
   transform: translateZ(0);
 }
+
+/* -------------------------------------------------------------------------- */
+/*  Claims page header                                                         */
+/* -------------------------------------------------------------------------- */
+.claims-page-header {
+  position: sticky;
+  top: 64px;
+  z-index: 500;
+  background: #fff;
+}

--- a/src/pages/ClaimsPage/components/ClaimsPageHeader.tsx
+++ b/src/pages/ClaimsPage/components/ClaimsPageHeader.tsx
@@ -29,7 +29,10 @@ const ClaimsPageHeader = React.memo<ClaimsPageHeaderProps>(({
   usesPagination = false,
 }) => {
   return (
-    <div style={{ marginBottom: 16, display: "flex", alignItems: "center", gap: 8 }}>
+    <div
+      className="claims-page-header"
+      style={{ marginBottom: 16, display: "flex", alignItems: "center", gap: 8 }}
+    >
       <Button
         type="primary"
         icon={<PlusOutlined />}

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -283,7 +283,7 @@ export default function ClaimsTable({
     <Table
       rowKey="id"
       columns={columnsWithResize}
-      sticky={{ offsetHeader: 80 }}
+      sticky={{ offsetHeader: 112 }}
       dataSource={treeData}
       loading={loading}
       pagination={showPagination ? {


### PR DESCRIPTION
## Summary
- keep Claims page header sticky under NavBar
- offset ClaimsTable sticky header

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6886f57b1cf4832e8828435fc317c5a9