### PR TITLE
Fix sticky header on claims page

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -233,3 +233,12 @@ body {
 .ant-table-tbody > tr > td {
   transform: translateZ(0);
 }
+
+/* Sticky header for claims page */
+.claims-page-header {
+  position: sticky;
+  top: 64px;
+  z-index: 900;
+  background: #fff;
+  padding: 8px 0;
+}

--- a/src/pages/ClaimsPage/components/ClaimsPageHeader.tsx
+++ b/src/pages/ClaimsPage/components/ClaimsPageHeader.tsx
@@ -29,7 +29,10 @@ const ClaimsPageHeader = React.memo<ClaimsPageHeaderProps>(({
   usesPagination = false,
 }) => {
   return (
-    <div style={{ marginBottom: 16, display: "flex", alignItems: "center", gap: 8 }}>
+    <div
+      className="claims-page-header"
+      style={{ marginBottom: 16, display: 'flex', alignItems: 'center', gap: 8 }}
+    >
       <Button
         type="primary"
         icon={<PlusOutlined />}

--- a/src/widgets/ClaimsTable.tsx
+++ b/src/widgets/ClaimsTable.tsx
@@ -283,7 +283,7 @@ export default function ClaimsTable({
     <Table
       rowKey="id"
       columns={columnsWithResize}
-      sticky={{ offsetHeader: 80 }}
+      sticky={{ offsetHeader: 112 }}
       dataSource={treeData}
       loading={loading}
       pagination={showPagination ? {


### PR DESCRIPTION
## Summary
- make claims page header sticky so controls always visible
- adjust table sticky offset to account for the header
- add CSS for the sticky header

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6886f57b1cf4832e8828435fc317c5a9